### PR TITLE
Prepared the release of version 0.20.0 

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -50,12 +57,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'adopt'
-        cache: maven
+
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,10 +50,12 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+        cache: maven
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,6 +58,10 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
     - name: Build with Maven
       run: mvn -B verify --file pom.xml

--- a/.github/workflows/release-to-maven-central.yml
+++ b/.github/workflows/release-to-maven-central.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
           server-id: ossrh
           server-username: OSS_SONATYPE_USERNAME

--- a/.github/workflows/release-to-maven-central.yml
+++ b/.github/workflows/release-to-maven-central.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - run: echo "Will release version ${{ github.event.release.tag_name }} to Maven Central"
       - uses: actions/checkout@v3
-      - name: Set up JDK 11 with Maven Central Release settings
+      - name: Set up JDK 17 with Maven Central Release settings
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
           cache: maven
           server-id: ossrh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -73,7 +75,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -113,7 +115,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -128,7 +130,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -206,7 +208,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -254,7 +256,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -276,7 +278,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -321,7 +323,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -355,7 +357,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -372,7 +374,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -444,7 +446,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -458,7 +460,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/README.md
+++ b/components/README.md
@@ -1,8 +1,10 @@
 # Essentials Java Components
 
-Essentials Components is a set of Java version 11 (and later) components that are based on
+Essentials Components is a set of Java version 17 (and later) components that are based on
 the [Essentials](../README.md) library while providing more complex features
 or Components such as `EventStore`, `EventSourced Aggregates`, `FencedLocks`, `DurableQueues`, `DurableLocalCommandbus`, `Inbox` and `Outbox`.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 ![Essentials Components modules](../images/essentials-components-modules.png)
 
@@ -47,7 +49,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -62,7 +64,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -134,7 +136,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -211,7 +213,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -237,7 +239,7 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -285,7 +287,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -330,7 +332,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -419,7 +421,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -442,7 +444,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -40,7 +40,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -505,6 +505,6 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -36,7 +36,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -257,7 +257,7 @@ To use `PostgresqlDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -305,7 +305,7 @@ To use `MongoDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 
@@ -817,7 +817,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/foundation/pom.xml
+++ b/components/foundation/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
-            <version>4.1.1</version>
+            <version>4.2.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -21,7 +21,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -673,6 +673,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -10,7 +10,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -40,7 +40,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
@@ -20,7 +20,6 @@ import dk.cloudcreate.essentials.components.foundation.test.fencedlock.DBFencedL
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -36,7 +35,7 @@ import java.util.stream.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 class MongoFencedLockManagerIT extends DBFencedLockManagerIT<MongoFencedLockManager> {
     @Container
     static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:latest");

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -10,7 +10,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/pom.xml
+++ b/components/springdata-mongo-queue/pom.xml
@@ -85,12 +85,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.mongodb</groupId>-->
-<!--            <artifactId>mongodb-driver-sync</artifactId>-->
-<!--            <version>${mongodb-driver-sync.version}</version>-->
-<!--            <scope>provided</scope>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>${mongodb-driver-sync.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
 
         <!-- Transient dependencies not included because Essentials uses the provided scope -->

--- a/components/springdata-mongo-queue/pom.xml
+++ b/components/springdata-mongo-queue/pom.xml
@@ -85,12 +85,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongodb-driver-sync</artifactId>
-            <version>${mongodb-driver-sync.version}</version>
-            <scope>provided</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.mongodb</groupId>-->
+<!--            <artifactId>mongodb-driver-sync</artifactId>-->
+<!--            <version>${mongodb-driver-sync.version}</version>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
 
 
         <!-- Transient dependencies not included because Essentials uses the provided scope -->

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBusIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBusIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.reactive.command.AbstractDurableLocalCommandBusIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -29,7 +28,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DurableLocalCommandBusIT extends AbstractDurableLocalCommandBusIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBus_withSingleOperationTransactionIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBus_withSingleOperationTransactionIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.reactive.command.AbstractDurableLocalCommandBusIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -31,7 +30,7 @@ import org.testcontainers.junit.jupiter.*;
 import java.time.Duration;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class DurableLocalCommandBus_withSingleOperationTransactionIT extends AbstractDurableLocalCommandBusIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.DistributedCompetingConsumersDurableQueuesIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -29,7 +28,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MongoDistributedCompetingConsumersDurableQueuesIT extends DistributedCompetingConsumersDurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
@@ -20,7 +20,6 @@ import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.Dura
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -30,7 +29,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MongoDurableQueuesIT extends DurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIndexIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIndexIT.java
@@ -18,7 +18,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -35,7 +34,7 @@ import java.util.stream.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MongoDurableQueuesIndexIT {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.LocalCompetingConsumersDurableQueueIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -29,7 +28,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MongoLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesDurableQueueIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.LocalOrderedMessagesDurableQueueIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -29,7 +28,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MongoLocalOrderedMessagesDurableQueueIT extends LocalOrderedMessagesDurableQueueIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.LocalOrderedMessagesRedeliveryDurableQueueIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -29,7 +28,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MongoLocalOrderedMessagesRedeliveryDurableQueueIT extends LocalOrderedMessagesRedeliveryDurableQueueIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.DistributedCompetingConsumersDurableQueuesIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.annotation.DirtiesContext;
@@ -30,7 +29,7 @@ import org.testcontainers.junit.jupiter.*;
 import java.time.Duration;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT extends DistributedCompetingConsumersDurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDurableQueuesIT.java
@@ -24,7 +24,6 @@ import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.
 import dk.cloudcreate.essentials.components.foundation.types.CorrelationId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.annotation.DirtiesContext;
@@ -38,7 +37,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class SingleOperationTransactionMongoDurableQueuesIT extends DurableQueuesIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoLocalCompetingConsumersDurableQueueIT.java
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.components.queue.springdata.mongodb;
 import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.LocalCompetingConsumersDurableQueueIT;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.annotation.DirtiesContext;
@@ -30,7 +29,7 @@ import org.testcontainers.junit.jupiter.*;
 import java.time.Duration;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class SingleOperationTransactionMongoLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<MongoDurableQueues, SpringMongoTransactionAwareUnitOfWorkFactory.SpringMongoTransactionAwareUnitOfWork, SpringMongoTransactionAwareUnitOfWorkFactory> {
     @Container

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -46,7 +46,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -17,7 +19,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,17 +60,16 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <java.version>17</java.version>
         <revision>DEV-SNAPSHOT</revision>
 
         <objenesis.version>3.3</objenesis.version>
         <postgresql.version>42.6.0</postgresql.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <spring-boot.version>2.7.11</spring-boot.version>
+        <slf4j.version>2.0.7</slf4j.version>
+        <spring-boot.version>3.0.6</spring-boot.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <spring-data-mongodb.version>3.4.11</spring-data-mongodb.version>
-        <spring-data-jpa.version>2.7.11</spring-data-jpa.version>
+        <spring-data-mongodb.version>4.0.6</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.0.6</spring-data-jpa.version>
         <objenesis.version>3.3</objenesis.version>
         <assertj.version>3.24.2</assertj.version>
         <mongodb-driver-sync.version>4.9.1</mongodb-driver-sync.version>
@@ -138,14 +137,14 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2020.0.31</version>
+                <version>2022.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>5.3.27</version>
+                <version>6.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -191,7 +190,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.12</version>
+            <version>1.4.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -276,6 +275,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -357,7 +360,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>1.5.0</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -14,7 +14,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -14,7 +14,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -14,7 +14,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/types-avro/src/test/java/dk/cloudcreate/essentials/types/avro/CustomConversionsTest.java
+++ b/types-avro/src/test/java/dk/cloudcreate/essentials/types/avro/CustomConversionsTest.java
@@ -25,9 +25,10 @@ import org.apache.avro.specific.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 public class CustomConversionsTest {
 
@@ -86,12 +87,11 @@ public class CustomConversionsTest {
         assertThat(deserializedOrder.getMapOfCurrencyValues()).isEqualTo(order.getMapOfCurrencyValues());
         assertThat((CharSequence) deserializedOrder.getOptionalCurrency()).isEqualTo(order.getOptionalCurrency());
         assertThat(deserializedOrder.getDueDate()).isEqualTo(order.getDueDate());
-        assertThat(deserializedOrder.getTimeOfDay()).isEqualTo(order.getTimeOfDay());
-        assertThat(deserializedOrder.getCreated()).isEqualTo(order.getCreated());
-        assertThat(deserializedOrder.getLastUpdated()).isEqualTo(order.getLastUpdated());
-        assertThat(deserializedOrder.getTransactionTime()).isEqualTo(order.getTransactionTime());
-        assertThat(deserializedOrder.getTransferTime()).isEqualTo(order.getTransferTime());
-        assertThat(deserializedOrder).isEqualTo(order);
+        assertThat(deserializedOrder.getTimeOfDay().value()).isCloseTo(order.getTimeOfDay().value(), within(100, ChronoUnit.MICROS));
+        assertThat(deserializedOrder.getCreated().value()).isCloseTo(order.getCreated().value(), within(100, ChronoUnit.MICROS));
+        assertThat(deserializedOrder.getLastUpdated().value()).isCloseTo(order.getLastUpdated().value(), within(100, ChronoUnit.MICROS));
+        assertThat(deserializedOrder.getTransactionTime().value()).isCloseTo(order.getTransactionTime().value(), within(100, ChronoUnit.MICROS));
+        assertThat(deserializedOrder.getTransferTime().value()).isCloseTo(order.getTransferTime().value(), within(100, ChronoUnit.MICROS));
     }
 
     @SuppressWarnings("unchecked")

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -18,7 +20,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -17,7 +19,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
@@ -23,9 +23,10 @@ import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
 
 import java.sql.*;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 class SingleValueTypeArgumentsTest {
     @Test
@@ -134,12 +135,12 @@ class SingleValueTypeArgumentsTest {
             assertThat(result.get("currency")).isEqualTo(currency.value());
             assertThat(result.get("email")).isEqualTo(email.value());
             assertThat(result.get("percentage")).isEqualTo(percentage.value());
-            assertThat(((Timestamp) result.get("created")).toLocalDateTime()).isEqualTo(created.value());
+            assertThat(((Timestamp) result.get("created")).toLocalDateTime()).isCloseTo(created.value(), within(100, ChronoUnit.MICROS));
             assertThat(((Date) result.get("due_date")).toLocalDate()).isEqualTo(dueDate.value());
-            assertThat(((Timestamp) result.get("last_updated")).toInstant()).isEqualTo(lastUpdated.value());
+            assertThat(((Timestamp) result.get("last_updated")).toInstant()).isCloseTo(lastUpdated.value(), within(100, ChronoUnit.MICROS));
             assertThat(((Time) result.get("time_of_day"))).isEqualTo(Time.valueOf(timeOfDay.value()));
-            assertThat(((Timestamp) result.get("transaction_time")).toInstant()).isEqualTo(transactionTime.value().toInstant());
-            assertThat(((Timestamp) result.get("transfer_time")).toInstant()).isEqualTo(transferTime.value().toInstant());
+            assertThat(((Timestamp) result.get("transaction_time")).toInstant()).isCloseTo(transactionTime.value().toInstant(), within(100, ChronoUnit.MICROS));
+            assertThat(((Timestamp) result.get("transfer_time")).toInstant()).isCloseTo(transferTime.value().toInstant(), within(100, ChronoUnit.MICROS));
 
 
             var columns = List.of(Tuple.of("id", orderId),

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
@@ -173,10 +173,36 @@ class SingleValueTypeArgumentsTest {
                     // Time looses precision
                     compareWithValue = TimeOfDay.of(Time.valueOf(((TimeOfDay)compareWithValue).value()).toLocalTime());
                 }
-                assertThat(columnValue.equals(compareWithValue))
-                        .describedAs("Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
-                                     column._1, column._2.getClass(), compareWithValue, columnValue, columnValue.getClass())
-                        .isTrue();
+                if (columnValue instanceof InstantType<?> c) {
+                    assertThat(c.value())
+                            .describedAs("Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
+                                         column._1, column._2.getClass(), compareWithValue, columnValue, columnValue.getClass())
+                            .isCloseTo(((InstantType<?>) compareWithValue).value(), within(100, ChronoUnit.MICROS));
+
+                } else if (columnValue instanceof LocalDateTimeType<?> c) {
+                    assertThat(c.value())
+                            .describedAs("Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
+                                         column._1, column._2.getClass(), compareWithValue, columnValue, columnValue.getClass())
+                            .isCloseTo(((LocalDateTimeType<?>) compareWithValue).value(), within(100, ChronoUnit.MICROS));
+
+                } else if (columnValue instanceof OffsetDateTimeType<?> c) {
+                    assertThat(c.value())
+                            .describedAs("Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
+                                         column._1, column._2.getClass(), compareWithValue, columnValue, columnValue.getClass())
+                            .isCloseTo(((OffsetDateTimeType<?>) compareWithValue).value(), within(100, ChronoUnit.MICROS));
+
+                } else if (columnValue instanceof ZonedDateTimeType<?> c) {
+                    assertThat(c.value())
+                            .describedAs("Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
+                                         column._1, column._2.getClass(), compareWithValue, columnValue, columnValue.getClass())
+                            .isCloseTo(((ZonedDateTimeType<?>) compareWithValue).value(), within(100, ChronoUnit.MICROS));
+
+                } else {
+                    assertThat(columnValue.equals(compareWithValue))
+                            .describedAs("Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
+                                         column._1, column._2.getClass(), compareWithValue, columnValue, columnValue.getClass())
+                            .isTrue();
+                }
             });
         });
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -18,7 +20,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/types-spring-web/pom.xml
+++ b/types-spring-web/pom.xml
@@ -68,16 +68,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>9.0.73</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-websocket</artifactId>
-            <version>9.0.73</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -17,7 +19,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/pom.xml
+++ b/types-springdata-jpa/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>2.2.3</version>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AmountAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AmountAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.Amount;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class AmountAttributeConverter extends BaseBigDecimalTypeAttributeConverter<Amount> {

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseBigDecimalTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseBigDecimalTypeAttributeConverter.java
@@ -17,8 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.AttributeConverter;
 
-import javax.persistence.AttributeConverter;
 import java.math.BigDecimal;
 
 /**
@@ -45,7 +45,7 @@ public abstract class BaseBigDecimalTypeAttributeConverter<T extends BigDecimalT
     @Override
     public T convertToEntityAttribute(Double dbData) {
         if (dbData == null) return null;
-        return SingleValueType.from(new BigDecimal(dbData), getConcreteBigDecimalType());
+        return SingleValueType.from(BigDecimal.valueOf(dbData), getConcreteBigDecimalType());
     }
 
     /**

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseByteTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseByteTypeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
-
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link ByteType} sub-class

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseCharSequenceTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseCharSequenceTypeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
-
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link CharSequenceType} sub-class (e.g. such as {@link CurrencyCode})

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseDoubleTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseDoubleTypeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
-
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link DoubleType} sub-class

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseFloatTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseFloatTypeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
-
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link FloatType} sub-class

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseInstantTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseInstantTypeAttributeConverter.java
@@ -17,10 +17,9 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.AttributeConverter;
 
-import javax.persistence.AttributeConverter;
-import java.sql.Timestamp;
-import java.time.LocalDate;
+import java.time.*;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link InstantType} sub-class
@@ -37,16 +36,16 @@ import java.time.LocalDate;
  *
  * @param <T> the concrete type of {@link InstantType} supported by this converter
  */
-public abstract class BaseInstantTypeAttributeConverter<T extends InstantType<T>> implements AttributeConverter<T, Timestamp> {
+public abstract class BaseInstantTypeAttributeConverter<T extends InstantType<T>> implements AttributeConverter<T, Instant> {
     @Override
-    public Timestamp convertToDatabaseColumn(T attribute) {
-        return attribute != null ? Timestamp.from(attribute.value()) : null;
+    public Instant convertToDatabaseColumn(T attribute) {
+        return attribute != null ? attribute.value() : null;
     }
 
     @Override
-    public T convertToEntityAttribute(Timestamp dbData) {
+    public T convertToEntityAttribute(Instant dbData) {
         if (dbData == null) return null;
-        return SingleValueType.from(dbData.toInstant(), getConcreteInstantType());
+        return SingleValueType.from(dbData, getConcreteInstantType());
     }
 
     /**

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseIntegerTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseIntegerTypeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
-
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link IntegerType} sub-class

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTimeTypeAttributeConverter.java
@@ -17,10 +17,9 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.AttributeConverter;
 
-import javax.persistence.AttributeConverter;
-import java.sql.Timestamp;
-import java.time.LocalDate;
+import java.time.*;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link LocalDateTimeType} sub-class
@@ -37,16 +36,16 @@ import java.time.LocalDate;
  *
  * @param <T> the concrete type of {@link LocalDateTimeType} supported by this converter
  */
-public abstract class BaseLocalDateTimeTypeAttributeConverter<T extends LocalDateTimeType<T>> implements AttributeConverter<T, Timestamp> {
+public abstract class BaseLocalDateTimeTypeAttributeConverter<T extends LocalDateTimeType<T>> implements AttributeConverter<T, LocalDateTime> {
     @Override
-    public Timestamp convertToDatabaseColumn(T attribute) {
-        return attribute != null ? Timestamp.valueOf(attribute.value()) : null;
+    public LocalDateTime convertToDatabaseColumn(T attribute) {
+        return attribute != null ? attribute.value() : null;
     }
 
     @Override
-    public T convertToEntityAttribute(Timestamp dbData) {
+    public T convertToEntityAttribute(LocalDateTime dbData) {
         if (dbData == null) return null;
-        return SingleValueType.from(dbData.toLocalDateTime(), getConcreteLocalDateTimeType());
+        return SingleValueType.from(dbData, getConcreteLocalDateTimeType());
     }
 
     /**

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTypeAttributeConverter.java
@@ -17,9 +17,9 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.AttributeConverter;
 
-import javax.persistence.AttributeConverter;
-import java.sql.Date;
+import java.time.LocalDate;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link LocalDateType} sub-class
@@ -36,16 +36,16 @@ import java.sql.Date;
  *
  * @param <T> the concrete type of {@link LocalDateType} supported by this converter
  */
-public abstract class BaseLocalDateTypeAttributeConverter<T extends LocalDateType<T>> implements AttributeConverter<T, Date> {
+public abstract class BaseLocalDateTypeAttributeConverter<T extends LocalDateType<T>> implements AttributeConverter<T, LocalDate> {
     @Override
-    public Date convertToDatabaseColumn(T attribute) {
-        return attribute != null ? Date.valueOf(attribute.value()) : null;
+    public LocalDate convertToDatabaseColumn(T attribute) {
+        return attribute != null ? attribute.value() : null;
     }
 
     @Override
-    public T convertToEntityAttribute(Date dbData) {
+    public T convertToEntityAttribute(LocalDate dbData) {
         if (dbData == null) return null;
-        return SingleValueType.from(dbData.toLocalDate(), getConcreteLocalDateType());
+        return SingleValueType.from(dbData, getConcreteLocalDateType());
     }
 
     /**

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalTimeTypeAttributeConverter.java
@@ -17,10 +17,9 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.AttributeConverter;
 
-import javax.persistence.AttributeConverter;
-import java.sql.Time;
-import java.time.LocalDate;
+import java.time.*;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link LocalTimeType} sub-class
@@ -37,16 +36,16 @@ import java.time.LocalDate;
  *
  * @param <T> the concrete type of {@link LocalTimeType} supported by this converter
  */
-public abstract class BaseLocalTimeTypeAttributeConverter<T extends LocalTimeType<T>> implements AttributeConverter<T, Time> {
+public abstract class BaseLocalTimeTypeAttributeConverter<T extends LocalTimeType<T>> implements AttributeConverter<T, LocalTime> {
     @Override
-    public Time convertToDatabaseColumn(T attribute) {
-        return attribute != null ? Time.valueOf(attribute.value()) : null;
+    public LocalTime convertToDatabaseColumn(T attribute) {
+        return attribute != null ? attribute.value() : null;
     }
 
     @Override
-    public T convertToEntityAttribute(Time dbData) {
+    public T convertToEntityAttribute(LocalTime dbData) {
         if (dbData == null) return null;
-        return SingleValueType.from(dbData.toLocalTime(), getConcreteLocalTimeType());
+        return SingleValueType.from(dbData, getConcreteLocalTimeType());
     }
 
     /**

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLongTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLongTypeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
-
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link LongType} sub-class

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseOffsetDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseOffsetDateTimeTypeAttributeConverter.java
@@ -17,9 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.AttributeConverter;
 
-import javax.persistence.AttributeConverter;
-import java.sql.Timestamp;
 import java.time.*;
 
 /**
@@ -37,16 +36,16 @@ import java.time.*;
  *
  * @param <T> the concrete type of {@link OffsetDateTimeType} supported by this converter
  */
-public abstract class BaseOffsetDateTimeTypeAttributeConverter<T extends OffsetDateTimeType<T>> implements AttributeConverter<T, Timestamp> {
+public abstract class BaseOffsetDateTimeTypeAttributeConverter<T extends OffsetDateTimeType<T>> implements AttributeConverter<T, OffsetDateTime> {
     @Override
-    public Timestamp convertToDatabaseColumn(T attribute) {
-        return attribute != null ? Timestamp.from(attribute.value().toInstant()) : null;
+    public OffsetDateTime convertToDatabaseColumn(T attribute) {
+        return attribute != null ? attribute.value() : null;
     }
 
     @Override
-    public T convertToEntityAttribute(Timestamp dbData) {
+    public T convertToEntityAttribute(OffsetDateTime dbData) {
         if (dbData == null) return null;
-        return SingleValueType.from(dbData.toInstant().atOffset(ZoneOffset.UTC), getConcreteOffsetDateTimeType());
+        return SingleValueType.from(dbData, getConcreteOffsetDateTimeType());
     }
 
     /**

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseShortTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseShortTypeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
-
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * Base implementation for all JPA {@link AttributeConverter}'s that can convert between a concrete {@link ShortType} sub-class

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseZonedDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseZonedDateTimeTypeAttributeConverter.java
@@ -17,9 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.AttributeConverter;
 
-import javax.persistence.AttributeConverter;
-import java.sql.Timestamp;
 import java.time.*;
 
 /**
@@ -37,16 +36,16 @@ import java.time.*;
  *
  * @param <T> the concrete type of {@link ZonedDateTimeType} supported by this converter
  */
-public abstract class BaseZonedDateTimeTypeAttributeConverter<T extends ZonedDateTimeType<T>> implements AttributeConverter<T, Timestamp> {
+public abstract class BaseZonedDateTimeTypeAttributeConverter<T extends ZonedDateTimeType<T>> implements AttributeConverter<T, ZonedDateTime> {
     @Override
-    public Timestamp convertToDatabaseColumn(T attribute) {
-        return attribute != null ? Timestamp.from(attribute.value().toInstant()) : null;
+    public ZonedDateTime convertToDatabaseColumn(T attribute) {
+        return attribute != null ? attribute.value() : null;
     }
 
     @Override
-    public T convertToEntityAttribute(Timestamp dbData) {
+    public T convertToEntityAttribute(ZonedDateTime dbData) {
         if (dbData == null) return null;
-        return SingleValueType.from(dbData.toInstant().atZone(ZoneId.of("UTC")), getConcreteZonedDateTimeType());
+        return SingleValueType.from(dbData, getConcreteZonedDateTimeType());
     }
 
     /**

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CountryCodeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CountryCodeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.CountryCode;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class CountryCodeAttributeConverter extends BaseCharSequenceTypeAttributeConverter<CountryCode> {

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CurrencyCodeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CurrencyCodeAttributeConverter.java
@@ -17,8 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.CurrencyCode;
+import jakarta.persistence.Converter;
 
-import javax.persistence.Converter;
 
 @Converter(autoApply = true)
 public class CurrencyCodeAttributeConverter extends BaseCharSequenceTypeAttributeConverter<CurrencyCode> {

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/EmailAddressAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/EmailAddressAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.EmailAddress;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class EmailAddressAttributeConverter extends BaseCharSequenceTypeAttributeConverter<EmailAddress> {

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/PercentageAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/PercentageAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.Percentage;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class PercentageAttributeConverter extends BaseBigDecimalTypeAttributeConverter<Percentage> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
@@ -30,9 +30,10 @@ import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 @Testcontainers
@@ -113,9 +114,24 @@ class OrderRepositoryIT {
         transactionTemplate.execute(status -> {
             var loadedOrder = orderRepository.findById(storedOrder.getId());
             assertThat(loadedOrder).isPresent();
-            assertThat(loadedOrder.get().getId()).isEqualTo(storedOrder.getId());
-            assertThat(loadedOrder.get().getId().value()).isEqualTo(storedOrder.getId().value());
-            assertThat(loadedOrder.get()).isEqualTo(storedOrder);
+            var actualOrder = loadedOrder.get();
+            assertThat(actualOrder.getId()).isEqualTo(storedOrder.getId());
+            assertThat(actualOrder.getId().value()).isEqualTo(storedOrder.getId().value());
+            assertThat((CharSequence) actualOrder.getCustomerId()).isEqualTo(storedOrder.getCustomerId());
+            assertThat(actualOrder.getAccountId()).isEqualTo(storedOrder.getAccountId());
+            assertThat(actualOrder.getOrderLines()).isEqualTo(storedOrder.getOrderLines());
+            assertThat(actualOrder.getAmount()).isEqualTo(storedOrder.getAmount());
+            assertThat(actualOrder.getPercentage()).isEqualTo(storedOrder.getPercentage());
+            assertThat((CharSequence) actualOrder.getCountry()).isEqualTo(storedOrder.getCountry());
+            assertThat((CharSequence) actualOrder.getCurrency()).isEqualTo(storedOrder.getCurrency());
+            assertThat((CharSequence) actualOrder.getEmail()).isEqualTo(storedOrder.getEmail());
+            assertThat(actualOrder.getTotalPrice()).isEqualTo(storedOrder.getTotalPrice());
+            assertThat(actualOrder.getCreated().value()).isCloseTo(storedOrder.getCreated().value(), within(100, ChronoUnit.MICROS));
+            assertThat(actualOrder.getDueDate()).isEqualTo(storedOrder.getDueDate());
+            assertThat(actualOrder.getLastUpdated().value()).isCloseTo(storedOrder.getLastUpdated().value(), within(100, ChronoUnit.MICROS));
+            assertThat(actualOrder.getTimeOfDay()).isEqualTo(storedOrder.getTimeOfDay());
+            assertThat(actualOrder.getTransactionTime().value()).isCloseTo(storedOrder.getTransactionTime().value(), within(100, ChronoUnit.MICROS));;
+            assertThat(actualOrder.getTransferTime().value()).isCloseTo(storedOrder.getTransferTime().value(), within(100, ChronoUnit.MICROS));
             return null;
         });
     }

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AccountIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AccountIdAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.AccountId;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class AccountIdAttributeConverter extends BaseLongTypeAttributeConverter<AccountId> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CreatedAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CreatedAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.Created;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class CreatedAttributeConverter extends BaseLocalDateTimeTypeAttributeConverter<Created> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CustomerIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CustomerIdAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.CustomerId;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class CustomerIdAttributeConverter extends BaseCharSequenceTypeAttributeConverter<CustomerId> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/DueDateAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/DueDateAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.DueDate;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class DueDateAttributeConverter extends BaseLocalDateTypeAttributeConverter<DueDate> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/LastUpdatedAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/LastUpdatedAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.LastUpdated;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class LastUpdatedAttributeConverter extends BaseInstantTypeAttributeConverter<LastUpdated> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/OrderIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/OrderIdAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.OrderId;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class OrderIdAttributeConverter extends BaseLongTypeAttributeConverter<OrderId> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/ProductIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/ProductIdAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.ProductId;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class ProductIdAttributeConverter extends BaseCharSequenceTypeAttributeConverter<ProductId> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/QuantityAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/QuantityAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.Quantity;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class QuantityAttributeConverter extends BaseIntegerTypeAttributeConverter<Quantity> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TimeOfDayAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TimeOfDayAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.TimeOfDay;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class TimeOfDayAttributeConverter extends BaseLocalTimeTypeAttributeConverter<TimeOfDay> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransactionTimeAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransactionTimeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.TransactionTime;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class TransactionTimeAttributeConverter extends BaseZonedDateTimeTypeAttributeConverter<TransactionTime> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransferTimeAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransferTimeAttributeConverter.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.converters;
 
 import dk.cloudcreate.essentials.types.springdata.jpa.model.TransferTime;
-
-import javax.persistence.Converter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class TransferTimeAttributeConverter extends BaseOffsetDateTimeTypeAttributeConverter<TransferTime> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
@@ -17,8 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.model;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.*;
 
-import javax.persistence.*;
 import java.util.*;
 
 @Entity

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderId.java
@@ -17,8 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.model;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.Embeddable;
 
-import javax.persistence.Embeddable;
 import java.util.Random;
 
 @Embeddable

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Price.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Price.java
@@ -17,8 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.model;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.Embeddable;
 
-import javax.persistence.Embeddable;
 import java.util.Objects;
 
 @Embeddable

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
@@ -17,7 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.model;
 
 
-import javax.persistence.*;
+import jakarta.persistence.*;
+
 import java.util.Objects;
 
 @Entity

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductId.java
@@ -17,8 +17,8 @@
 package dk.cloudcreate.essentials.types.springdata.jpa.model;
 
 import dk.cloudcreate.essentials.types.*;
+import jakarta.persistence.Embeddable;
 
-import javax.persistence.Embeddable;
 import java.util.UUID;
 
 @Embeddable

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TimeOfDay.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TimeOfDay.java
@@ -26,10 +26,12 @@ public class TimeOfDay extends LocalTimeType<TimeOfDay> {
     }
 
     public static TimeOfDay of(LocalTime value) {
-        return new TimeOfDay(value);
+        // Setting nanoSeconds to 0 because LocalTime is stored as hours, minutes and seconds (see https://docs.jboss.org/hibernate/orm/6.2/userguide/html_single/Hibernate_User_Guide.html#basic-temporal)
+        return new TimeOfDay(value.withNano(0));
     }
 
     public static TimeOfDay now() {
-        return new TimeOfDay(LocalTime.now());
+        // Setting nanoSeconds to 0 because LocalTime is stored as hours, minutes and seconds
+        return new TimeOfDay(LocalTime.now().withNano(0));
     }
 }

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -17,7 +19,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
@@ -21,7 +21,6 @@ import dk.cloudcreate.essentials.types.springdata.mongo.model.Order;
 import dk.cloudcreate.essentials.types.springdata.mongo.model.*;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.test.annotation.DirtiesContext;
@@ -34,7 +33,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class OrderRepositoryIT {
 

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
@@ -20,7 +20,6 @@ import dk.cloudcreate.essentials.types.*;
 import dk.cloudcreate.essentials.types.springdata.mongo.model.*;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.*;
@@ -32,7 +31,7 @@ import org.testcontainers.junit.jupiter.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
-@DataMongoTest(excludeAutoConfiguration = EmbeddedMongoAutoConfiguration.class)
+@DataMongoTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class ProductRepositoryIT {
 

--- a/types/README.md
+++ b/types/README.md
@@ -1,7 +1,9 @@
 # Essentials Java building blocks
 
-Essentials is a set of Java version 11 (and later) building blocks built from the ground up to have no dependencies
+Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
+
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
@@ -18,7 +20,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.9.6</version>
+    <version>0.20.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
which is the first version support Java 17 as well as `jakarta.persistence` namespace, Spring 6.0.* and SpringBoot 3.0.*

Updated 3rd party dependencies:
- slf4j 2.0.7
- spring boot 3.0.6
- spring data mongodb 4.0.6
- spring data jpa 3.0.6
- spring 6.0.9
- reactor 2022.0.7
- jakarta.persistence-api 3.1.0
- java-uuid-generator 4.2.0
- logback 1.4.7

Updated maven plugins:
- flatten-maven-plugin 1.5.0