### PR TITLE
Release 0.40.3

### DIFF
--- a/.github/workflows/release-to-maven-central.yml
+++ b/.github/workflows/release-to-maven-central.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn -B versions:set -DnewVersion=${{ github.event.release.tag_name }} -DgenerateBackupPoms=false
 
       - name: Release to Maven Central
-        run: mvn -B clean deploy -P release -DskipTests
+        run: mvn -B clean deploy -P release -DskipTests -DskipDependencyCheck=true
         env:
           OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
           OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -121,7 +121,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -136,7 +136,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -214,7 +214,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -262,7 +262,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -284,7 +284,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -329,7 +329,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -363,7 +363,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -380,7 +380,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -452,7 +452,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -466,7 +466,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/README.md
+++ b/components/README.md
@@ -48,7 +48,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -63,7 +63,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -105,7 +105,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -144,7 +144,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -221,7 +221,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -249,7 +249,7 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -297,7 +297,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -342,7 +342,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -431,7 +431,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -454,7 +454,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -43,7 +43,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -508,6 +508,6 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -35,7 +35,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -160,7 +160,7 @@ To use `PostgresqlDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -208,7 +208,7 @@ To use `MongoDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 
@@ -720,7 +720,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -21,7 +21,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -691,6 +691,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -56,6 +56,7 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
 
     /**
      * The {@link EventStore} associated with the {@link EventStoreSubscriptionManager}
+     *
      * @return the {@link EventStore} associated with the {@link EventStoreSubscriptionManager
      */
     EventStore getEventStore();
@@ -957,9 +958,9 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                     return;
                 }
                 log.trace("[{}-{}] Requesting {} event(s)",
-                         subscriberId,
-                         aggregateType,
-                         n);
+                          subscriberId,
+                          aggregateType,
+                          n);
                 subscription.request(n);
             }
 
@@ -1303,9 +1304,9 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                 }
 
                 log.trace("[{}-{}] Requesting {} event(s)",
-                         subscriberId,
-                         aggregateType,
-                         n);
+                          subscriberId,
+                          aggregateType,
+                          n);
                 subscription.request(n);
             }
 
@@ -1342,7 +1343,7 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
 
             @Override
             public void resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder) {
-                if (started) {
+                if (isStarted() && isActive()) {
                     log.info("[{}-{}] Resetting resume point and re-starts the subscriber from and including globalOrder {}",
                              subscriberId,
                              aggregateType,
@@ -1351,7 +1352,13 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                     overrideResumePoint(subscribeFromAndIncludingGlobalOrder);
                     start();
                 } else {
-                    overrideResumePoint(subscribeFromAndIncludingGlobalOrder);
+                    log.info("[{}-{}] Cannot reset resume point to fromAndIncluding {} because the underlying lock hasn't been acquired. isStarted: {}, isActive (is-lock-acquired): {}",
+                             subscriberId,
+                             aggregateType,
+                             subscribeFromAndIncludingGlobalOrder,
+                             isStarted(),
+                             isActive());
+
                 }
             }
 
@@ -1368,10 +1375,10 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                     eventHandler.onResetFrom(this, subscribeFromAndIncludingGlobalOrder);
                 } catch (Exception e) {
                     log.info(msg("[{}-{}] Failed to reset eventHandler '{}' to use start from-and-including-globalOrder {}",
-                             subscriberId,
-                             aggregateType,
-                             eventHandler,
-                             subscribeFromAndIncludingGlobalOrder),
+                                 subscriberId,
+                                 aggregateType,
+                                 eventHandler,
+                                 subscribeFromAndIncludingGlobalOrder),
                              e);
                 }
             }

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -10,7 +10,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -856,7 +856,7 @@ public class PostgresqlDurableQueues implements DurableQueues {
                                                                           "        is_dead_letter_message = FALSE AND\n" +
                                                                           "        is_being_delivered = FALSE AND\n" +
                                                                           "        next_delivery_ts <= :now AND\n" +
-                                                                          "        NOT EXISTS (SELECT 1 FROM {:tableName} q2 WHERE q2.key = q1.key AND q2.key_order < q1.key_order)\n" +
+                                                                          "        NOT EXISTS (SELECT 1 FROM {:tableName} q2 WHERE q2.key = q1.key AND q2.queue_name = q1.queue_name AND q2.key_order < q1.key_order)\n" +
                                                                           excludeKeysLimitSql +
                                                                           "    ORDER BY key_order ASC, next_delivery_ts ASC\n" + // TODO: Future improvement: Allow the user to specify if key_order or next_delivery_ts should have the highest priority
                                                                           "    LIMIT 1\n" +

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -40,7 +40,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -10,7 +10,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -46,7 +46,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -18,7 +18,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <revision>DEV-SNAPSHOT</revision>
+        <skipDependencyCheck>false</skipDependencyCheck>
 
         <objenesis.version>3.3</objenesis.version>
         <postgresql.version>42.7.1</postgresql.version>
@@ -104,7 +105,7 @@
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>9.0.7</dependency-check-maven.version>
+        <dependency-check-maven.version>9.0.8</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
@@ -402,6 +403,7 @@
                     <skipTestScope>false</skipTestScope>
                     <failBuildOnCVSS>0</failBuildOnCVSS>
                     <suppressionFile>${maven.multiModuleProjectDirectory}/project-suppression.xml</suppressionFile>
+                    <skip>${skipDependencyCheck}</skip>
                 </configuration>
                 <executions>
                     <execution>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -14,7 +14,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -14,7 +14,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -14,7 +14,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -20,7 +20,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -19,7 +19,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -20,7 +20,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -20,7 +20,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.2</version>
+    <version>0.40.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
- Added `EventProcessor#resetAllSubscriptions` and `EventProcessor#resetSubscriptions`
- Adjusted `EventStoreSubscriptionManager.ExclusiveAsynchronousSubscription#resetFrom(GlobalEventOrder)` to require a lock to reset
- Adjusted `PostgresqlDurableQueues#getNextMessageReadyForDelivery` to include queue_name in the NOT EXISTS criteria to avoid dead letter messages from one queue to block IN_ORDER deliveries of messages with the same key in another queue
- Added `skipDependencyCheck` (default value false) to `dependency-check-maven` and set it to true during release (since release takes too long)