### PR TITLE
Release 0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -101,7 +101,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -114,7 +114,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -190,7 +190,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -237,7 +237,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -258,7 +258,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -302,7 +302,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -334,7 +334,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -349,7 +349,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -419,7 +419,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -431,7 +431,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/components/README.md
+++ b/components/README.md
@@ -43,7 +43,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -469,7 +469,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -1014,7 +1014,7 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -1092,7 +1092,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -1187,7 +1187,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -1312,7 +1312,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -1333,7 +1333,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptor.java
@@ -224,7 +224,7 @@ public interface EventStoreInterceptor {
     }
 
     /**
-     * Operation matching the {@link EventStore#loadEventsByGlobalOrder(AggregateType, LongRange, Optional)}  method call
+     * Operation matching the {@link EventStore#loadEventsByGlobalOrder(AggregateType, LongRange, List, Optional)}  method call
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     class LoadEventsByGlobalOrder {

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategy.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategy.java
@@ -485,7 +485,11 @@ public class SeparateTablePerAggregateTypePersistenceStrategy implements Aggrega
                                       .setFetchSize(1)
                                       .map(new PersistedEventRowMapper(this, configuration))
                                       .findOne();
-        log.debug("[{}] Found Last-Persisted-Event for Aggregate with id '{}': {}", configuration.aggregateType, aggregateId, lastPersistedEvent);
+        if (lastPersistedEvent.isPresent()) {
+            log.debug("[{}] Found Last-Persisted-Event for Aggregate with id '{}': {}", configuration.aggregateType, aggregateId, lastPersistedEvent);
+        } else {
+            log.debug("[{}] Did NOT find any Last-Persisted-Event for Aggregate with id '{}'", configuration.aggregateType, aggregateId);
+        }
         return lastPersistedEvent;
     }
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -596,7 +596,7 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                                  } catch (Exception cause) {
                                                      onErrorHandlingEvent(e, cause);
                                                  } finally {
-                                                     resumePoint.setResumeFromAndIncluding(e.globalEventOrder());
+                                                     resumePoint.setResumeFromAndIncluding(e.globalEventOrder().increment());
                                                  }
                                              });
                 } else {
@@ -637,12 +637,11 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                       aggregateType), e);
                     }
                     // Save resume point to be the next global order event AFTER the one we know we just handled
-                    log.debug("[{}-{}] Advancing ResumePoint from {} to {}",
+                    log.debug("[{}-{}] Saving ResumePoint {}",
                               subscriberId,
                               aggregateType,
-                              resumePoint.getResumeFromAndIncluding(),
-                              resumePoint.getResumeFromAndIncluding().increment());
-                    resumePoint.setResumeFromAndIncluding(resumePoint.getResumeFromAndIncluding().increment());
+                              resumePoint.getResumeFromAndIncluding());
+                    resumePoint.setResumeFromAndIncluding(resumePoint.getResumeFromAndIncluding());
                     durableSubscriptionRepository.saveResumePoint(resumePoint);
                     started = false;
                     log.info("[{}-{}] Stopped subscription",
@@ -814,7 +813,7 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                                          } catch (Exception cause) {
                                                              onErrorHandlingEvent(e, cause);
                                                          } finally {
-                                                             resumePoint.setResumeFromAndIncluding(e.globalEventOrder());
+                                                             resumePoint.setResumeFromAndIncluding(e.globalEventOrder().increment());
                                                          }
                                                      });
                         }
@@ -840,8 +839,8 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                     subscription.dispose();
                                 } else {
                                     log.debug("[{}-{}] Didn't find a subscription flux to dispose",
-                                             subscriberId,
-                                             aggregateType);
+                                              subscriberId,
+                                              aggregateType);
                                 }
                             } catch (Exception e) {
                                 log.error(msg("[{}-{}] Failed to dispose subscription flux",
@@ -854,7 +853,7 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                       aggregateType,
                                       resumePoint.getResumeFromAndIncluding(),
                                       resumePoint.getResumeFromAndIncluding().increment());
-                            resumePoint.setResumeFromAndIncluding(resumePoint.getResumeFromAndIncluding().increment());
+                            resumePoint.setResumeFromAndIncluding(resumePoint.getResumeFromAndIncluding());
                             durableSubscriptionRepository.saveResumePoint(resumePoint);
                             active = false;
                             log.info("[{}-{}] Stopped subscription",

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -636,8 +636,8 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                       subscriberId,
                                       aggregateType), e);
                     }
-                    // Save resume point to be the next global order event AFTER the one we know we just handled
-                    log.debug("[{}-{}] Saving ResumePoint {}",
+                    // Save resume point to be the next global order event
+                    log.debug("[{}-{}] Storing ResumePoint with resumeFromAndIncluding {}",
                               subscriberId,
                               aggregateType,
                               resumePoint.getResumeFromAndIncluding());
@@ -827,11 +827,6 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                      subscriberId,
                                      aggregateType);
                             try {
-                                fencedLockAwareSubscriber.onLockReleased(lock);
-                            } catch (Exception e) {
-                                log.error(msg("FencedLockAwareSubscriber#onLockReleased failed for lock {}", lock.getName()), e);
-                            }
-                            try {
                                 if (subscription != null) {
                                     log.debug("[{}-{}] Stopping subscription flux",
                                               subscriberId,
@@ -847,12 +842,18 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                               subscriberId,
                                               aggregateType), e);
                             }
+
+                            try {
+                                fencedLockAwareSubscriber.onLockReleased(lock);
+                            } catch (Exception e) {
+                                log.error(msg("FencedLockAwareSubscriber#onLockReleased failed for lock {}", lock.getName()), e);
+                            }
+
                             // Save resume point to be the next global order event AFTER the one we know we just handled
-                            log.debug("[{}-{}] Advancing ResumePoint from {} to {}",
+                            log.debug("[{}-{}] Storing ResumePoint with resumeFromAndIncluding {}",
                                       subscriberId,
                                       aggregateType,
-                                      resumePoint.getResumeFromAndIncluding(),
-                                      resumePoint.getResumeFromAndIncluding().increment());
+                                      resumePoint.getResumeFromAndIncluding());
                             resumePoint.setResumeFromAndIncluding(resumePoint.getResumeFromAndIncluding());
                             durableSubscriptionRepository.saveResumePoint(resumePoint);
                             active = false;

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
@@ -1,0 +1,72 @@
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkException;
+import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.GenericHandleAwareUnitOfWorkFactory;
+import org.slf4j.*;
+
+import java.util.*;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+
+class EventStoreManagedUnitOfWork extends GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork implements EventStoreUnitOfWork {
+    private final Logger                                       log = LoggerFactory.getLogger(EventStoreManagedUnitOfWork.class);
+    /**
+     * The list is maintained by the {@link EventStoreManagedUnitOfWorkFactory} and provided in the constructor
+     */
+    private final List<PersistedEventsCommitLifecycleCallback> lifecycleCallbacks;
+    private final List<PersistedEvent>                         eventsPersisted;
+
+    public EventStoreManagedUnitOfWork(GenericHandleAwareUnitOfWorkFactory<?> unitOfWorkFactory, List<PersistedEventsCommitLifecycleCallback> lifecycleCallbacks) {
+        super(unitOfWorkFactory);
+        this.lifecycleCallbacks = requireNonNull(lifecycleCallbacks, "No lifecycleCallbacks provided");
+        this.eventsPersisted = new ArrayList<>();
+    }
+
+    @Override
+    public void registerEventsPersisted(List<PersistedEvent> eventsPersistedInThisUnitOfWork) {
+        requireNonNull(eventsPersistedInThisUnitOfWork, "No eventsPersistedInThisUnitOfWork provided");
+        this.eventsPersisted.addAll(eventsPersistedInThisUnitOfWork);
+    }
+
+    @Override
+    protected void beforeCommitting() {
+        for (PersistedEventsCommitLifecycleCallback callback : lifecycleCallbacks) {
+            try {
+                log.trace("BeforeCommit PersistedEvents for {} with {} persisted events", callback.getClass().getName(), eventsPersisted.size());
+                callback.beforeCommit(this, eventsPersisted);
+            } catch (RuntimeException e) {
+                UnitOfWorkException unitOfWorkException = new UnitOfWorkException(msg("{} failed during beforeCommit PersistedEvents", callback.getClass().getName()), e);
+                unitOfWorkException.fillInStackTrace();
+                rollback(unitOfWorkException);
+                throw unitOfWorkException;
+            }
+        }
+    }
+
+
+    @Override
+    protected void afterCommitting() {
+        for (PersistedEventsCommitLifecycleCallback callback : lifecycleCallbacks) {
+            try {
+                log.trace("AfterCommit PersistedEvents for {} with {} persisted events", callback.getClass().getName(), eventsPersisted.size());
+                callback.afterCommit(this, eventsPersisted);
+            } catch (RuntimeException e) {
+                log.error(msg("Failed {} failed during afterCommit PersistedEvents", callback.getClass().getName()), e);
+            }
+        }
+    }
+
+    @Override
+    protected void afterRollback(Exception cause) {
+        for (PersistedEventsCommitLifecycleCallback callback : lifecycleCallbacks) {
+            try {
+                log.trace("AfterCommit PersistedEvents for {} with {} persisted events", callback.getClass().getName(), eventsPersisted.size());
+                callback.afterCommit(this, eventsPersisted);
+            } catch (RuntimeException e) {
+                log.error(msg("Failed {} failed during afterCommit PersistedEvents", callback.getClass().getName()), e);
+            }
+        }
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWorkFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWorkFactory.java
@@ -17,7 +17,6 @@
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction;
 
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
 import dk.cloudcreate.essentials.components.foundation.transaction.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.GenericHandleAwareUnitOfWorkFactory;
 import org.jdbi.v3.core.Jdbi;
@@ -26,7 +25,6 @@ import org.slf4j.*;
 import java.util.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
-import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 
 /**
  * {@link UnitOfWorkFactory} variant where the {@link EventStore} is manually
@@ -57,64 +55,4 @@ public class EventStoreManagedUnitOfWorkFactory extends GenericHandleAwareUnitOf
         return this;
     }
 
-    private static class EventStoreManagedUnitOfWork extends GenericHandleAwareUnitOfWork implements EventStoreUnitOfWork {
-        private final Logger                                       log = LoggerFactory.getLogger(EventStoreManagedUnitOfWork.class);
-        /**
-         * The list is maintained by the {@link EventStoreManagedUnitOfWorkFactory} and provided in the constructor
-         */
-        private final List<PersistedEventsCommitLifecycleCallback> lifecycleCallbacks;
-        private final List<PersistedEvent> eventsPersisted;
-
-        public EventStoreManagedUnitOfWork(GenericHandleAwareUnitOfWorkFactory<?> unitOfWorkFactory, List<PersistedEventsCommitLifecycleCallback> lifecycleCallbacks) {
-            super(unitOfWorkFactory);
-            this.lifecycleCallbacks = requireNonNull(lifecycleCallbacks, "No lifecycleCallbacks provided");
-            this.eventsPersisted = new ArrayList<>();
-        }
-
-        @Override
-        public void registerEventsPersisted(List<PersistedEvent> eventsPersistedInThisUnitOfWork) {
-            requireNonNull(eventsPersistedInThisUnitOfWork, "No eventsPersistedInThisUnitOfWork provided");
-            this.eventsPersisted.addAll(eventsPersistedInThisUnitOfWork);
-        }
-
-        @Override
-        protected void beforeCommitting() {
-            for (PersistedEventsCommitLifecycleCallback callback : lifecycleCallbacks) {
-                try {
-                    log.trace("BeforeCommit PersistedEvents for {} with {} persisted events", callback.getClass().getName(), eventsPersisted.size());
-                    callback.beforeCommit(this, eventsPersisted);
-                } catch (RuntimeException e) {
-                    UnitOfWorkException unitOfWorkException = new UnitOfWorkException(msg("{} failed during beforeCommit PersistedEvents", callback.getClass().getName()), e);
-                    unitOfWorkException.fillInStackTrace();
-                    rollback(unitOfWorkException);
-                    throw unitOfWorkException;
-                }
-            }
-        }
-
-
-        @Override
-        protected void afterCommitting() {
-            for (PersistedEventsCommitLifecycleCallback callback : lifecycleCallbacks) {
-                try {
-                    log.trace("AfterCommit PersistedEvents for {} with {} persisted events", callback.getClass().getName(), eventsPersisted.size());
-                    callback.afterCommit(this, eventsPersisted);
-                } catch (RuntimeException e) {
-                    log.error(msg("Failed {} failed during afterCommit PersistedEvents", callback.getClass().getName()), e);
-                }
-            }
-        }
-
-        @Override
-        protected void afterRollback(Exception cause) {
-            for (PersistedEventsCommitLifecycleCallback callback : lifecycleCallbacks) {
-                try {
-                    log.trace("AfterCommit PersistedEvents for {} with {} persisted events", callback.getClass().getName(), eventsPersisted.size());
-                    callback.afterCommit(this, eventsPersisted);
-                } catch (RuntimeException e) {
-                    log.error(msg("Failed {} failed during afterCommit PersistedEvents", callback.getClass().getName()), e);
-                }
-            }
-        }
-    }
 }

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
@@ -336,7 +336,19 @@ class EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchr
                                                  .get();
         System.out.println("test_start_and_stop_subscription - Total number of Order Events: " + totalNumberOfOrderEvents);
         Awaitility.waitAtMost(Duration.ofSeconds(10))
-                  .untilAsserted(() -> assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents));
+                  .untilAsserted(() -> {
+                      var receivedGlobalOrders = orderEventsReceived.stream()
+                                                                    .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
+                                                                    .collect(Collectors.toList());
+                      if (orderEventsReceived.size() > totalNumberOfOrderEvents) {
+                          System.out.println("******************** RECEIVED MORE EVENTS THAN EXPECTED ********************");
+                          System.out.println("Received orderEventsReceived      : " + orderEventsReceived.size());
+                          System.out.println("Expected totalNumberOfOrderEvents : " + totalNumberOfOrderEvents);
+                          System.out.println("orderEventsReceived - globalOrders: " + receivedGlobalOrders);
+                      }
+                      assertThat(orderEventsReceived).doesNotHaveDuplicates();
+                      assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents);
+                  });
         assertThat(orderEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(ORDERS)).findAny()).isEmpty();
         assertThat(orderEventsReceived.stream()
                                       .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
@@ -424,10 +436,16 @@ class EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchr
         System.out.println("Total number of Order Events: " + totalNumberOfOrderEvents);
         Awaitility.waitAtMost(Duration.ofSeconds(10))
                   .untilAsserted(() -> {
-                      System.out.println("Received " + orderEventsReceived.size() + " out of " + totalNumberOfOrderEvents);
+                      var receivedGlobalOrders = orderEventsReceived.stream()
+                                                                    .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
+                                                                    .collect(Collectors.toList());
                       if (orderEventsReceived.size() > totalNumberOfOrderEvents) {
-                          System.out.println("Received events: " + orderEventsReceived);
+                          System.out.println("******************** RECEIVED MORE EVENTS THAN EXPECTED ********************");
+                          System.out.println("Received orderEventsReceived      : " + orderEventsReceived.size());
+                          System.out.println("Expected totalNumberOfOrderEvents : " + totalNumberOfOrderEvents);
+                          System.out.println("orderEventsReceived - globalOrders: " + receivedGlobalOrders);
                       }
+                      assertThat(orderEventsReceived).doesNotHaveDuplicates();
                       assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents);
                   });
         assertThat(orderEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(ORDERS)).findAny()).isEmpty();

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
@@ -310,7 +310,19 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
                                                  .get();
         System.out.println("Total number of Order Events: " + totalNumberOfOrderEvents);
         Awaitility.waitAtMost(Duration.ofSeconds(5))
-                  .untilAsserted(() -> assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents));
+                  .untilAsserted(() -> {
+                      var receivedGlobalOrders = orderEventsReceived.stream()
+                                                                    .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
+                                                                    .collect(Collectors.toList());
+                      if (orderEventsReceived.size() > totalNumberOfOrderEvents) {
+                          System.out.println("******************** RECEIVED MORE EVENTS THAN EXPECTED ********************");
+                          System.out.println("Received orderEventsReceived      : " + orderEventsReceived.size());
+                          System.out.println("Expected totalNumberOfOrderEvents : " + totalNumberOfOrderEvents);
+                          System.out.println("orderEventsReceived - globalOrders: " + receivedGlobalOrders);
+                      }
+                      assertThat(orderEventsReceived).doesNotHaveDuplicates();
+                      assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents);
+                  });
         assertThat(orderEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(ORDERS)).findAny()).isEmpty();
         assertThat(orderEventsReceived.stream()
                                       .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
@@ -397,7 +409,19 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
                                                  .get();
         System.out.println("Total number of Order Events: " + totalNumberOfOrderEvents);
         Awaitility.waitAtMost(Duration.ofSeconds(5))
-                  .untilAsserted(() -> assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents));
+                  .untilAsserted(() -> {
+                      var receivedGlobalOrders = orderEventsReceived.stream()
+                                                                    .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
+                                                                    .collect(Collectors.toList());
+                      if (orderEventsReceived.size() > totalNumberOfOrderEvents) {
+                          System.out.println("******************** RECEIVED MORE EVENTS THAN EXPECTED ********************");
+                          System.out.println("Received orderEventsReceived      : " + orderEventsReceived.size());
+                          System.out.println("Expected totalNumberOfOrderEvents : " + totalNumberOfOrderEvents);
+                          System.out.println("orderEventsReceived - globalOrders: " + receivedGlobalOrders);
+                      }
+                      assertThat(orderEventsReceived).doesNotHaveDuplicates();
+                      assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents);
+                  });
         assertThat(orderEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(ORDERS)).findAny()).isEmpty();
         assertThat(orderEventsReceived.stream()
                                       .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())

--- a/components/postgresql-event-store/src/test/resources/logback-test.xml
+++ b/components/postgresql-event-store/src/test/resources/logback-test.xml
@@ -25,6 +25,10 @@
     </appender>
 
     <logger name="dk.cloudcreate.essentials" level="TRACE"/>
+    <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler" level="DEBUG"/>
+    <logger name="dk.cloudcreate.essentials.components.foundation.transaction.jdbi.GenericHandleAwareUnitOfWorkFactory" level="INFO"/>
+    <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWork" level="INFO"/>
+    <logger name="dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkFactory" level="INFO"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/components/springdata-mongo-queue/pom.xml
+++ b/components/springdata-mongo-queue/pom.xml
@@ -161,11 +161,6 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
             <scope>test</scope>
         </dependency>

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ManualAckMongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ManualAckMongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -30,6 +31,7 @@ import java.time.Duration;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ManualAckMongoDistributedCompetingConsumersDurableQueuesIT extends DistributedCompetingConsumersDurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ManualAckMongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ManualAckMongoDurableQueuesIT.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ManualAckMongoDurableQueuesIT extends DurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ManualAckMongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ManualAckMongoLocalCompetingConsumersDurableQueueIT.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -30,6 +31,7 @@ import java.time.Duration;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ManualAckMongoLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -23,12 +23,14 @@ import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoCo
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MongoDistributedCompetingConsumersDurableQueuesIT extends DistributedCompetingConsumersDurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
@@ -24,12 +24,14 @@ import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoCo
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MongoDurableQueuesIT extends DurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
@@ -23,12 +23,14 @@ import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoCo
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MongoLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -46,7 +46,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -17,7 +17,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-bom</artifactId>
-                <version>3.34.0</version>
+                <version>3.35.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -184,12 +184,6 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.23.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -210,4 +210,22 @@
         <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
         <vulnerabilityName>CVE-2022-41854</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        According to https://nvd.nist.gov/vuln/detail/CVE-2022-1471 this issue is only relevant when
+        parsing untrusted content. Essentials is only using SnakeYAML for testing and reading local yaml files.
+   file name: snakeyaml-1.33.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-1471</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        According to https://nvd.nist.gov/vuln/detail/CVE-2022-45868 this issue is only
+        relevant if the H2 DB was started via the CLI with the argument -webAdminPassword
+        Essentials only use H2 for in memory tests.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.h2database/h2@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-45868</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -14,7 +14,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -14,7 +14,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -14,7 +14,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -17,7 +17,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -9,7 +9,7 @@ many of the most popular libraries and frameworks such as Jackson, Spring Boot, 
 
 ## Types-JDBI
 
-This library focuses purely on providing [JDBI v3](https://jdbi.org) **argument** support for the **types** defined in the Essentials `types`
+This library focuses purely on providing [JDBI v3](https://jdbi.org) `ArgumentFactory` and `ColumnMapper` support for the **types** defined in the Essentials `types`
 library.
 
 To use `Types-JDBI` just add the following Maven dependency:
@@ -17,7 +17,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 
@@ -81,12 +81,12 @@ var customerId = CustomerId.random();
 var productId  = ProductId.random();
 var accountId  = AccountId.random();
 
-handle.useHandle(handle -> handle.createUpdate("INSERT INTO orders(id, customer_id, product_id, account_id) VALUES (:id, :customerId, :productId, :accountId)")
-                                  .bind("id", orderId)
-                                  .bind("customerId", customerId)
-                                  .bind("productId", productId)
-                                  .bind("accountId", accountId)
-                                  .execute());
+jdbi.useHandle(handle -> handle.createUpdate("INSERT INTO orders(id, customer_id, product_id, account_id) VALUES (:id, :customerId, :productId, :accountId)")
+                               .bind("id", orderId)
+                               .bind("customerId", customerId)
+                               .bind("productId", productId)
+                               .bind("accountId", accountId)
+                               .execute());
 ```
 
 ## ColumnMapper
@@ -106,9 +106,8 @@ jdbi.registerColumnMapper(new PercentageColumnMapper());
 
 An example of using it:
 ```
-return handle.useHandle(handle -> 
-                 handle.createQuery("SELECT MAX(discount) FROM ORDERS")
-                 .setFetchSize(1)
-                 .mapTo(Percentage.class)
-                 .findOne();
+return jdbi.useHandle(handle -> handle.createQuery("SELECT MAX(discount) FROM ORDERS")
+                                      .setFetchSize(1)
+                                      .mapTo(Percentage.class)
+                                      .findOne();
 ```

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -18,7 +18,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -17,7 +17,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @Testcontainers
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class OrderRepositoryIT {
 
     @Container

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @Testcontainers
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ProductRepositoryIT {
     @Container
     static PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer("postgres:latest")

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -17,7 +17,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class OrderRepositoryIT {
 
     @Container

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoCo
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.*;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -32,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 @DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ProductRepositoryIT {
 
     @Container

--- a/types/README.md
+++ b/types/README.md
@@ -18,7 +18,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Changed the handling of when resume from globalOrder is increased and resolved a rare situation where the `resumeFromAndIncluding` in the `ResumePoint` would resume from an already handled event.

Moved the original implementation of `PostgresqlEventStore#pollEvents` to `PostgresqlEventStore#unboundedPollForEvents` and introduced a new implementation for `PostgresqlEventStore#pollEvents` which support backpressure handling.

Ensured that subscription is cancelled as the first thing when the Exclusive Asynchronous subscription is stopped

Improved remainingDemandForEvents event publishing logic