### PR TITLE
Release 0.20.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -115,7 +115,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -130,7 +130,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -208,7 +208,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -256,7 +256,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -278,7 +278,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -323,7 +323,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -357,7 +357,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -374,7 +374,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -446,7 +446,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -460,7 +460,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/README.md
+++ b/components/README.md
@@ -49,7 +49,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -64,7 +64,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -136,7 +136,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -213,7 +213,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -239,7 +239,7 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -287,7 +287,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -332,7 +332,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -421,7 +421,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -444,7 +444,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -40,7 +40,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -505,6 +505,6 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
@@ -209,7 +209,8 @@ public abstract class DurableQueuesIT<DURABLE_QUEUES extends DurableQueues, UOW 
         // Then
         Awaitility.waitAtMost(Duration.ofSeconds(2))
                   .untilAsserted(() -> assertThat(recordingQueueMessageHandler.messages).hasSize(3));
-        assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(0);
+        Awaitility.waitAtMost(Duration.ofSeconds(2))
+                  .untilAsserted(() -> assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(0));
         assertThat(durableQueues.getTotalDeadLetterMessagesQueuedFor(queueName)).isEqualTo(0);
 
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -36,7 +36,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -257,7 +257,7 @@ To use `PostgresqlDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -305,7 +305,7 @@ To use `MongoDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 
@@ -817,7 +817,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -21,7 +21,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -673,6 +673,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -1030,8 +1030,7 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                     }
 
                     overrideResumePoint(subscribeFromAndIncludingGlobalOrder);
-                    started = false;
-
+                    stop();
                     start();
                 } else {
                     overrideResumePoint(subscribeFromAndIncludingGlobalOrder);
@@ -1350,8 +1349,7 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                     }
 
                     overrideResumePoint(subscribeFromAndIncludingGlobalOrder);
-                    started = false;
-
+                    stop();
                     start();
                 } else {
                     overrideResumePoint(subscribeFromAndIncludingGlobalOrder);

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -10,7 +10,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -40,7 +40,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -10,7 +10,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -46,7 +46,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -19,7 +19,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -14,7 +14,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -14,7 +14,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -14,7 +14,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -20,7 +20,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -19,7 +19,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -20,7 +20,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -20,7 +20,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.20.2</version>
+    <version>0.20.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Added DurableQueuesIT waitAtMost to cover NonTransactional setup's
Changed `resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder)` in `NonExclusiveAsynchronousSubscription` and especially `ExclusiveAsynchronousSubscription` to ensure that resume-point reset is also picked up by the current holder of the fenced lock (as long as the reset is performed on the node which has acquired the fenced lock)