### PR TITLE
Release 0.20.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -121,7 +121,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -136,7 +136,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -214,7 +214,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -262,7 +262,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -284,7 +284,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -329,7 +329,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -363,7 +363,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -380,7 +380,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -452,7 +452,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -466,7 +466,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/README.md
+++ b/components/README.md
@@ -100,6 +100,15 @@ See [spring-boot-starter-postgresql](spring-boot-starter-postgresql/README.md)
 
 # Essentials Postgresql Event Store: Spring Boot starter
 
+To use `spring-boot-starter-postgresql-event-store` to add the following dependency:
+```
+<dependency>
+    <groupId>dk.cloudcreate.essentials.components</groupId>
+    <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
+    <version>0.40.0</version>
+</dependency>
+```
+
 Auto configures everything from [spring-boot-starter-postgresql](spring-boot-starter-postgresql/README.md)
 as well as the `EventStore`.
 

--- a/components/README.md
+++ b/components/README.md
@@ -48,7 +48,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -63,7 +63,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -144,7 +144,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -221,7 +221,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -249,7 +249,7 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -297,7 +297,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -342,7 +342,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -431,7 +431,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -454,7 +454,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -43,7 +43,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -508,6 +508,6 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
@@ -153,7 +153,7 @@ public interface CommandHandler<COMMAND, EVENT, ERROR> {
                                                              .reduce(initialStateAndEventStream._1,
                                                                      (deltaState, event) -> {
                                                                          eventOrderOfLastRehydratedEvent.set(event.eventOrder());
-                                                                         return decider.applyEvent(deltaState, event.event().deserialize());
+                                                                         return decider.applyEvent(event.event().deserialize(), deltaState);
                                                                      },
                                                                      (deltaState, deltaState2) -> deltaState2);
 
@@ -176,7 +176,7 @@ public interface CommandHandler<COMMAND, EVENT, ERROR> {
                 if (result.isSuccess()) {
                     var events = result.asSuccess().events();
                     if (!events.isEmpty()) {
-                        log.debug("[{}] Successfully handled command '{}' against '{}' with  associated aggregateId '{}'. Resulted in {} events of type {}",
+                        log.debug("[{}] Successfully handled command '{}' against state '{}' associated with aggregateId '{}'. Resulted in {} events of type {}",
                                   aggregateType,
                                   cmd.getClass().getName(),
                                   stateType.getName(),
@@ -209,14 +209,14 @@ public interface CommandHandler<COMMAND, EVENT, ERROR> {
                                                                                                                                              events),
                                                                                                 new DeciderUnitOfWorkLifecycleCallback());
                                   }, () -> {
-                                      log.debug("[{}] !!! No active UnitOfWork so will NOT persist {} events associated with '{}' with aggregateId '{}'",
+                                      log.debug("[{}] !!! No active UnitOfWork so will NOT persist {} events associated withﬁ '{}' with aggregateId '{}'",
                                                 aggregateType,
                                                 events.size(),
                                                 stateType.getName(),
                                                 aggregateId);
                                   });
                     } else {
-                        log.debug("[{}] Successfully handled command '{}' against '{}' with associated aggregateId '{}', but it didn't result in any events",
+                        log.debug("[{}] Successfully handled command '{}' against state '{}' associated with aggregateId '{}', but it didn't result in any events",
                                   aggregateType,
                                   cmd.getClass().getName(),
                                   stateType.getName(),

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Decider.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Decider.java
@@ -27,7 +27,7 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  * @param <ERROR>   The type of Error that can be returned by the {@link #handle(Object, Object)} method
  * @param <STATE>   The type of Aggregate State that this {@link Decider} works with in {@link #handle(Object, Object)}, {@link #initialState()}, {@link #applyEvent(Object, Object)} and {@link #isFinal(Object)}
  */
-public interface Decider<COMMAND, EVENT, ERROR, STATE> extends Handler<COMMAND, EVENT, ERROR, STATE>, StateEvolver<STATE, EVENT>, InitialStateProvider<STATE>, IsStateFinalResolver<STATE> {
+public interface Decider<COMMAND, EVENT, ERROR, STATE> extends Handler<COMMAND, EVENT, ERROR, STATE>, StateEvolver<EVENT, STATE>, InitialStateProvider<STATE>, IsStateFinalResolver<STATE> {
     /**
      * Factory method for creating a {@link Decider} instance from instances of the various {@link Decider} related interfaces
      *
@@ -43,7 +43,7 @@ public interface Decider<COMMAND, EVENT, ERROR, STATE> extends Handler<COMMAND, 
      */
     static <COMMAND, EVENT, ERROR, STATE> Decider<COMMAND, EVENT, ERROR, STATE> decider(Handler<COMMAND, EVENT, ERROR, STATE> handler,
                                                                                         InitialStateProvider<STATE> initialStateProvider,
-                                                                                        StateEvolver<STATE, EVENT> stateEvolver,
+                                                                                        StateEvolver<EVENT, STATE> stateEvolver,
                                                                                         IsStateFinalResolver<STATE> stateIsStateFinalResolver) {
         requireNonNull(handler, "No handler provided");
         requireNonNull(initialStateProvider, "No initialStateProvider provided");
@@ -51,8 +51,8 @@ public interface Decider<COMMAND, EVENT, ERROR, STATE> extends Handler<COMMAND, 
         requireNonNull(stateIsStateFinalResolver, "No stateIsStateFinalResolver provided");
         return new Decider<>() {
             @Override
-            public STATE applyEvent(STATE state, EVENT event) {
-                return stateEvolver.applyEvent(state, event);
+            public STATE applyEvent(EVENT event, STATE state) {
+                return stateEvolver.applyEvent(event, state);
             }
 
             @Override

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/StateEvolver.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/StateEvolver.java
@@ -27,16 +27,16 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  * @param <STATE> The type of <i>aggregate/projection/view</i> <code>STATE</code> that {@link #applyEvent(Object, Object)} supports
  */
 @FunctionalInterface
-public interface StateEvolver<STATE, EVENT> {
+public interface StateEvolver<EVENT, STATE> {
     /**
      * Apply the <code>EVENT</code> to the <i>aggregate/projection/view</i> <code>STATE</code> instance<br>
      * <b>Note: This method is called <code>evolve</code> in the decider pattern</b><br>
      *
-     * @param state the current <code>STATE</code> of the <i>aggregate/projection/view</i>
      * @param event the <code>EVENT</code> to be applied / projected onto the current <i>aggregate/projection/view</i> <code>STATE</code>
+     * @param state the current <code>STATE</code> of the <i>aggregate/projection/view</i>
      * @return the new <i>aggregate/projection/view</i> <code>STATE</code> (after the <code>EVENT</code> has been applied / projected onto the current <i>aggregate/projection/view</i> <code>STATE</code>)
      */
-    STATE applyEvent(STATE state, EVENT event);
+    STATE applyEvent(EVENT event, STATE state);
 
     /**
      * Perform a left-fold over the <code>eventStream</code> using the <code>initialState</code> as the initial state<br>
@@ -48,13 +48,13 @@ public interface StateEvolver<STATE, EVENT> {
      * @param <STATE>      The type of <i>aggregate/projection/view</i> <code>STATE</code> that {@link #applyEvent(Object, Object)} supports
      * @return the initial state with all events applied to it
      */
-    static <STATE, EVENT> STATE applyEvents(StateEvolver<STATE, EVENT> stateEvolver,
+    static <STATE, EVENT> STATE applyEvents(StateEvolver<EVENT, STATE> stateEvolver,
                                             STATE initialState,
                                             Stream<EVENT> eventStream) {
         requireNonNull(initialState, "No initialState provided");
         return requireNonNull(eventStream, "No eventStream provided")
                 .reduce(initialState,
-                        stateEvolver::applyEvent,
+                        (state, event) -> stateEvolver.applyEvent(event, state),
                         (deltaState, deltaState2) -> deltaState2);
     }
 }

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/View.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/View.java
@@ -22,6 +22,6 @@ package dk.cloudcreate.essentials.components.eventsourced.aggregates.decider;
  * @param <EVENT> The type of Events that can be applied in the {@link #applyEvent(Object, Object)}
  * @param <STATE> The type of <i>projection/view</i> <code>STATE</code> that {@link #applyEvent(Object, Object)} supports
  */
-public interface View<STATE, EVENT> extends StateEvolver<STATE, EVENT>, InitialStateProvider<STATE> {
+public interface View<EVENT, STATE> extends StateEvolver<EVENT, STATE>, InitialStateProvider<STATE> {
 
 }

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
@@ -203,7 +203,7 @@ class DeciderTest {
 
         @Override
         public GuessingGameState initialState() {
-            return new GuessingGameState.NotStartedGame();
+            return new GuessingGameState.GameNotStartedState();
         }
 
         @Override
@@ -214,7 +214,7 @@ class DeciderTest {
 
     // -------------------------- State --------------------------
     public sealed interface GuessingGameState extends Handler<GuessingGameCommand, GuessingGameEvent, GuessingGameError, GuessingGameState>, StateEvolver<GuessingGameEvent, GuessingGameState> {
-        record NotStartedGame() implements GuessingGameState {
+        record GameNotStartedState() implements GuessingGameState {
             @Override
             public HandlerResult<GuessingGameError, GuessingGameEvent> handle(GuessingGameCommand cmd, GuessingGameState game) {
                 if (cmd instanceof GuessingGameCommand.JoinGame joinGame) {
@@ -229,7 +229,7 @@ class DeciderTest {
             @Override
             public GuessingGameState applyEvent(GuessingGameEvent gameEvent, GuessingGameState game) {
                 if (gameEvent instanceof GuessingGameEvent.GameStarted gameStarted) {
-                    return new StartedGameState(gameStarted.secret,
+                    return new GameStartedState(gameStarted.secret,
                                                 gameStarted.allowedDigits,
                                                 gameStarted.maxAttempts);
                 }
@@ -237,13 +237,13 @@ class DeciderTest {
             }
         }
 
-        final class StartedGameState implements GuessingGameState {
+        final class GameStartedState implements GuessingGameState {
             private final Secret     secret;
             private final Set<Digit> allowedDigits;
             private final int        maxAttempts;
             int attempts;
 
-            public StartedGameState(Secret secret,
+            public GameStartedState(Secret secret,
                                     Set<Digit> allowedDigits,
                                     int maxAttempts) {
                 this.secret = secret;

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
@@ -207,13 +207,13 @@ class DeciderTest {
         }
 
         @Override
-        public GuessingGameState applyEvent(GuessingGameState gameState, GuessingGameEvent gameEvent) {
-            return gameState.applyEvent(gameState, gameEvent);
+        public GuessingGameState applyEvent(GuessingGameEvent gameEvent, GuessingGameState gameState) {
+            return gameState.applyEvent(gameEvent, gameState);
         }
     }
 
     // -------------------------- State --------------------------
-    public sealed interface GuessingGameState extends Handler<GuessingGameCommand, GuessingGameEvent, GuessingGameError, GuessingGameState>, StateEvolver<GuessingGameState, GuessingGameEvent> {
+    public sealed interface GuessingGameState extends Handler<GuessingGameCommand, GuessingGameEvent, GuessingGameError, GuessingGameState>, StateEvolver<GuessingGameEvent, GuessingGameState> {
         record NotStartedGame() implements GuessingGameState {
             @Override
             public HandlerResult<GuessingGameError, GuessingGameEvent> handle(GuessingGameCommand cmd, GuessingGameState game) {
@@ -227,7 +227,7 @@ class DeciderTest {
             }
 
             @Override
-            public GuessingGameState applyEvent(GuessingGameState game, GuessingGameEvent gameEvent) {
+            public GuessingGameState applyEvent(GuessingGameEvent gameEvent, GuessingGameState game) {
                 if (gameEvent instanceof GuessingGameEvent.GameStarted gameStarted) {
                     return new StartedGameState(gameStarted.secret,
                                                 gameStarted.allowedDigits,
@@ -300,7 +300,7 @@ class DeciderTest {
             }
 
             @Override
-            public GuessingGameState applyEvent(GuessingGameState game, GuessingGameEvent gameEvent) {
+            public GuessingGameState applyEvent(GuessingGameEvent gameEvent, GuessingGameState game) {
                 if (gameEvent instanceof GuessingGameEvent.GuessMade) {
                     attempts++;
                 } else if (gameEvent instanceof GuessingGameEvent.GameWon) {
@@ -323,7 +323,7 @@ class DeciderTest {
             }
 
             @Override
-            public GuessingGameState applyEvent(GuessingGameState game, GuessingGameEvent gameEvent) {
+            public GuessingGameState applyEvent(GuessingGameEvent gameEvent, GuessingGameState game) {
                 return game;
             }
         }
@@ -335,7 +335,7 @@ class DeciderTest {
             }
 
             @Override
-            public GuessingGameState applyEvent(GuessingGameState game, GuessingGameEvent gameEvent) {
+            public GuessingGameState applyEvent(GuessingGameEvent gameEvent, GuessingGameState game) {
                 return game;
             }
         }

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -35,7 +35,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -160,7 +160,7 @@ To use `PostgresqlDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -208,7 +208,7 @@ To use `MongoDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 
@@ -720,7 +720,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageHandlerInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageHandlerInterceptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward;
+
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.operation.InvokeMessageHandlerMethod;
+import dk.cloudcreate.essentials.shared.interceptor.*;
+
+public interface MessageHandlerInterceptor extends Interceptor {
+    /**
+     * Intercept {@link dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.operation.InvokeMessageHandlerMethod} calls
+     *
+     * @param operation        the operation
+     * @param interceptorChain the interceptor chain (call {@link InterceptorChain#proceed()} to continue the processing chain)
+     */
+    default void intercept(InvokeMessageHandlerMethod operation, InterceptorChain<InvokeMessageHandlerMethod, Void, MessageHandlerInterceptor> interceptorChain) {
+        interceptorChain.proceed();
+    }
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/operation/InvokeMessageHandlerMethod.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/operation/InvokeMessageHandlerMethod.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.operation;
+
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.Message;
+
+import java.lang.reflect.Method;
+
+public class InvokeMessageHandlerMethod {
+    public final  Method   methodToInvoke;
+    private final Message  message;
+    private final Object   messagPayload;
+    public final  Object   invokeMethodOn;
+    public final  Class<?> resolvedInvokeMethodWithArgumentOfType;
+
+    public InvokeMessageHandlerMethod(Method methodToInvoke, Message message, Object messagPayload, Object invokeMethodOn, Class<?> resolvedInvokeMethodWithArgumentOfType) {
+        this.methodToInvoke = methodToInvoke;
+        this.message = message;
+        this.messagPayload = messagPayload;
+        this.invokeMethodOn = invokeMethodOn;
+        this.resolvedInvokeMethodWithArgumentOfType = resolvedInvokeMethodWithArgumentOfType;
+    }
+
+    @Override
+    public String toString() {
+        return "InvokeMessageHandlerMethod{" +
+                "methodToInvoke=" + methodToInvoke +
+                ", message= {" + message + "}" +
+                ", resolvedInvokeMethodWithArgumentOfType=" + resolvedInvokeMethodWithArgumentOfType +
+                ", invokeMethodOn=" + invokeMethodOn +
+                '}';
+    }
+}

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerWithInterceptorTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerWithInterceptorTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward;
+
+import dk.cloudcreate.essentials.components.foundation.messaging.MessageHandler;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.operation.InvokeMessageHandlerMethod;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.test_data.*;
+import dk.cloudcreate.essentials.shared.interceptor.InterceptorChain;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PatternMatchingMessageHandlerWithInterceptorTest {
+    @Test
+    void test_queued_message_pattern_matching_with_1_parameter() {
+        // Given
+        var messageHandler = new TestPatternMatchingMessageHandler();
+        var someCommand    = new SomeCommand("Test");
+
+        // When
+        messageHandler.accept(Message.of(someCommand));
+
+        // Then
+        assertThat(messageHandler.interceptor.operation).isNotNull();
+        assertThat(messageHandler.interceptor.operation.methodToInvoke.getName()).isEqualTo("handleSomeCommand");
+        assertThat(messageHandler.someCommand).isEqualTo(someCommand);
+        assertThat(messageHandler.someOtherCommand).isNull();
+        assertThat(messageHandler.messageForSomeOtherCommand).isNull();
+        assertThat(messageHandler.someThirdCommand).isNull();
+        assertThat(messageHandler.messageForSomeThirdCommand).isNull();
+        assertThat(messageHandler.unmatchedMessage).isNull();
+
+
+        assertThat(messageHandler.handlesMessageWithPayload(someCommand.getClass())).isTrue();
+    }
+
+    @Test
+    void test_queued_message_pattern_matching_with_2_parameters() {
+        // Given
+        var messageHandler   = new TestPatternMatchingMessageHandler();
+        var someOtherCommand = new SomeOtherCommand("Test");
+
+        // When
+        var message = Message.of(someOtherCommand);
+        messageHandler.accept(message);
+
+        // Then
+        assertThat(messageHandler.interceptor.operation).isNotNull();
+        assertThat(messageHandler.interceptor.operation.methodToInvoke.getName()).isEqualTo("handleSomeOtherCommand");
+
+        assertThat(messageHandler.someCommand).isNull();
+        assertThat(messageHandler.someOtherCommand).isEqualTo(someOtherCommand);
+        assertThat(messageHandler.messageForSomeOtherCommand).isEqualTo(message);
+        assertThat(messageHandler.someThirdCommand).isNull();
+        assertThat(messageHandler.messageForSomeThirdCommand).isNull();
+
+        assertThat(messageHandler.unmatchedMessage).isNull();
+
+        assertThat(messageHandler.handlesMessageWithPayload(someOtherCommand.getClass())).isTrue();
+    }
+
+    @Test
+    void test_queued_message_pattern_matching_with_OrderedMessage() {
+        // Given
+        var messageHandler   = new TestPatternMatchingMessageHandler();
+        var someThirdCommand = new SomeThirdCommand("Test");
+
+        // When
+        var message = OrderedMessage.of(someThirdCommand, "key1", 10);
+        messageHandler.accept(message);
+
+        // Then
+        assertThat(messageHandler.interceptor.operation).isNotNull();
+        assertThat(messageHandler.interceptor.operation.methodToInvoke.getName()).isEqualTo("handleSomeThirdCommand");
+
+        assertThat(messageHandler.someCommand).isNull();
+        assertThat(messageHandler.someOtherCommand).isNull();
+        assertThat(messageHandler.someThirdCommand).isEqualTo(someThirdCommand);
+        assertThat(messageHandler.messageForSomeOtherCommand).isNull();
+        assertThat(messageHandler.messageForSomeThirdCommand).isEqualTo(message);
+        assertThat(messageHandler.unmatchedMessage).isNull();
+
+        assertThat(messageHandler.handlesMessageWithPayload(someThirdCommand.getClass())).isTrue();
+    }
+
+    @Test
+    void test_queued_message_pattern_matching_with_unmatched_message() {
+        // Given
+        var messageHandler       = new TestPatternMatchingMessageHandler();
+        var someUnmatchedCommand = new SomeUnmatchedCommand("Test");
+
+        // When
+        var message = Message.of(someUnmatchedCommand);
+        messageHandler.accept(message);
+
+        // Then
+        assertThat(messageHandler.interceptor.operation).isNull();
+
+        assertThat(messageHandler.someCommand).isNull();
+        assertThat(messageHandler.someOtherCommand).isNull();
+        assertThat(messageHandler.messageForSomeOtherCommand).isNull();
+        assertThat(messageHandler.someThirdCommand).isNull();
+        assertThat(messageHandler.messageForSomeThirdCommand).isNull();
+        assertThat(messageHandler.unmatchedMessage).isEqualTo(message);
+
+        assertThat(messageHandler.handlesMessageWithPayload(someUnmatchedCommand.getClass())).isFalse();
+    }
+
+    private static class TestPatternMatchingMessageHandler extends PatternMatchingMessageHandler {
+        private TestMessageHandlerInterceptor interceptor;
+        private SomeCommand      someCommand;
+        private SomeOtherCommand someOtherCommand;
+        private Message          messageForSomeOtherCommand;
+        private Message          unmatchedMessage;
+        private SomeThirdCommand someThirdCommand;
+        private OrderedMessage   messageForSomeThirdCommand;
+
+        public TestPatternMatchingMessageHandler() {
+            super();
+            interceptor = new TestMessageHandlerInterceptor();
+            addInterceptor(interceptor);
+        }
+
+        @MessageHandler
+        void handleSomeCommand(SomeCommand someCommand) {
+            this.someCommand = someCommand;
+        }
+
+        @MessageHandler
+        void handleSomeOtherCommand(SomeOtherCommand someOtherCommand, Message messageForSomeOtherCommand) {
+            this.someOtherCommand = someOtherCommand;
+            this.messageForSomeOtherCommand = messageForSomeOtherCommand;
+        }
+
+        @MessageHandler
+        void handleSomeThirdCommand(SomeThirdCommand someThirdCommand, OrderedMessage messageForSomeThirdCommand) {
+            this.someThirdCommand = someThirdCommand;
+            this.messageForSomeThirdCommand = messageForSomeThirdCommand;
+        }
+
+        @Override
+        protected void handleUnmatchedMessage(Message message) {
+            this.unmatchedMessage = message;
+        }
+    }
+
+    private static class TestMessageHandlerInterceptor implements MessageHandlerInterceptor {
+        private InvokeMessageHandlerMethod operation;
+
+        @Override
+        public void intercept(InvokeMessageHandlerMethod operation, InterceptorChain<InvokeMessageHandlerMethod, Void, MessageHandlerInterceptor> interceptorChain) {
+            this.operation = operation;
+            interceptorChain.proceed();
+        }
+    }
+}

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -21,7 +21,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -691,6 +691,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStreamBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStreamBuilder.java
@@ -32,7 +32,7 @@ public class FetchStreamBuilder<ID> {
     private AggregateType    aggregateType;
     private ID               aggregateId;
     private LongRange        eventOrderRange;
-    private Optional<Tenant> tenant;
+    private Optional<Tenant> tenant = Optional.empty();
 
     /**
      * @param aggregateType the aggregate type that the underlying {@link AggregateEventStream} is associated with

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
@@ -189,7 +189,7 @@ public abstract class EventProcessor implements Lifecycle {
         commandBusHandlerDelegate = new AnnotatedCommandHandler(this);
         commandBus.addCommandHandler(commandBusHandlerDelegate);
 
-        patternMatchingInboxMessageHandlerDelegate = new PatternMatchingMessageHandler(this);
+        patternMatchingInboxMessageHandlerDelegate = new PatternMatchingMessageHandler(this, getMessageHandlerInterceptors());
         patternMatchingInboxMessageHandlerDelegate.allowUnmatchedMessages();
         inboxMessageHandlerDelegate = (msg) -> {
             if (msg instanceof OrderedMessage orderedMessage && EventReferenceOrderedMessage.isEventReference(orderedMessage)) {
@@ -227,6 +227,15 @@ public abstract class EventProcessor implements Lifecycle {
                 patternMatchingInboxMessageHandlerDelegate.accept(msg);
             }
         };
+    }
+
+    /**
+     * Override {@link MessageHandlerInterceptor}'s that should be used when calling {@link MessageHandler} annotated methods
+     *
+     * @return
+     */
+    protected List<MessageHandlerInterceptor> getMessageHandlerInterceptors() {
+        return List.of();
     }
 
 

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -10,7 +10,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -32,34 +32,57 @@ The `EssentialsComponentsConfiguration` auto-configures:
   - Supports additional properties:
   - ```
     essentials.durable-queues.shared-queue-collection-name=durable_queues
-    essentials.durable-queues.transactional-mode=fullytransactional
+    essentials.durable-queues.transactional-mode=fullytransactional or singleoperationtransaction (default)
     essentials.durable-queues.polling-delay-interval-increment-factor=0.5
     essentials.durable-queues.max-polling-interval=2s
     essentials.durable-queues.verbose-tracing=false
     # Only relevant if transactional-mode=singleoperationtransaction
-    # essentials.durable-queues.message-handling-timeout=5s
+    essentials.durable-queues.message-handling-timeout=5s
     ```
 - `Inboxes`, `Outboxes` and `DurableLocalCommandBus` configured to use `MongoDurableQueues`
 - `LocalEventBus` with bus-name `default` and Bean name `eventBus`
 - `ReactiveHandlersBeanPostProcessor` (for auto-registering `EventHandler` and `CommandHandler` Beans with the `EventBus`'s and `CommandBus` beans found in the `ApplicationContext`)
 - Automatically calling `Lifecycle.start()`/`Lifecycle.stop`, on any Beans implementing the `Lifecycle` interface, when the `ApplicationContext` is started/stopped
 
+## Spring Data Mongo converters
+**Converter**'s for core semantic types (`LockName`, `QueueEntryId` and `QueueName`) are automatically registered by the `EssentialsComponentsConfiguration` during its configuration of the
+`MongoCustomConversions` Bean (you can choose to provide your own Bean).
+
+You can add support for additional concrete `CharSequenceType`'s by providing a Bean of type `AdditionalCharSequenceTypesSupported`:
+```java
+@Bean
+AdditionalCharSequenceTypesSupported additionalCharSequenceTypesSupported() {
+    return new AdditionalCharSequenceTypesSupported(OrderId.class);
+}
+```
+
+Similarly, you can add additional `Converter`/`GenericConverter`/etc by providing a Bean of type `AdditionalConverters`:
+
+```java
+@Bean
+AdditionalConverters additionalGenericConverters() {
+    return new AdditionalConverters(Jsr310Converters.StringToDurationConverter.INSTANCE,
+                                    Jsr310Converters.DurationToStringConverter.INSTANCE);
+}
+```
   
-Full configuration:
+## Full configuration override:
 
 Optional overriding of values in `src/main/resources/application.properties`:
 ```
 essentials.durable-queues.shared-queue-collection-name=durable_queues
-essentials.durable-queues.transactional-mode=fullytransactional
-# Only relevant if transactional-mode=singleoperationtransaction
-# essentials.durable-queues.message-handling-timeout=5s
+essentials.durable-queues.message-handling-timeout=5s
+essentials.durable-queues.polling-delay-interval-increment-factor=0.5
+essentials.durable-queues.max-polling-interval=2s
+essentials.durable-queues.verbose-tracing=false
+essentials.durable-queues.transactional-mode=singleoperationtransaction
 
 essentials.fenced-lock-manager.fenced-locks-collection-name=fenced_locks
 essentials.fenced-lock-manager.lock-confirmation-interval=5s
 essentials.fenced-lock-manager.lock-time-out=12s
 ```
 
-`pom.xml` dependencies:
+## `pom.xml` dependencies:
 ```
 <dependencies>
     <dependency>

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalCharSequenceTypesSupported.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalCharSequenceTypesSupported.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.boot.autoconfigure.mongodb;
+
+import dk.cloudcreate.essentials.types.CharSequenceType;
+
+import java.util.*;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * The {@link AdditionalCharSequenceTypesSupported} class represents a collection of additional {@link CharSequenceType} classes
+ * that will be supported by the {@link dk.cloudcreate.essentials.types.springdata.mongo.SingleValueTypeConverter}
+ * that is registered in {@link EssentialsComponentsConfiguration#mongoCustomConversions(Optional, Optional)}
+ */
+public class AdditionalCharSequenceTypesSupported {
+    public final List<Class<? extends CharSequenceType<?>>> charSequenceTypes;
+
+    public AdditionalCharSequenceTypesSupported() {
+        this(List.of());
+    }
+
+    /**
+     * Constructs an instance of AdditionalCharSequenceTypesSupported with the given charSequenceTypes.
+     *
+     * @param charSequenceTypes an array of Class objects representing the additional CharSequenceType classes
+     *                          to be supported
+     */
+    public AdditionalCharSequenceTypesSupported(Class<? extends CharSequenceType<?>>... charSequenceTypes) {
+        this(List.of(charSequenceTypes));
+    }
+
+
+    /**
+     * Constructs an instance of AdditionalCharSequenceTypesSupported with the given charSequenceTypes.
+     *
+     * @param charSequenceTypes a list of Class objects representing the additional CharSequenceType classes
+     *                          to be supported (must not be null)
+     */
+    public AdditionalCharSequenceTypesSupported(List<Class<? extends CharSequenceType<?>>> charSequenceTypes) {
+        this.charSequenceTypes = requireNonNull(charSequenceTypes, "charSequenceTypes is null");
+    }
+}

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalConverters.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalConverters.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.boot.autoconfigure.mongodb;
+
+import org.springframework.core.convert.converter.*;
+
+import java.util.*;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * {@link AdditionalConverters} class represents a collection of additional {@link Converter}/{@link GenericConverter}/etc.
+ * that will be added to the {@link org.springframework.data.mongodb.core.convert.MongoCustomConversions}
+ * that is created in {@link EssentialsComponentsConfiguration#mongoCustomConversions(Optional, Optional)}
+ */
+public class AdditionalConverters {
+    /**
+     * {@link Converter}/{@link GenericConverter}/etc.
+     */
+    public final List<?> converters;
+
+    public AdditionalConverters() {
+        this(List.of());
+    }
+
+    /**
+     * Constructs an instance of AdditionalGenericConverters with the given array of {@link Converter}/{@link GenericConverter}/etc. objects.
+     *
+     * @param converters an array of {@link Converter} objects to be added as additional converters
+     */
+    public AdditionalConverters(Object... converters) {
+        this(List.of(converters));
+    }
+
+    /**
+     * Constructs an instance of AdditionalGenericConverters with the given array of {@link Converter}/{@link GenericConverter}/etc. objects.
+     *
+     * @param converters a list of {@link Converter} objects to be added as additional converters (must not be null)
+     */
+    public AdditionalConverters(List<?> converters) {
+        this.converters = requireNonNull(converters, "converters is null");
+    }
+}

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -148,7 +148,21 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
      * Registers <code>new SingleValueTypeConverter(LockName.class, QueueEntryId.class, QueueName.class)))</code> with the {@link MongoCustomConversions}
      * as {@link LockName}, {@link QueueEntryId} and {@link QueueName} are required by {@link FencedLockManager} and {@link DurableQueues}
      * and any additional {@link CharSequenceType}'s provided in the optional {@link AdditionalCharSequenceTypesSupported} parameter.<br>
-     * Through the optional {@link AdditionalConverters} parameter it supports easily registration of additional {@link Converter}/{@link GenericConverter}'s/etc
+     * Through the optional {@link AdditionalConverters} parameter it supports easily registration of additional {@link Converter}/{@link GenericConverter}'s/etc<br>
+     * <br>
+     * Example Spring Config:
+     * <pre>{@code
+     * @Bean
+     * AdditionalCharSequenceTypesSupported additionalCharSequenceTypesSupported() {
+     *     return new AdditionalCharSequenceTypesSupported(OrderId.class);
+     * }
+     *
+     * @Bean
+     * AdditionalConverters additionalGenericConverters() {
+     *     return new AdditionalConverters(Jsr310Converters.StringToDurationConverter.INSTANCE,
+     *                                     Jsr310Converters.DurationToStringConverter.INSTANCE);
+     * }
+     * }</pre>
      *
      * @param optionalAdditionalCharSequenceTypesSupported An optional additional concrete {@link CharSequenceType}'s that will be registered with the {@link SingleValueTypeConverter}
      *                                                     being added to the returned {@link MongoCustomConversions}

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -42,6 +42,7 @@ import dk.cloudcreate.essentials.reactive.*;
 import dk.cloudcreate.essentials.reactive.command.*;
 import dk.cloudcreate.essentials.reactive.command.interceptor.CommandBusInterceptor;
 import dk.cloudcreate.essentials.reactive.spring.ReactiveHandlersBeanPostProcessor;
+import dk.cloudcreate.essentials.types.CharSequenceType;
 import dk.cloudcreate.essentials.types.springdata.mongo.*;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
@@ -56,6 +57,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.*;
+import org.springframework.core.convert.converter.*;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.*;
@@ -130,7 +132,7 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     @Bean
     @ConditionalOnClass(name = "org.objenesis.ObjenesisStd")
     @ConditionalOnMissingBean
-    public com.fasterxml.jackson.databind.Module essentialsImmutableJacksonModule() {
+    public EssentialsImmutableJacksonModule essentialsImmutableJacksonModule() {
         return new EssentialsImmutableJacksonModule();
     }
 
@@ -141,15 +143,32 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     }
 
     /**
+     * Creates a {@link MongoCustomConversions} bean  (using <code>SpringDataJavaTimeCodecs</code>)
+     * with optional additional char sequence types supported and generic converters.<br>
      * Registers <code>new SingleValueTypeConverter(LockName.class, QueueEntryId.class, QueueName.class)))</code> with the {@link MongoCustomConversions}
      * as {@link LockName}, {@link QueueEntryId} and {@link QueueName} are required by {@link FencedLockManager} and {@link DurableQueues}
+     * and any additional {@link CharSequenceType}'s provided in the optional {@link AdditionalCharSequenceTypesSupported} parameter.<br>
+     * Through the optional {@link AdditionalConverters} parameter it supports easily registration of additional {@link Converter}/{@link GenericConverter}'s/etc
+     *
+     * @param optionalAdditionalCharSequenceTypesSupported An optional additional concrete {@link CharSequenceType}'s that will be registered with the {@link SingleValueTypeConverter}
+     *                                                     being added to the returned {@link MongoCustomConversions}
+     * @param optionalAdditionalGenericConverters          An optional additional {@link Converter}/{@link GenericConverter}'s/etc. that will be
+     *                                                     added to the returned  {@link MongoCustomConversions}
      * @return the {@link MongoCustomConversions}
      */
     @Bean
     @ConditionalOnMissingBean
-    public MongoCustomConversions mongoCustomConversions() {
-        return new MongoCustomConversions(List.of(
-                new SingleValueTypeConverter(LockName.class, QueueEntryId.class, QueueName.class)));
+    public MongoCustomConversions mongoCustomConversions(Optional<AdditionalCharSequenceTypesSupported> optionalAdditionalCharSequenceTypesSupported,
+                                                         Optional<AdditionalConverters> optionalAdditionalGenericConverters) {
+        return MongoCustomConversions.create(mongoConverterConfigurationAdapter -> {
+            mongoConverterConfigurationAdapter.useSpringDataJavaTimeCodecs();
+            List<Class<? extends CharSequenceType<?>>> allCharSequenceTypesSupported = new ArrayList<>(List.of(LockName.class, QueueEntryId.class, QueueName.class));
+            optionalAdditionalCharSequenceTypesSupported.ifPresent(additionalCharSequenceTypesSupported -> allCharSequenceTypesSupported.addAll(additionalCharSequenceTypesSupported.charSequenceTypes));
+
+            List<Object> allGenericConverters = new ArrayList<>(List.of(new SingleValueTypeConverter(allCharSequenceTypesSupported)));
+            optionalAdditionalGenericConverters.ifPresent(additionalGenericConverters -> allGenericConverters.addAll(additionalGenericConverters.converters));
+            mongoConverterConfigurationAdapter.registerConverters(allGenericConverters);
+        });
     }
 
     /**
@@ -333,28 +352,32 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     /**
      * {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      *
+     * @param optionalEssentialsImmutableJacksonModule the optional {@link EssentialsImmutableJacksonModule}
      * @return the {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      */
     @Bean
     @ConditionalOnMissingBean
-    public ObjectMapper essentialComponentsObjectMapper() {
-        var objectMapper = JsonMapper.builder()
-                                     .disable(MapperFeature.AUTO_DETECT_GETTERS)
-                                     .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
-                                     .disable(MapperFeature.AUTO_DETECT_SETTERS)
-                                     .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
-                                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                                     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                                     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                                     .enable(MapperFeature.AUTO_DETECT_CREATORS)
-                                     .enable(MapperFeature.AUTO_DETECT_FIELDS)
-                                     .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
-                                     .addModule(new Jdk8Module())
-                                     .addModule(new JavaTimeModule())
-                                     .addModule(new EssentialTypesJacksonModule())
-                                     .addModule(new EssentialsImmutableJacksonModule())
-                                     .build();
+    public ObjectMapper essentialComponentsObjectMapper(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule) {
+        var objectMapperBuilder = JsonMapper.builder()
+                                            .disable(MapperFeature.AUTO_DETECT_GETTERS)
+                                            .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+                                            .disable(MapperFeature.AUTO_DETECT_SETTERS)
+                                            .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                                            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                                            .enable(MapperFeature.AUTO_DETECT_CREATORS)
+                                            .enable(MapperFeature.AUTO_DETECT_FIELDS)
+                                            .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
+                                            .addModule(new Jdk8Module())
+                                            .addModule(new JavaTimeModule())
+                                            .addModule(new EssentialTypesJacksonModule());
 
+        optionalEssentialsImmutableJacksonModule.ifPresent(essentialsImmutableJacksonModule -> {
+            objectMapperBuilder.addModule(new EssentialsImmutableJacksonModule());
+        });
+
+        var objectMapper = objectMapperBuilder.build();
         objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
                                                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
                                                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -33,10 +33,12 @@ This will ensure to include the `spring-boot-starter-postgresql` starter, so you
   - Supports additional properties:
   - ```
     essentials.durable-queues.shared-queue-table-name=durable_queues
+    essentials.durable-queues.transactional-mode=fullytransactional or singleoperationtransaction (default)
     essentials.durable-queues.polling-delay-interval-increment-factor=0.5
     essentials.durable-queues.max-polling-interval=2s
+    essentials.durable-queues.verbose-tracing=false
     # Only relevant if transactional-mode=singleoperationtransaction
-    # essentials.durable-queues.message-handling-timeout=5s
+    essentials.durable-queues.message-handling-timeout=5s
     ```
 - `Inboxes`, `Outboxes` and `DurableLocalCommandBus` configured to use `PostgresqlDurableQueues`
 - `LocalEventBus` with bus-name `default` and Bean name `eventBus`

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -31,12 +31,12 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
   - Supports additional properties:
   - ```
     essentials.durable-queues.shared-queue-table-name=durable_queues
-    essentials.durable-queues.transactional-mode=fullytransactional
+    essentials.durable-queues.transactional-mode=fullytransactional or singleoperationtransaction (default)
     essentials.durable-queues.polling-delay-interval-increment-factor=0.5
     essentials.durable-queues.max-polling-interval=2s
     essentials.durable-queues.verbose-tracing=false
     # Only relevant if transactional-mode=singleoperationtransaction
-    # essentials.durable-queues.message-handling-timeout=5s
+    essentials.durable-queues.message-handling-timeout=5s
     ```
 - `Inboxes`, `Outboxes` and `DurableLocalCommandBus` configured to use `PostgresqlDurableQueues`
 - `LocalEventBus` with bus-name `default` and Bean name `eventBus`

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -130,7 +130,7 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     @Bean
     @ConditionalOnClass(name = "org.objenesis.ObjenesisStd")
     @ConditionalOnMissingBean
-    public com.fasterxml.jackson.databind.Module essentialsImmutableJacksonModule() {
+    public EssentialsImmutableJacksonModule essentialsImmutableJacksonModule() {
         return new EssentialsImmutableJacksonModule();
     }
 
@@ -319,28 +319,32 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     /**
      * {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      *
+     * @param optionalEssentialsImmutableJacksonModule the optional {@link EssentialsImmutableJacksonModule}
      * @return the {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      */
     @Bean
     @ConditionalOnMissingBean
-    public ObjectMapper essentialComponentsObjectMapper() {
-        var objectMapper = JsonMapper.builder()
-                                     .disable(MapperFeature.AUTO_DETECT_GETTERS)
-                                     .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
-                                     .disable(MapperFeature.AUTO_DETECT_SETTERS)
-                                     .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
-                                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                                     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                                     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                                     .enable(MapperFeature.AUTO_DETECT_CREATORS)
-                                     .enable(MapperFeature.AUTO_DETECT_FIELDS)
-                                     .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
-                                     .addModule(new Jdk8Module())
-                                     .addModule(new JavaTimeModule())
-                                     .addModule(new EssentialTypesJacksonModule())
-                                     .addModule(new EssentialsImmutableJacksonModule())
-                                     .build();
+    public ObjectMapper essentialComponentsObjectMapper(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule) {
+        var objectMapperBuilder = JsonMapper.builder()
+                                            .disable(MapperFeature.AUTO_DETECT_GETTERS)
+                                            .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+                                            .disable(MapperFeature.AUTO_DETECT_SETTERS)
+                                            .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                                            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                                            .enable(MapperFeature.AUTO_DETECT_CREATORS)
+                                            .enable(MapperFeature.AUTO_DETECT_FIELDS)
+                                            .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
+                                            .addModule(new Jdk8Module())
+                                            .addModule(new JavaTimeModule())
+                                            .addModule(new EssentialTypesJacksonModule());
 
+        optionalEssentialsImmutableJacksonModule.ifPresent(essentialsImmutableJacksonModule -> {
+            objectMapperBuilder.addModule(new EssentialsImmutableJacksonModule());
+        });
+
+        var objectMapper = objectMapperBuilder.build();
         objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
                                                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
                                                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -40,7 +40,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -10,7 +10,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -46,7 +46,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -17,7 +17,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,19 +65,49 @@
 
         <objenesis.version>3.3</objenesis.version>
         <postgresql.version>42.7.1</postgresql.version>
-        <slf4j.version>2.0.9</slf4j.version>
+        <slf4j.version>2.0.10</slf4j.version>
         <spring-boot.version>3.0.13</spring-boot.version>
         <awaitility.version>4.2.0</awaitility.version>
         <spring-data-mongodb.version>4.0.12</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.0.12</spring-data-jpa.version>
+        <spring-data-jpa.version>3.0.13</spring-data-jpa.version>
         <objenesis.version>3.3</objenesis.version>
-        <assertj.version>3.24.2</assertj.version>
+        <assertj.version>3.25.1</assertj.version>
         <mongodb-driver-sync.version>4.11.1</mongodb-driver-sync.version>
-        <log4j-to-slf4j.version>2.22.0</log4j-to-slf4j.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
+        <log4j-to-slf4j.version>2.22.1</log4j-to-slf4j.version>
         <json-smart.version>2.5.0</json-smart.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
         <micrometer.version>1.12.1</micrometer.version>
         <micrometer-tracing.version>1.2.1</micrometer-tracing.version>
+        <netty-bom.version>4.1.104.Final</netty-bom.version>
+        <junit-bom.version>5.10.1</junit-bom.version>
+        <testcontainers-bom.version>1.19.3</testcontainers-bom.version>
+        <jdbi3-bom.version>3.43.0</jdbi3-bom.version>
+        <jackson-bom.version>2.16.1</jackson-bom.version>
+        <reactor-bom.version>2022.0.14</reactor-bom.version>
+        <spring-framework-bom.version>6.0.15</spring-framework-bom.version>
+        <mockito-bom.version>5.8.0</mockito-bom.version>
+        <logback.version>1.4.14</logback.version>
+
+        <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
+        <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
+        <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
+        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
+        <maven-failsafe-plugin.version>3.2.3</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+        <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
+        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+        <minimum-maven-version>3.8.8</minimum-maven-version>
+        <dependency-check-maven.version>9.0.7</dependency-check-maven.version>
+        <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
     </properties>
 
     <modules>
@@ -112,56 +142,56 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.104.Final</version>
+                <version>${netty-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.1</version>
+                <version>${junit-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.19.3</version>
+                <version>${testcontainers-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>
                 <artifactId>jdbi3-bom</artifactId>
-                <version>3.42.0</version>
+                <version>${jdbi3-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.16.0</version>
+                <version>${jackson-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2022.0.14</version>
+                <version>${reactor-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-framework-bom</artifactId>
-                <version>6.0.15</version>
+                <version>${spring-framework-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
-                <version>5.8.0</version>
+                <version>${mockito-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -200,7 +230,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.14</version>
+            <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -224,52 +254,52 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>${maven-dependency-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>${maven-project-info-reports-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>${maven-clean-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>${maven-install-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>${maven-resources-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>${maven-deploy-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>${maven-site-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>${maven-source-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.6.3</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <doclint>none</doclint>
                     </configuration>
@@ -285,26 +315,29 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.2.3</version>
+                    <version>${maven-failsafe-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.3</version>
+                    <version>${maven-surefire-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.2</version>
+                    <version>${versions-maven-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -328,7 +361,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -338,7 +371,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.8.8</version>
+                                    <version>${minimum-maven-version}</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>${java.version}</version>
@@ -364,7 +397,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>9.0.6</version>
+                <version>${dependency-check-maven.version}</version>
                 <configuration>
                     <skipTestScope>false</skipTestScope>
                     <failBuildOnCVSS>0</failBuildOnCVSS>
@@ -381,7 +414,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.5.0</version>
+                <version>${flatten-maven-plugin.version}</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>resolveCiFriendliesOnly</flattenMode>
@@ -414,7 +447,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>${nexus-staging-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
@@ -426,7 +459,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <spring-boot.version>3.0.13</spring-boot.version>
         <awaitility.version>4.2.0</awaitility.version>
         <spring-data-mongodb.version>4.0.12</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.0.13</spring-data-jpa.version>
+        <spring-data-jpa.version>3.0.12</spring-data-jpa.version>
         <objenesis.version>3.3</objenesis.version>
         <assertj.version>3.25.1</assertj.version>
         <mongodb-driver-sync.version>4.11.1</mongodb-driver-sync.version>

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -254,8 +254,7 @@
         <packageUrl regex="true">^pkg:maven/org\.testcontainers/mongodb@.*$</packageUrl>
         <cpe>cpe:/a:mongodb:mongodb</cpe>
     </suppress>
-  
-      <suppress>
+    <suppress>
         <notes><![CDATA[
         springdata-mongo-distributed-fenced-lock-?.?.?.jar dependency isn't the same as mongodb:mongodb
    ]]></notes>
@@ -268,5 +267,14 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/dk\.cloudcreate\.essentials\.components/springdata-mongo-queue@.*$</packageUrl>
         <cpe>cpe:/a:mongodb:mongodb</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: json-path-2.8.0.jar
+   Under review - see https://github.com/json-path/JsonPath/issues/973 for details
+   Ignoring as json-path is included under test scope which means it won't be parsing user provided input
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.jayway\.jsonpath/json\-path@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-51074</vulnerabilityName>
     </suppress>
 </suppressions>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -14,7 +14,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -14,7 +14,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/types/GenericType.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/types/GenericType.java
@@ -88,7 +88,7 @@ public abstract class GenericType<T> {
      * <code>{@literal class AggregateRoot<ID, AGGREGATE_TYPE extends AggregateRoot<ID, AGGREGATE_TYPE>> implements Aggregate<ID>}</code><br>
      * <br>
      * <b>And sub/concrete class:</b><br>
-     * <code>{@literal class Order extends AggregateRoot<OrderId, Order>}</code>br>
+     * <code>{@literal class Order extends AggregateRoot<OrderId, Order>}</code><br>
      * <br>
      * <b>Then:</b><br>
      * <code>GenericType.resolveGenericType(Order.class, 0)</code> will return <code>OrderId.class</code><br>

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -14,7 +14,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -130,6 +130,7 @@ public class Order extends org.apache.avro.specific.SpecificRecordBase implement
 ### JSR 310 Semantic Types
 
 This library also supports Logical-Types for all `JSR310SingleValueType` which wraps existing JSR-310 types (java.time):
+
 | `JSR310SingleValueType` specialization | Value Type |
 |----------------------------------|-------------------------|
 | `InstantType`                    | `Instant`               |

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -20,7 +20,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -3,6 +3,8 @@
 Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
 
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
+
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
 many of the most popular libraries and frameworks such as Jackson, Spring Boot, Spring Data, JPA, etc.
@@ -70,6 +72,7 @@ ObjectMapper objectMapper = EssentialTypesJacksonModule.createObjectMapper(new E
 ### JSR 310 Semantic Types
 
 This library also supports `JSR310SingleValueType` which wraps existing JSR-310 types (java.time):
+
 | `JSR310SingleValueType` specialization | Value Type |
 |----------------------------------|-------------------------|
 | `InstantType`                    | `Instant`               |

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -19,7 +19,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -3,6 +3,8 @@
 Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
 
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
+
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
 many of the most popular libraries and frameworks such as Jackson, Spring Boot, Spring Data, JPA, etc.
@@ -115,6 +117,7 @@ return jdbi.useHandle(handle -> handle.createQuery("SELECT MAX(discount) FROM OR
 ### JSR 310 Semantic Types
 
 This library also supports `JSR310SingleValueType` which wraps existing JSR-310 types (java.time):
+
 | `JSR310SingleValueType` specialization | Value Type |
 |----------------------------------|-------------------------|
 | `InstantType`                    | `Instant`               |

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -18,7 +18,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -3,6 +3,8 @@
 Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
 
+> Note: [For Java version 11 to 16 support, please use version 0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)
+
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with
 many of the most popular libraries and frameworks such as Jackson, Spring Boot, Spring Data, JPA, etc.
@@ -97,6 +99,7 @@ public MongoCustomConversions mongoCustomConversions() {
 ### JSR 310 Semantic Types
 
 This library also supports for the following `JSR310SingleValueType` which wraps existing JSR-310 types (java.time):
+
 | `JSR310SingleValueType` specialization | Value Type |
 |----------------------------------|-------------------------|
 | `InstantType`                    | `Instant`               |

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeConverter.java
+++ b/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeConverter.java
@@ -135,13 +135,13 @@ public class SingleValueTypeConverter implements GenericConverter {
         if (source instanceof CharSequenceType && ObjectId.class.isAssignableFrom(targetType.getType()) && ObjectId.isValid(source.toString())) {
             return new ObjectId(source.toString());
         } else if (LocalDateTimeType.class.isAssignableFrom(targetType.getType())) {
-            return LocalDateTime.ofInstant(((Date) source).toInstant(), ZoneId.of("UTC"));
+            return SingleValueType.fromObject(LocalDateTime.ofInstant(((Date) source).toInstant(), ZoneId.of("UTC")), (Class<SingleValueType<?, ?>>) targetType.getType());
         } else if (LocalDateType.class.isAssignableFrom(targetType.getType())) {
-            return LocalDate.ofInstant(((Date) source).toInstant(), ZoneId.of("UTC"));
+            return SingleValueType.fromObject(LocalDate.ofInstant(((Date) source).toInstant(), ZoneId.of("UTC")), (Class<SingleValueType<?, ?>>) targetType.getType());
         } else if (InstantType.class.isAssignableFrom(targetType.getType())) {
-            return ((Date) source).toInstant();
+            return SingleValueType.fromObject(((Date) source).toInstant(), (Class<SingleValueType<?, ?>>) targetType.getType());
         } else if (LocalTimeType.class.isAssignableFrom(targetType.getType())) {
-            return LocalTime.ofInstant(((Date) source).toInstant(), ZoneId.of("UTC"));
+            return SingleValueType.fromObject(LocalTime.ofInstant(((Date) source).toInstant(), ZoneId.of("UTC")), (Class<SingleValueType<?, ?>>) targetType.getType());
         } else if (source instanceof SingleValueType) {
             return ((SingleValueType<?, ?>) source).value();
         } else if (source instanceof ObjectId) {

--- a/types/README.md
+++ b/types/README.md
@@ -18,7 +18,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.20.8</version>
+    <version>0.20.9</version>
 </dependency>
 ```
 

--- a/types/src/main/java/dk/cloudcreate/essentials/types/IntegerType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/IntegerType.java
@@ -43,6 +43,14 @@ public abstract class IntegerType<CONCRETE_TYPE extends IntegerType<CONCRETE_TYP
         super(value);
     }
 
+    public CONCRETE_TYPE increment() {
+        return  (CONCRETE_TYPE) SingleValueType.from(this.getValue()+1, this.getClass());
+    }
+
+    public CONCRETE_TYPE decrement() {
+        return  (CONCRETE_TYPE) SingleValueType.from(this.getValue()-1, this.getClass());
+    }
+
     @Override
     public int compareTo(CONCRETE_TYPE o) {
         return value.compareTo(o.intValue());

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LongType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LongType.java
@@ -51,6 +51,15 @@ public abstract class LongType<CONCRETE_TYPE extends LongType<CONCRETE_TYPE>> ex
         super(value);
     }
 
+    public CONCRETE_TYPE increment() {
+        return  (CONCRETE_TYPE) SingleValueType.from(this.getValue()+1, this.getClass());
+    }
+
+    public CONCRETE_TYPE decrement() {
+        return  (CONCRETE_TYPE) SingleValueType.from(this.getValue()-1, this.getClass());
+    }
+
+
     @Override
     public int compareTo(CONCRETE_TYPE o) {
         return value.compareTo(o.longValue());

--- a/types/src/main/java/dk/cloudcreate/essentials/types/ShortType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/ShortType.java
@@ -43,6 +43,14 @@ public abstract class ShortType<CONCRETE_TYPE extends ShortType<CONCRETE_TYPE>> 
         super(value);
     }
 
+    public CONCRETE_TYPE increment() {
+        return  (CONCRETE_TYPE) SingleValueType.from(this.getValue()+1, this.getClass());
+    }
+
+    public CONCRETE_TYPE decrement() {
+        return  (CONCRETE_TYPE) SingleValueType.from(this.getValue()-1, this.getClass());
+    }
+
     @Override
     public int compareTo(CONCRETE_TYPE o) {
         return value.compareTo(o.shortValue());


### PR DESCRIPTION
0.20.9 Spring Boot 3.0.*

- Updated readme.md description for all Spring Boot starters

`spring-boot-starter-mongodb`
- Added support for easily adding Mongo converter support for additional `CharSequenceType`'s by providing a `AdditionalCharSequenceTypesSupported` bean.
- Added support for easily adding additional Mongo `Converter`/`GenericConverter`'s/etc. by providing a `AdditionalConverters` bean.
- Added explicit handling of `EssentialsImmutableJacksonModule` registration with the Essentials `ObjectMapper`
- Added Spring config example as Javadoc to `#mongoCustomConversions(...)`

`spring-boot-starter-postgresql`
- Added explicit handling of `EssentialsImmutableJacksonModule` registration with the Essentials `ObjectMapper`

`types-springdata-mongo`: 
- Fixed conversion of mongo data type to the supported `JSR310SingleValueType`'s in `SingleValueTypeConverter`

`eventsourced-aggregates`: 
- Changed the `StateEvolver` type parameter order from `StateEvolver<STATE, EVENT>`to `StateEvolver<EVENT, STATE>`
- Changed state class names in `DeciderTest`

`postgresql-event-store`: 
- Added default `tenant` value in `FetchStreamBuilder`

`types`: 
- Added `increment` and `decrement` methods to `IntegerType`, `LongType`, `ShortType`

`foundation`: 
- Added `MessageHandlerInterceptor` support to `PatternMatchingMessageHandler` and `EventProcessor`

Updated 3rd party dependencies:
- Spring boot 3.0.13
- slf4j 2.0.10
- assertj 3.25.1
- log4j 2.22.1
- Jackson 2.16.1
- Jdbi 3.43.0

Updated maven plugins:
- Maven Compiler 3.12.1