### PR TITLE
Release 0.30.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -125,7 +125,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -140,7 +140,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -218,7 +218,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -266,7 +266,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -288,7 +288,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -333,7 +333,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -367,7 +367,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -384,7 +384,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -456,7 +456,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -470,7 +470,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ on other libraries, unless explicitly mentioned.
 ## License
 Essentials is released under version 2.0 of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
 
+## Versions
+
 | Essentials version                                                                   | Java compatibility | Spring Boot compatibility |
 |--------------------------------------------------------------------------------------|--------------------|---------------------------|
 | [0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)            | 11-16              | 2.7.x                     |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Essentials is a set of Java version 17 (and later) building blocks built from the ground up to have no dependencies
 on other libraries, unless explicitly mentioned.
 
+## License
+Essentials is released under version 2.0 of the [Apache License](https://www.apache.org/licenses/LICENSE-2.0)
 
 | Essentials version                                                                   | Java compatibility | Spring Boot compatibility |
 |--------------------------------------------------------------------------------------|--------------------|---------------------------|

--- a/components/README.md
+++ b/components/README.md
@@ -48,7 +48,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -63,7 +63,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -144,7 +144,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -221,7 +221,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -249,7 +249,7 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -297,7 +297,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -342,7 +342,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -431,7 +431,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -454,7 +454,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -43,7 +43,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -508,6 +508,6 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -415,9 +415,9 @@ configured `AggregateEventStreamPersistenceStrategy`
 ```
 var orders = AggregateType.of("Orders");
 var ordersRepository = StatefulAggregateRepository.from(eventStore,
-                                                    SeparateTablePerAggregateTypeConfiguration.standardSingleTenantConfigurationUsingJackson(
+                                                    SeparateTablePerAggregateTypeConfiguration.standardSingleTenantConfiguration(
                                                         orders,
-                                                        createObjectMapper(),
+                                                        new JacksonJSONEventSerializer(createObjectMapper()),
                                                         AggregateIdSerializer.serializerFor(OrderId.class),
                                                         IdentifierColumnType.UUID,
                                                         JSONColumnType.JSONB),
@@ -472,7 +472,7 @@ It's therefore advisable to combine `PostgresqlAggregateSnapshotRepository` with
 except for `AggregateSnapshotRepository#aggregateUpdated(Object, AggregateEventStream)` and `AggregateSnapshotRepository#deleteSnapshots(AggregateType, Object, Class, List)`, which are performed **asynchronously** in the background.
 
 ```
-var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
+var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
                                                                                                                                                           IdentifierColumnType.UUID,
                                                                                                                                                                   JSONColumnType.JSONB);
 var snapshotRepository = new PostgresqlAggregateSnapshotRepository(eventStore,

--- a/components/eventsourced-aggregates/pom.xml
+++ b/components/eventsourced-aggregates/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/Aggregate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/Aggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/AggregateException.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/AggregateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventHandler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventsToPersist.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventsToPersist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OptimisticAggregateLoadException.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OptimisticAggregateLoadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/AggregateIdResolver.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/AggregateIdResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Decider.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Decider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Handler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/HandlerResult.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/HandlerResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/InitialStateProvider.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/InitialStateProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/IsStateFinalResolver.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/IsStateFinalResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/StateEvolver.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/StateEvolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/View.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/View.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregate.java
@@ -71,9 +71,9 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  * FlexAggregateRepository<OrderId, Order> repository =
  *                   FlexAggregateRepository.from(
  *                        eventStores,
- *                        standardSingleTenantConfigurationUsingJackson(
+ *                        standardSingleTenantConfiguration(
  *                             AggregateType.of("Orders"),
- *                             createObjectMapper(),
+ *                             new JacksonJSONEventSerializer(createObjectMapper()),
  *                             AggregateIdSerializer.serializerFor(OrderId.class),
  *                             IdentifierColumnType.UUID,
  *                             JSONColumnType.JSONB),

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepository.java
@@ -41,9 +41,9 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  * FlexAggregateRepository<OrderId, Order> repository =
  *      FlexAggregateRepository.from(
  *                eventStores,
- *                standardSingleTenantConfigurationUsingJackson(
+ *                standardSingleTenantConfiguration(
  *                     AggregateType.of("Orders"),
- *                     createObjectMapper(),
+ *                     new JacksonJSONEventSericreateObjectMapper(),
  *                     AggregateIdSerializer.serializerFor(OrderId.class),
  *                     IdentifierColumnType.UUID,
  *                     JSONColumnType.JSONB),

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategy.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategy.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/BrokenSnapshot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/BrokenSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/DelayedAddAndDeleteAggregateSnapshotDelegate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/DelayedAddAndDeleteAggregateSnapshotDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInMemoryProjector.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInMemoryProjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInstanceFactory.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/AggregateRoot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/AggregateRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/AggregateRoot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/AggregateRoot.java
@@ -57,10 +57,10 @@ public abstract class AggregateRoot<ID, EVENT_TYPE extends Event<ID>, AGGREGATE_
     /**
      * Zero based event order
      */
-    private           EventOrder                              eventOrderOfLastAppliedEvent;
+    private           EventOrder                              eventOrderOfLastAppliedEvent = EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED;
     private           boolean                                 hasBeenRehydrated;
     private           boolean                                 isRehydrating;
-    private           EventOrder                              eventOrderOfLastRehydratedEvent;
+    private           EventOrder                              eventOrderOfLastRehydratedEvent = EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED;
 
     public AggregateRoot() {
         initialize();
@@ -233,6 +233,7 @@ public abstract class AggregateRoot<ID, EVENT_TYPE extends Event<ID>, AGGREGATE_
     @Override
     public void markChangesAsCommitted() {
         uncommittedChanges = new ArrayList<>();
+        eventOrderOfLastRehydratedEvent = null;
     }
 
     /**

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/Event.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/InitialEventIsMissingAggregateIdException.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/InitialEventIsMissingAggregateIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateRootWithState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateRootWithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateRoot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateRoot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateRoot.java
@@ -118,9 +118,9 @@ import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 public abstract class AggregateRoot<ID, EVENT_TYPE, AGGREGATE_TYPE extends AggregateRoot<ID, EVENT_TYPE, AGGREGATE_TYPE>> implements StatefulAggregate<ID, EVENT_TYPE, AGGREGATE_TYPE> {
     private transient PatternMatchingMethodInvoker<Object>           invoker;
     private           ID                                             aggregateId;
-    private           EventOrder                                     eventOrderOfLastAppliedEvent = EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED;
+    private           EventOrder                                     eventOrderOfLastAppliedEvent    = EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED;
     private           List<EVENT_TYPE>                               uncommittedEvents;
-    private           EventOrder                                     eventOrderOfLastRehydratedEvent;
+    private           EventOrder                                     eventOrderOfLastRehydratedEvent = EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED;
     private           boolean                                        hasBeenRehydrated;
     private           boolean                                        isRehydrating;
     private           AggregateState<ID, EVENT_TYPE, AGGREGATE_TYPE> state;
@@ -161,6 +161,7 @@ public abstract class AggregateRoot<ID, EVENT_TYPE, AGGREGATE_TYPE extends Aggre
     @Override
     public void markChangesAsCommitted() {
         uncommittedEvents = new ArrayList<>();
+        eventOrderOfLastRehydratedEvent = null;
     }
 
     @Override

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/WithState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/WithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/CustomerId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OrderId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductIdKeyDeserializer.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootRepositoryIT.java
@@ -29,6 +29,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -86,9 +87,9 @@ class OrderAggregateRootRepositoryIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                                                                IdentifierColumnType.UUID,
-                                                                                                                                                                                                                JSONColumnType.JSONB)));
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                                    IdentifierColumnType.UUID,
+                                                                                                                                                                                                    JSONColumnType.JSONB)));
 
         recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();
         eventStore.localEventBus().addSyncSubscriber(recordingLocalEventBusConsumer);

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderEvents.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/NoDefaultConstructorOrderEvents.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/NoDefaultConstructorOrderEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootRepositoryIT.java
@@ -29,6 +29,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -49,7 +50,6 @@ import java.time.*;
 import java.util.*;
 
 import static dk.cloudcreate.essentials.components.eventsourced.aggregates.stateful.StatefulAggregateInstanceFactory.objenesisAggregateRootFactory;
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Objenesis Classic OrderAggregateRootRepositoryTest")
@@ -89,9 +89,9 @@ class OrderAggregateRootRepositoryIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                   IdentifierColumnType.UUID,
-                                                                                                                                                   JSONColumnType.JSONB)
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                                    IdentifierColumnType.UUID,
+                                                                                                                                                                                                    JSONColumnType.JSONB)
                                                 ));
         eventStore.addAggregateEventStreamConfiguration(ORDERS,
                                                         OrderId.class);

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootRepositoryIT.java
@@ -30,6 +30,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -50,7 +51,6 @@ import java.time.*;
 import java.util.*;
 
 import static dk.cloudcreate.essentials.components.eventsourced.aggregates.stateful.StatefulAggregateInstanceFactory.objenesisAggregateRootFactory;
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Objenesis OrderWithStateAggregateRootRepositoryTest")
@@ -90,9 +90,9 @@ class OrderWithStateAggregateRootRepositoryIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                   IdentifierColumnType.UUID,
-                                                                                                                                                   JSONColumnType.JSONB)));
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                                    IdentifierColumnType.UUID,
+                                                                                                                                                                                                    JSONColumnType.JSONB)));
         eventStore.addAggregateEventStreamConfiguration(ORDERS,
                                                         OrderId.class);
         recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootWithStateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootWithStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootRepositoryIT.java
@@ -31,6 +31,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.e
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -51,7 +52,7 @@ import java.time.*;
 import java.util.*;
 
 import static dk.cloudcreate.essentials.components.eventsourced.aggregates.stateful.StatefulAggregateInstanceFactory.reflectionBasedAggregateRootFactory;
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfigurationUsingJackson;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
@@ -90,18 +91,18 @@ class OrderWithStateAggregateRootRepositoryIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                                                                IdentifierColumnType.TEXT,
-                                                                                                                                                                                                                JSONColumnType.JSON)));
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                                    IdentifierColumnType.TEXT,
+                                                                                                                                                                                                    JSONColumnType.JSON)));
         recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();
         eventStore.localEventBus().addSyncSubscriber(recordingLocalEventBusConsumer);
 
         ordersRepository = StatefulAggregateRepository.from(eventStore,
-                                                            standardSingleTenantConfigurationUsingJackson(ORDERS,
-                                                                                                          createObjectMapper(),
-                                                                                                          AggregateIdSerializer.serializerFor(OrderId.class),
-                                                                                                          IdentifierColumnType.UUID,
-                                                                                                          JSONColumnType.JSONB),
+                                                            standardSingleTenantConfiguration(ORDERS,
+                                                                                              new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                              AggregateIdSerializer.serializerFor(OrderId.class),
+                                                                                              IdentifierColumnType.UUID,
+                                                                                              JSONColumnType.JSONB),
                                                             reflectionBasedAggregateRootFactory(),
                                                             OrderWithState.class);
 

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootWithStateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootWithStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderBasedCommandHandlerIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderBasedCommandHandlerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderBasedCommandHandlerIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderBasedCommandHandlerIT.java
@@ -24,6 +24,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -42,7 +43,6 @@ import java.time.*;
 import java.util.*;
 import java.util.stream.*;
 
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson;
 import static dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule.createObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -137,9 +137,9 @@ class DeciderBasedCommandHandlerIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     standardSingleTenantConfigurationUsingJackson(objectMapper,
-                                                                                                                                                   IdentifierColumnType.TEXT,
-                                                                                                                                                   JSONColumnType.JSONB)));
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(objectMapper),
+                                                                                                                                                                                                    IdentifierColumnType.TEXT,
+                                                                                                                                                                                                    JSONColumnType.JSONB)));
         recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();
         eventStore.localEventBus().addSyncSubscriber(recordingLocalEventBusConsumer);
 

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepositoryIT.java
@@ -27,6 +27,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -84,9 +85,9 @@ public class FlexAggregateRepositoryIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                                                                IdentifierColumnType.UUID,
-                                                                                                                                                                                                                JSONColumnType.JSONB)));
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                                    IdentifierColumnType.UUID,
+                                                                                                                                                                                                    JSONColumnType.JSONB)));
         recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();
         eventStore.localEventBus().addSyncSubscriber(recordingLocalEventBusConsumer);
 

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/AggregateRootTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/AggregateRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/AggregateRootTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/AggregateRootTest.java
@@ -33,7 +33,7 @@ public class AggregateRootTest {
         var aggregate          = new Order(orderId, orderingCustomerId, orderNumber);
         var uncommittedChanges = aggregate.getUncommittedChanges();
         assertThat((CharSequence) uncommittedChanges.aggregateId).isEqualTo(orderId);
-        assertThat((CharSequence) uncommittedChanges.eventOrderOfLastRehydratedEvent).isNull();
+        assertThat(uncommittedChanges.eventOrderOfLastRehydratedEvent).isEqualTo(EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED);
         assertThat(uncommittedChanges.events.size()).isEqualTo(1);
         assertThat(uncommittedChanges.events.get(0)).isInstanceOf(OrderEvent.OrderAdded.class);
         assertThat((CharSequence) ((OrderEvent.OrderAdded) uncommittedChanges.events.get(0)).orderId).isEqualTo(orderId);

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderAggregateRootRepositoryIT.java
@@ -28,6 +28,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -48,7 +49,6 @@ import java.time.*;
 import java.util.*;
 
 import static dk.cloudcreate.essentials.components.eventsourced.aggregates.stateful.StatefulAggregateInstanceFactory.reflectionBasedAggregateRootFactory;
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Modern OrderAggregateRootRepositoryTest")
@@ -88,9 +88,9 @@ class OrderAggregateRootRepositoryIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                   IdentifierColumnType.UUID,
-                                                                                                                                                   JSONColumnType.JSONB)));
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                                    IdentifierColumnType.UUID,
+                                                                                                                                                                                                    JSONColumnType.JSONB)));
         recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();
         eventStore.localEventBus().addSyncSubscriber(recordingLocalEventBusConsumer);
 

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderEvent.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/BiTemporalProductPriceIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/BiTemporalProductPriceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/BiTemporalProductPriceIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/BiTemporalProductPriceIT.java
@@ -26,6 +26,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.P
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventTypeOrName;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -48,7 +49,6 @@ import java.util.Comparator;
 
 import static dk.cloudcreate.essentials.components.eventsourced.aggregates.modern.bitemporal.ProductPrice.PRESENT;
 import static dk.cloudcreate.essentials.components.eventsourced.aggregates.stateful.StatefulAggregateInstanceFactory.reflectionBasedAggregateRootFactory;
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 import static dk.cloudcreate.essentials.shared.collections.Lists.toIndexedStream;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,9 +84,9 @@ public class BiTemporalProductPriceIT {
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
                                                                                        persistableEventMapper(),
-                                                                                       standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                     IdentifierColumnType.UUID,
-                                                                                                                                     JSONColumnType.JSONB));
+                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                                                      JSONColumnType.JSONB));
 
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 persistenceStrategy);

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/InitialPriceSet.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/InitialPriceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceAdjusted.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceAdjusted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceValidityAdjusted.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceValidityAdjusted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPrice.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPrice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPriceEvent.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPriceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/AggregateRootWithStateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/AggregateRootWithStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/AggregateRootWithStateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/AggregateRootWithStateTest.java
@@ -34,7 +34,7 @@ public class AggregateRootWithStateTest {
         var aggregate          = new Order(orderId, orderingCustomerId, orderNumber);
         var uncommittedChanges = aggregate.getUncommittedChanges();
         assertThat((CharSequence) uncommittedChanges.aggregateId).isEqualTo(orderId);
-        assertThat((CharSequence) uncommittedChanges.eventOrderOfLastRehydratedEvent).isNull();
+        assertThat(uncommittedChanges.eventOrderOfLastRehydratedEvent).isEqualTo(EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED);
         assertThat(uncommittedChanges.events.size()).isEqualTo(1);
         assertThat(uncommittedChanges.events.get(0)).isInstanceOf(OrderEvent.OrderAdded.class);
         assertThat((CharSequence) ((OrderEvent.OrderAdded) uncommittedChanges.events.get(0)).orderId).isEqualTo(orderId);

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderAggregateRootWithStateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderAggregateRootWithStateRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderAggregateRootWithStateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderAggregateRootWithStateRepositoryIT.java
@@ -29,6 +29,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -88,9 +89,9 @@ class OrderAggregateRootWithStateRepositoryIT {
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,
                                                                                                      eventMapper,
-                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                                                                IdentifierColumnType.UUID,
-                                                                                                                                                                                                                JSONColumnType.JSONB)));
+                                                                                                     SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                                    IdentifierColumnType.UUID,
+                                                                                                                                                                                                    JSONColumnType.JSONB)));
         recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();
         eventStore.localEventBus().addSyncSubscriber(recordingLocalEventBusConsumer);
 

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategyTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategyTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_deleteAllHistoricSnapshotsIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_deleteAllHistoricSnapshotsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_deleteAllHistoricSnapshotsIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_deleteAllHistoricSnapshotsIT.java
@@ -29,6 +29,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.P
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -74,9 +75,9 @@ class PostgresqlAggregateSnapshotRepository_deleteAllHistoricSnapshotsIT {
 
         aggregateType = ORDERS;
         unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
-        var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                  IdentifierColumnType.UUID,
-                                                                                                                                                                  JSONColumnType.JSONB);
+        var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                      JSONColumnType.JSONB);
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_keepALimitedNumberOfHistoricSnapshotsIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_keepALimitedNumberOfHistoricSnapshotsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_keepALimitedNumberOfHistoricSnapshotsIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_keepALimitedNumberOfHistoricSnapshotsIT.java
@@ -29,6 +29,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.P
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -77,9 +78,9 @@ class PostgresqlAggregateSnapshotRepository_keepALimitedNumberOfHistoricSnapshot
 
         aggregateType = ORDERS;
         unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
-        var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                  IdentifierColumnType.UUID,
-                                                                                                                                                                  JSONColumnType.JSONB);
+        var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                      JSONColumnType.JSONB);
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryIT.java
@@ -29,6 +29,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.P
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
@@ -77,9 +78,9 @@ class StatefulAggregateRepositoryIT {
 
         aggregateType = ORDERS;
         unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
-        var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                  IdentifierColumnType.UUID,
-                                                                                                                                                                  JSONColumnType.JSONB);
+        var aggregateEventStreamConfigurationFactory = SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                      JSONColumnType.JSONB);
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                                      unitOfWorkFactory,

--- a/components/eventsourced-aggregates/src/test/resources/logback-test.xml
+++ b/components/eventsourced-aggregates/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/foundation-test/pom.xml
+++ b/components/foundation-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManagerIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalCompetingConsumersDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/AccountId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/CustomerId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderEvent.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductEvent.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/reactive/command/AbstractDurableLocalCommandBusIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/reactive/command/AbstractDurableLocalCommandBusIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -35,7 +35,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -160,7 +160,7 @@ To use `PostgresqlDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -208,7 +208,7 @@ To use `MongoDurableQueues` you must include dependency
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 
@@ -720,7 +720,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/foundation/pom.xml
+++ b/components/foundation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/Lifecycle.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/Lifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLock.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLockManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLock.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockEvents.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockStorage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallback.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallbackBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallbackBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONDeserializationException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONDeserializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONDeserializationException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONDeserializationException.java
@@ -22,7 +22,7 @@ public class JSONDeserializationException extends RuntimeException {
         super(message);
     }
 
-    public JSONDeserializationException(String msg, Exception cause) {
+    public JSONDeserializationException(String msg, Throwable cause) {
         super(msg, cause);
     }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializationException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializationException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializationException.java
@@ -17,7 +17,7 @@
 package dk.cloudcreate.essentials.components.foundation.json;
 
 public class JSONSerializationException extends RuntimeException {
-    public JSONSerializationException(String msg, Exception cause) {
+    public JSONSerializationException(String msg, Throwable cause) {
         super(msg, cause);
     }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
@@ -16,11 +16,8 @@
 
 package dk.cloudcreate.essentials.components.foundation.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dk.cloudcreate.essentials.shared.reflection.Classes;
-
-import java.io.IOException;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
@@ -40,7 +37,7 @@ public class JacksonJSONSerializer implements JSONSerializer {
         requireNonNull(obj, "you must provide a non-null object");
         try {
             return objectMapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
+        } catch (Throwable e) {
             throw new JSONSerializationException(msg("Failed to serialize {} to JSON", obj.getClass().getName()),
                                                  e);
         }
@@ -51,7 +48,7 @@ public class JacksonJSONSerializer implements JSONSerializer {
         requireNonNull(obj, "you must provide a non-null object");
         try {
             return objectMapper.writeValueAsBytes(obj);
-        } catch (JsonProcessingException e) {
+        } catch (Throwable e) {
             throw new JSONSerializationException(msg("Failed to serialize {} to JSON", obj.getClass().getName()),
                                                  e);
         }
@@ -70,7 +67,7 @@ public class JacksonJSONSerializer implements JSONSerializer {
         requireNonNull(javaType, "No javaType provided");
         try {
             return objectMapper.readValue(json, javaType);
-        } catch (JsonProcessingException e) {
+        } catch (Throwable e) {
             throw new JSONDeserializationException(msg("Failed to deserialize JSON to {}", javaType.getName()),
                                                    e);
         }
@@ -88,7 +85,7 @@ public class JacksonJSONSerializer implements JSONSerializer {
         requireNonNull(javaType, "No javaType provided");
         try {
             return objectMapper.readValue(json, javaType);
-        } catch (IOException e) {
+        } catch (Throwable e) {
             throw new JSONDeserializationException(msg("Failed to deserialize JSON to {}", javaType.getName()),
                                                    e);
         }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/ExponentialBackoffBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/ExponentialBackoffBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/FixedBackoffBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/FixedBackoffBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/LinearBackoffBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/LinearBackoffBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
@@ -39,7 +39,7 @@ public interface MessageDeliveryErrorHandler {
      * @return true if the error is a permanent error - in which case the message is instantly marked as an Poison-Message/Dead-Letter-Message,
      * otherwise false - in which case the message will be redelivered according to the specified {@link RedeliveryPolicy}
      */
-    boolean isPermanentError(QueuedMessage queuedMessage, Exception error);
+    boolean isPermanentError(QueuedMessage queuedMessage, Throwable error);
 
     /**
      * Create a {@link MessageDeliveryErrorHandler} that always retries no matter which exception occurs
@@ -99,7 +99,7 @@ public interface MessageDeliveryErrorHandler {
         }
 
         @Override
-        public boolean isPermanentError(QueuedMessage queuedMessage, Exception error) {
+        public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
             return exceptions.contains(error.getClass()) ||
                     exceptions.stream()
                               .anyMatch(exception -> exception.isAssignableFrom(error.getClass()));
@@ -115,7 +115,7 @@ public interface MessageDeliveryErrorHandler {
 
     class AlwaysRetry implements MessageDeliveryErrorHandler {
         @Override
-        public boolean isPermanentError(QueuedMessage queuedMessage, Exception error) {
+        public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
             return false;
         }
 
@@ -127,7 +127,7 @@ public interface MessageDeliveryErrorHandler {
 
     class NeverRetry implements MessageDeliveryErrorHandler {
         @Override
-        public boolean isPermanentError(QueuedMessage queuedMessage, Exception error) {
+        public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
             return true;
         }
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
@@ -100,14 +100,14 @@ public class MessageDeliveryErrorHandlerBuilder {
         var stopRedeliveryOnHandler = MessageDeliveryErrorHandler.stopRedeliveryOn(stopRedeliveryOnExceptions);
         return new MessageDeliveryErrorHandler() {
             @Override
-            public boolean isPermanentError(QueuedMessage queuedMessage, Exception error) {
+            public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
                 if (shouldAlwaysRetryOn(error)) {
                     return false;
                 }
                 return stopRedeliveryOnHandler.isPermanentError(queuedMessage, error);
             }
 
-            private boolean shouldAlwaysRetryOn(Exception error) {
+            private boolean shouldAlwaysRetryOn(Throwable error) {
                 return alwaysRetryOnExceptions.contains(error.getClass()) ||
                         alwaysRetryOnExceptions.stream()
                                                .anyMatch(exception -> exception.isAssignableFrom(error.getClass()));

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
@@ -176,7 +176,7 @@ public class RedeliveryPolicy {
                         .build();
     }
 
-    public boolean isPermanentError(QueuedMessage queuedMessage, Exception error) {
+    public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
         return deliveryErrorHandler.isPermanentError(queuedMessage, error);
     }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicyBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inbox.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inbox.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inbox.java
@@ -20,6 +20,7 @@ import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 
+import java.time.Duration;
 import java.util.function.Consumer;
 
 /**
@@ -116,6 +117,20 @@ public interface Inbox {
     }
 
     /**
+     * Register or add a message (with meta-data) that has been received and where the message should be delivered later<br>
+     * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
+     * The message will be delivered asynchronously to the message consumer
+     *
+     * @param payload  the message payload
+     * @param metaData the message meta-data
+     * @param deliveryDelay    duration before the message should be delivered
+     * @return this inbox instance
+     */
+    default Inbox addMessageReceived(Object payload, MessageMetaData metaData, Duration deliveryDelay) {
+        return addMessageReceived(new Message(payload, metaData), deliveryDelay);
+    }
+
+    /**
      * Register or add a message (without meta-data) that has been received<br>
      * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
      * The message will be delivered asynchronously to the message consumer
@@ -124,6 +139,18 @@ public interface Inbox {
      */
     default Inbox addMessageReceived(Object payload) {
         return addMessageReceived(new Message(payload));
+    }
+
+    /**
+     * Register or add a message (without meta-data) that has been received and where the message should be delivered later<br>
+     * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
+     * The message will be delivered asynchronously to the message consumer
+     *
+     * @param payload the message payload
+     * @param deliveryDelay   duration before the message should be delivered
+     */
+    default Inbox addMessageReceived(Object payload, Duration deliveryDelay) {
+        return addMessageReceived(new Message(payload), deliveryDelay);
     }
 
     /**
@@ -136,6 +163,18 @@ public interface Inbox {
      * @see OrderedMessage
      */
     Inbox addMessageReceived(Message message);
+
+    /**
+     * Register or add a message that has been received and where the message should be delivered later<br>
+     * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
+     * The message will be delivered asynchronously to the message consumer
+     *
+     * @param message the message
+     * @param deliveryDelay   duration before the message should be delivered
+     * @return this inbox instance
+     * @see OrderedMessage
+     */
+    Inbox addMessageReceived(Message message, Duration deliveryDelay);
 
     /**
      * Get the number of message received that haven't been processed yet (or successfully processed) by the message consumer

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfig.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfigBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inboxes.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inboxes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageConsumptionMode.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageConsumptionMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageHandlerInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outbox.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outbox.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outbox.java
@@ -20,6 +20,7 @@ import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 
+import java.time.Duration;
 import java.util.function.Consumer;
 
 /**
@@ -116,6 +117,19 @@ public interface Outbox {
     }
 
     /**
+     * Send a message (without meta-data) asynchronously and where the message should be delivered later.<br>
+     * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
+     * The message will be delivered asynchronously to the message consumer
+     *
+     * @param payload       the message payload
+     * @param deliveryDelay duration before the message should be delivered
+     * @return this outbox instance
+     */
+    default Outbox sendMessage(Object payload, Duration deliveryDelay) {
+        return sendMessage(new Message(payload), deliveryDelay);
+    }
+
+    /**
      * Send a message (with meta-data) asynchronously.<br>
      * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
      * The message will be delivered asynchronously to the message consumer
@@ -129,6 +143,20 @@ public interface Outbox {
     }
 
     /**
+     * Send a message (with meta-data) asynchronously and where the message should be delivered later.<br>
+     * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
+     * The message will be delivered asynchronously to the message consumer
+     *
+     * @param payload       the message payload
+     * @param metaData      the message meta-data
+     * @param deliveryDelay duration before the message should be delivered
+     * @return this outbox instance
+     */
+    default Outbox sendMessage(Object payload, MessageMetaData metaData, Duration deliveryDelay) {
+        return sendMessage(new Message(payload, metaData), deliveryDelay);
+    }
+
+    /**
      * Send a message asynchronously.<br>
      * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
      * The message will be delivered asynchronously to the message consumer
@@ -138,6 +166,18 @@ public interface Outbox {
      * @see OrderedMessage
      */
     Outbox sendMessage(Message message);
+
+    /**
+     * Send a message asynchronously and where the message should be delivered later.<br>
+     * This message will be stored durably (without any duplication check) in connection with the currently active {@link UnitOfWork} (or a new {@link UnitOfWork} will be created in case no there isn't an active {@link UnitOfWork}).<br>
+     * The message will be delivered asynchronously to the message consumer
+     *
+     * @param message       the message
+     * @param deliveryDelay duration before the message should be delivered
+     * @return this outbox instance
+     * @see OrderedMessage
+     */
+    Outbox sendMessage(Message message, Duration deliveryDelay);
 
     /**
      * Get the number of message in the outbox that haven't been sent yet

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfig.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfigBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
@@ -21,6 +21,7 @@ import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 import dk.cloudcreate.essentials.reactive.EventHandler;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
@@ -230,6 +231,14 @@ public interface Outboxes {
             public Outbox sendMessage(Message payload) {
                 durableQueues.queueMessage(outboxQueueName,
                                            payload);
+                return this;
+            }
+
+            @Override
+            public Outbox sendMessage(Message payload, Duration deliveryDelay) {
+                durableQueues.queueMessage(outboxQueueName,
+                                           payload,
+                                           deliveryDelay);
                 return this;
             }
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/operation/InvokeMessageHandlerMethod.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/operation/InvokeMessageHandlerMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
@@ -213,7 +213,7 @@ public class DefaultDurableQueueConsumer<DURABLE_QUEUES extends DurableQueues, U
             if (postTransactionalSideEffect != null) {
                 postTransactionalSideEffect.run();
             }
-        } catch (DurableQueueException e) {
+        } catch (Throwable e) {
             LOG.error(msg("[{}] {} - Failed to poll queue",
                           consumeFromQueue.consumerName,
                           queueName), e);
@@ -249,7 +249,7 @@ public class DefaultDurableQueueConsumer<DURABLE_QUEUES extends DurableQueues, U
             } else {
                 return NO_POSTPROCESSING_AFTER_PROCESS_NEXT_MESSAGE;
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOG.error(msg("[{}] Error Polling Queue", queueName), e);
             return NO_POSTPROCESSING_AFTER_PROCESS_NEXT_MESSAGE;
         }
@@ -290,7 +290,7 @@ public class DefaultDurableQueueConsumer<DURABLE_QUEUES extends DurableQueues, U
             durableQueues.acknowledgeMessageAsHandled(queuedMessage.getId());
             orderedMessageDeliveryThreads.remove(Thread.currentThread());
             return () -> queuePollingOptimizer.queuePollingReturnedMessage(queuedMessage);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             MESSAGE_HANDLING_FAILURE_LOG.debug(msg("[{}:{}] {} - QueueMessageHandler for failed to handle message: {}",
                                                    queueName,
                                                    queuedMessage.getId(),
@@ -309,7 +309,7 @@ public class DefaultDurableQueueConsumer<DURABLE_QUEUES extends DurableQueues, U
                     durableQueues.markAsDeadLetterMessage(queuedMessage.getId(), e);
                     orderedMessageDeliveryThreads.remove(Thread.currentThread());
                     return () -> queuePollingOptimizer.queuePollingReturnedMessage(queuedMessage);
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     MESSAGE_HANDLING_FAILURE_LOG.error(msg("[{}:{}] {} - Failed to mark the Message as a Dead Letter Message. Details: Is Permanent Error: {}. Message: {}",
                                                            queueName,
                                                            queuedMessage.getId(),
@@ -336,7 +336,7 @@ public class DefaultDurableQueueConsumer<DURABLE_QUEUES extends DurableQueues, U
                                                redeliveryDelay);
                     orderedMessageDeliveryThreads.remove(Thread.currentThread());
                     return NO_POSTPROCESSING_AFTER_PROCESS_NEXT_MESSAGE;
-                } catch (Exception ex) {
+                } catch (Throwable ex) {
                     if (ex.getMessage().contains("Interrupted waiting for lock")) {
                         // Usually happening when SpringBoot is performing an unclean shutdown
                         MESSAGE_HANDLING_FAILURE_LOG.debug(msg("[{}:{}] {} - Failed to register the message for retry.",

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultQueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultQueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumerNotifications.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumerNotifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -440,7 +440,7 @@ public interface DurableQueues extends Lifecycle {
      * @return the {@link QueuedMessage} message wrapped in an {@link Optional} if the operation was successful, otherwise it returns an {@link Optional#empty()}
      */
     default Optional<QueuedMessage> retryMessage(QueueEntryId queueEntryId,
-                                                 Exception causeForRetry,
+                                                 Throwable causeForRetry,
                                                  Duration deliveryDelay) {
         return retryMessage(new RetryMessage(queueEntryId,
                                              causeForRetry,
@@ -469,7 +469,7 @@ public interface DurableQueues extends Lifecycle {
      * @return the {@link QueuedMessage} message wrapped in an {@link Optional} if the operation was successful, otherwise it returns an {@link Optional#empty()}
      */
     default Optional<QueuedMessage> markAsDeadLetterMessage(QueueEntryId queueEntryId,
-                                                            Exception causeForBeingMarkedAsDeadLetter) {
+                                                            Throwable causeForBeingMarkedAsDeadLetter) {
         return markAsDeadLetterMessage(new MarkAsDeadLetterMessage(queueEntryId,
                                                                    causeForBeingMarkedAsDeadLetter));
     }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueuesInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueuesInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/Message.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageMetaData.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/NextQueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/NextQueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/OrderedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/OrderedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueEntryId.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueEntryId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuePollingOptimizer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuePollingOptimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/TransactionalMode.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/TransactionalMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerTracingInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerTracingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandled.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandledBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandledBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueue.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueueBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessages.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessagesBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessagesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDelivery.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDelivery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDeliveryBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDeliveryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessages.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessagesBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessagesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedFor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedForBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedForBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedFor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedForBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedForBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
@@ -34,7 +34,7 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  */
 public class MarkAsDeadLetterMessage {
     public final QueueEntryId queueEntryId;
-    private      Exception    causeForBeingMarkedAsDeadLetter;
+    private      Throwable    causeForBeingMarkedAsDeadLetter;
 
     /**
      * Create a new builder that produces a new {@link MarkAsDeadLetterMessage} instance
@@ -54,7 +54,7 @@ public class MarkAsDeadLetterMessage {
      * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
      * @param causeForBeingMarkedAsDeadLetter the reason for the message being marked as a Dead Letter Message
      */
-    public MarkAsDeadLetterMessage(QueueEntryId queueEntryId, Exception causeForBeingMarkedAsDeadLetter) {
+    public MarkAsDeadLetterMessage(QueueEntryId queueEntryId, Throwable causeForBeingMarkedAsDeadLetter) {
         this.queueEntryId = requireNonNull(queueEntryId, "No queueEntryId provided");
         this.causeForBeingMarkedAsDeadLetter = causeForBeingMarkedAsDeadLetter;
     }
@@ -71,7 +71,7 @@ public class MarkAsDeadLetterMessage {
      *
      * @return the reason for the message being marked as a Dead Letter Message
      */
-    public Exception getCauseForBeingMarkedAsDeadLetter() {
+    public Throwable getCauseForBeingMarkedAsDeadLetter() {
         return causeForBeingMarkedAsDeadLetter;
     }
 
@@ -79,7 +79,7 @@ public class MarkAsDeadLetterMessage {
      *
      * @param causeForBeingMarkedAsDeadLetter the reason for the message being marked as a Dead Letter Message
      */
-    public void setCauseForBeingMarkedAsDeadLetter(Exception causeForBeingMarkedAsDeadLetter) {
+    public void setCauseForBeingMarkedAsDeadLetter(Throwable causeForBeingMarkedAsDeadLetter) {
         this.causeForBeingMarkedAsDeadLetter = causeForBeingMarkedAsDeadLetter;
     }
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueue.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueueBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessages.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessagesBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessagesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
@@ -32,7 +32,7 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  */
 public class RetryMessage {
     public final QueueEntryId queueEntryId;
-    private      Exception    causeForRetry;
+    private      Throwable    causeForRetry;
     private      Duration     deliveryDelay;
 
     /**
@@ -53,7 +53,7 @@ public class RetryMessage {
      * @param causeForRetry the reason why the message delivery has to be retried
      * @param deliveryDelay how long will the queue wait until it delivers the message to the {@link DurableQueueConsumer}
      */
-    public RetryMessage(QueueEntryId queueEntryId, Exception causeForRetry, Duration deliveryDelay) {
+    public RetryMessage(QueueEntryId queueEntryId, Throwable causeForRetry, Duration deliveryDelay) {
         this.queueEntryId = requireNonNull(queueEntryId, "No queueEntryId provided");
         this.causeForRetry = causeForRetry;
         this.deliveryDelay = deliveryDelay;
@@ -71,7 +71,7 @@ public class RetryMessage {
      *
      * @return the reason why the message delivery has to be retried
      */
-    public Exception getCauseForRetry() {
+    public Throwable getCauseForRetry() {
         return causeForRetry;
     }
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueue.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueueBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
@@ -16,7 +16,7 @@
 
 package dk.cloudcreate.essentials.components.foundation.postgresql;
 
-import dk.cloudcreate.essentials.components.foundation.json.*;
+import dk.cloudcreate.essentials.components.foundation.json.JSONSerializer;
 import dk.cloudcreate.essentials.components.foundation.postgresql.ListenNotify.SqlOperation;
 import dk.cloudcreate.essentials.reactive.EventBus;
 import dk.cloudcreate.essentials.shared.concurrent.ThreadFactoryBuilder;
@@ -167,7 +167,7 @@ public class MultiTableChangeListener<T extends TableChangeNotification> impleme
                           }
                           try {
                               return jsonSerializer.deserialize(notification.getParameter(), payloadType);
-                          } catch (JSONDeserializationException e) {
+                          } catch (Throwable e) {
                               log.error(msg("Failed to deserialize notification payload '{}' to concrete {} related to table '{}'",
                                             notification.getParameter(),
                                             payloadType.getName(),

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/PostgresqlUtil.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/PostgresqlUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/SqlExecutionTimeLogger.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/SqlExecutionTimeLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/TableChangeNotification.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/TableChangeNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBus.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBus.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBus.java
@@ -435,9 +435,6 @@ public class DurableLocalCommandBus extends AbstractCommandBus implements Lifecy
                                                            }
                                                        })
                                   .proceed();
-        if (durableQueues.getTransactionalMode() == TransactionalMode.SingleOperationTransaction) {
-            durableQueues.acknowledgeMessageAsHandled(queuedMessage.getId());
-        }
     }
 
     public int getParallelSendAndDontWaitConsumers() {

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBusBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBusBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/UnitOfWorkControllingCommandBusInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/UnitOfWorkControllingCommandBusInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/UnitOfWorkControllingCommandBusInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/UnitOfWorkControllingCommandBusInterceptor.java
@@ -19,6 +19,7 @@ package dk.cloudcreate.essentials.components.foundation.reactive.command;
 import dk.cloudcreate.essentials.components.foundation.transaction.*;
 import dk.cloudcreate.essentials.reactive.command.interceptor.*;
 import dk.cloudcreate.essentials.shared.functional.CheckedFunction;
+import dk.cloudcreate.essentials.shared.interceptor.InterceptorOrder;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -26,6 +27,7 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  * {@link CommandBusInterceptor} that ensures that each Command is handled within a {@link UnitOfWork}
  * by using the {@link UnitOfWorkFactory#withUnitOfWork(CheckedFunction)}
  */
+@InterceptorOrder(5)
 public class UnitOfWorkControllingCommandBusInterceptor implements CommandBusInterceptor {
     private final UnitOfWorkFactory<? extends UnitOfWork> unitOfWorkFactory;
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/NoActiveUnitOfWorkException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/NoActiveUnitOfWorkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkLifecycleCallback.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkLifecycleCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkStatus.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/GenericHandleAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/GenericHandleAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/JdbiUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/JdbiUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/mongo/ClientSessionAwareUnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/mongo/ClientSessionAwareUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/jdbi/SpringTransactionAwareJdbiUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/jdbi/SpringTransactionAwareJdbiUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/mongo/SpringMongoTransactionAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/mongo/SpringMongoTransactionAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/CorrelationId.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/CorrelationId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/EventId.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/EventId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/MessageId.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/MessageId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/RandomIdGenerator.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/RandomIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/SubscriberId.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/SubscriberId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/Tenant.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/Tenant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/TenantId.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/types/TenantId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueInboxesTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueInboxesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueOutboxesTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueOutboxesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerWithInterceptorTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerWithInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandlerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeOtherCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeOtherCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeThirdCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeThirdCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeUnmatchedCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeUnmatchedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyIT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyPostgresql12IT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyPostgresql12IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerIT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerIT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerIT.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import dk.cloudcreate.essentials.components.foundation.json.JacksonJSONSerializer;
 import dk.cloudcreate.essentials.reactive.LocalEventBus;
 import org.assertj.core.api.Fail;
 import org.jdbi.v3.core.Jdbi;
@@ -88,7 +89,7 @@ class MultiTableChangeListenerIT {
             ListenNotify.addChangeNotificationTriggerToTable(handle, TABLE_3, List.of(ListenNotify.SqlOperation.INSERT), "id", "column5", "column6");
         });
 
-        listener = new MultiTableChangeListener<>(jdbi, Duration.ofMillis(50), objectMapper, localEventBus);
+        listener = new MultiTableChangeListener<>(jdbi, Duration.ofMillis(50), new JacksonJSONSerializer(objectMapper), localEventBus);
         listener.listenToNotificationsFor(TABLE_1, Table1Notification.class);
         listener.listenToNotificationsFor(TABLE_2, Table2Notification.class);
         listener.listenToNotificationsFor(TABLE_3, Table3Notification.class);

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerPostgresql12IT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerPostgresql12IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/resources/logback-test.xml
+++ b/components/foundation/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -21,7 +21,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/postgresql-distributed-fenced-lock/pom.xml
+++ b/components/postgresql-distributed-fenced-lock/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManager.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerBuilder.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockStorage.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameArgumentFactory.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameColumnMapper.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerIT.java
+++ b/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/test/resources/logback-test.xml
+++ b/components/postgresql-distributed-fenced-lock/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -691,6 +691,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -215,8 +215,8 @@ or
 ```java
 var orders = AggregateType.of("Order");
 eventStore.addAggregateEventStreamConfiguration(
-    SeparateTablePerAggregateTypeConfiguration.standardSingleTenantConfigurationUsingJackson(orders,
-                                                  createObjectMapper(),
+    SeparateTablePerAggregateTypeConfiguration.standardSingleTenantConfiguration(orders,
+                                                  new JacksonJSONEventSerializer(createObjectMapper()),
                                                   AggregateIdSerializer.serializerFor(OrderId.class),
                                                   IdentifierColumnType.UUID,
                                                   JSONColumnType.JSONB));

--- a/components/postgresql-event-store/pom.xml
+++ b/components/postgresql-event-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/AggregateNotFoundException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/AggregateNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/ConfigurableEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/ConfigurableEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreSubscription.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/InMemoryProjector.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/InMemoryProjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
@@ -30,6 +30,7 @@ import dk.cloudcreate.essentials.reactive.EventBus;
 import dk.cloudcreate.essentials.shared.Exceptions;
 import dk.cloudcreate.essentials.types.LongRange;
 import org.jdbi.v3.core.ConnectionException;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.slf4j.*;
 import reactor.core.publisher.*;
 import reactor.core.scheduler.Schedulers;
@@ -45,6 +46,7 @@ import java.util.stream.*;
 import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor.EventStoreInterceptorChain.newInterceptorChainForOperation;
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+import static dk.cloudcreate.essentials.shared.interceptor.DefaultInterceptorChain.sortInterceptorsByOrder;
 
 /**
  * Postgresql specific {@link EventStore} implementation
@@ -197,12 +199,14 @@ public class PostgresqlEventStore<CONFIG extends AggregateEventStreamConfigurati
     @Override
     public ConfigurableEventStore<CONFIG> addEventStoreInterceptor(EventStoreInterceptor eventStoreInterceptor) {
         this.eventStoreInterceptors.add(requireNonNull(eventStoreInterceptor, "No eventStoreInterceptor provided"));
+        sortInterceptorsByOrder(this.eventStoreInterceptors);
         return this;
     }
 
     @Override
     public ConfigurableEventStore<CONFIG> removeEventStoreInterceptor(EventStoreInterceptor eventStoreInterceptor) {
         this.eventStoreInterceptors.remove(requireNonNull(eventStoreInterceptor, "No eventStoreInterceptor provided"));
+        sortInterceptorsByOrder(this.eventStoreInterceptors);
         return this;
     }
 
@@ -673,7 +677,7 @@ public class PostgresqlEventStore<CONFIG extends AggregateEventStreamConfigurati
                 unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
             } catch (Exception e) {
                 var rootCause = Exceptions.getRootCause(e);
-                if (e.getMessage().contains("has been closed") || rootCause instanceof IOException || rootCause instanceof ConnectionException) {
+                if (e.getMessage().contains("has been closed") || rootCause instanceof IOException || rootCause instanceof ConnectionException || rootCause instanceof UnableToExecuteStatementException) {
                     eventStoreStreamLog.debug(msg("[{}] Polling worker - Experienced a Postgresql Connection issue while creating a UnitOfWork",
                                                   eventStreamLogName), e);
                 } else {

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/CommitStage.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/CommitStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/EventStoreEventBus.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/EventStoreEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateEventStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateEventStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateType.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNames.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/IdentifierColumnType.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/IdentifierColumnType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/JSONColumnType.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/JSONColumnType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEvent.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/EventStreamGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/EventStreamGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/NoEventStreamGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/NoEventStreamGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/SubscriptionGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/SubscriptionGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptorChain.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptorChain.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptorChain.java
@@ -84,7 +84,7 @@ public interface EventStoreInterceptorChain<OPERATION, RESULT> {
          * Create a new {@link EventStoreInterceptorChain} instance for the provided <code>operation</code>
          *
          * @param operation                  the {@link EventStore} operation to intercept, aka. the argument to the interceptor
-         * @param interceptors               the {@link EventStoreInterceptor}'s (can be an empty List if no interceptors have been configured)
+         * @param interceptors               the ordered {@link EventStoreInterceptor}'s (can be an empty List if no interceptors have been configured)
          * @param interceptorMethodInvoker   the function that's responsible for invoking the matching {@link EventStoreInterceptor} method
          * @param defaultEventStoreBehaviour the default {@link EventStore} behaviour for the given <code>operation</code> in case none of the interceptors provided a different result and stopped the interceptor chain
          */

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/micrometer/MicrometerTracingEventStoreInterceptor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/micrometer/MicrometerTracingEventStoreInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStreamBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStreamBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStreamBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStreamBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEvent.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrderBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedTo.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedToBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedToBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfiguration.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfigurationFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamPersistenceStrategy.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamPersistenceStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AppendToStreamException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AppendToStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/EventMetaData.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/EventMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/OptimisticAppendToStreamException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/OptimisticAppendToStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEvent.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistableEventEnricher.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistableEventEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistedEventRowMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistedEventRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PostgresqlEventStreamListener.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PostgresqlEventStreamListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfiguration.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfiguration.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfiguration.java
@@ -16,7 +16,6 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.*;
@@ -96,23 +95,23 @@ public class SeparateTablePerAggregateEventStreamConfiguration extends Aggregate
      * {@link SeparateTablePerAggregateEventStreamConfiguration#jsonSerializer} = {@link JacksonJSONEventSerializer}<br>
      *
      * @param aggregateType                             The type of Aggregate this event stream configuration relates to
-     * @param objectMapper                              The {@link ObjectMapper} that will be wrapped in a {@link JacksonJSONEventSerializer}
+     * @param jsonSerializer                            The {@link JSONEventSerializer}
      * @param aggregateIdSerializer                     The serializer for the Aggregate Id
      * @param identifierColumnTypeUsedForAllIdentifiers The SQL Column type used for all identifier columns (aggregate id, event id, correlation id, etc.)
      * @param jsonColumnTypeUsedForAllJSONColumns       The SQL JSON column type used for all JSON columns (Event and {@link EventMetaData})
      * @return the event stream configuration for the given aggregate type
      */
-    public static SeparateTablePerAggregateEventStreamConfiguration standardSingleTenantConfigurationUsingJackson(AggregateType aggregateType,
-                                                                                                                  ObjectMapper objectMapper,
-                                                                                                                  AggregateIdSerializer aggregateIdSerializer,
-                                                                                                                  IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
-                                                                                                                  JSONColumnType jsonColumnTypeUsedForAllJSONColumns) {
-        return standardConfigurationUsingJackson(aggregateType,
-                                                 objectMapper,
-                                                 aggregateIdSerializer,
-                                                 identifierColumnTypeUsedForAllIdentifiers,
-                                                 jsonColumnTypeUsedForAllJSONColumns,
-                                                 new NoSupportForMultiTenancySerializer());
+    public static SeparateTablePerAggregateEventStreamConfiguration standardSingleTenantConfiguration(AggregateType aggregateType,
+                                                                                                      JSONEventSerializer jsonSerializer,
+                                                                                                      AggregateIdSerializer aggregateIdSerializer,
+                                                                                                      IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
+                                                                                                      JSONColumnType jsonColumnTypeUsedForAllJSONColumns) {
+        return standardConfiguration(aggregateType,
+                                     jsonSerializer,
+                                     aggregateIdSerializer,
+                                     identifierColumnTypeUsedForAllIdentifiers,
+                                     jsonColumnTypeUsedForAllJSONColumns,
+                                     new NoSupportForMultiTenancySerializer());
     }
 
     /**
@@ -123,25 +122,25 @@ public class SeparateTablePerAggregateEventStreamConfiguration extends Aggregate
      * {@link SeparateTablePerAggregateEventStreamConfiguration#jsonSerializer} = {@link JacksonJSONEventSerializer}<br>
      *
      * @param aggregateType                             The type of Aggregate this event stream configuration relates to
-     * @param objectMapper                              The {@link ObjectMapper} that will be wrapped in a {@link JacksonJSONEventSerializer}
+     * @param jsonSerializer                            The {@link JSONEventSerializer}
      * @param aggregateIdSerializer                     The serializer for the Aggregate Id
      * @param identifierColumnTypeUsedForAllIdentifiers The SQL Column type used for all identifier columns (aggregate id, event id, correlation id, etc.)
      * @param jsonColumnTypeUsedForAllJSONColumns       The SQL JSON column type used for all JSON columns (Event and {@link EventMetaData})
      * @param tenantSerializer                          The {@link TenantSerializer} to use (e.g. {@link TenantIdSerializer})
      * @return the event stream configuration for the given aggregate type
      */
-    public static SeparateTablePerAggregateEventStreamConfiguration standardConfigurationUsingJackson(AggregateType aggregateType,
-                                                                                                      ObjectMapper objectMapper,
-                                                                                                      AggregateIdSerializer aggregateIdSerializer,
-                                                                                                      IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
-                                                                                                      JSONColumnType jsonColumnTypeUsedForAllJSONColumns,
-                                                                                                      TenantSerializer<?> tenantSerializer) {
+    public static SeparateTablePerAggregateEventStreamConfiguration standardConfiguration(AggregateType aggregateType,
+                                                                                          JSONEventSerializer jsonSerializer,
+                                                                                          AggregateIdSerializer aggregateIdSerializer,
+                                                                                          IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
+                                                                                          JSONColumnType jsonColumnTypeUsedForAllJSONColumns,
+                                                                                          TenantSerializer<?> tenantSerializer) {
         requireNonNull(aggregateType, "No aggregateType provided");
         return new SeparateTablePerAggregateEventStreamConfiguration(aggregateType,
                                                                      aggregateType.toString() + "_events",
                                                                      EventStreamTableColumnNames.defaultColumnNames(),
                                                                      100,
-                                                                     new JacksonJSONEventSerializer(objectMapper),
+                                                                     jsonSerializer,
                                                                      aggregateIdSerializer,
                                                                      identifierColumnTypeUsedForAllIdentifiers,
                                                                      identifierColumnTypeUsedForAllIdentifiers,

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypeEventStreamConfigurationFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypeEventStreamConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypeEventStreamConfigurationFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypeEventStreamConfigurationFactory.java
@@ -16,7 +16,6 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.*;
@@ -45,11 +44,11 @@ public class SeparateTablePerAggregateTypeEventStreamConfigurationFactory implem
     /**
      * The SQL fetch size for Queries
      */
-    public final int                  queryFetchSize;
+    public final int                             queryFetchSize;
     /**
      * The {@link JSONEventSerializer} used to serialize and deserialize {@link PersistedEvent#event()} and {@link PersistedEvent#metaData()}
      */
-    public final JSONEventSerializer  jsonSerializer;
+    public final JSONEventSerializer             jsonSerializer;
     /**
      * The SQL Column type for the Aggregate Id<br>
      * We've deliberately split {@link AggregateIdSerializer} and {@link #aggregateIdColumnType}
@@ -57,7 +56,7 @@ public class SeparateTablePerAggregateTypeEventStreamConfigurationFactory implem
      * which purely contains {@link java.util.UUID} string values, in which case it should be possible to
      * map these to {@link IdentifierColumnType#UUID}
      */
-    public final IdentifierColumnType aggregateIdColumnType;
+    public final IdentifierColumnType            aggregateIdColumnType;
     /**
      * The SQL column type for the {@link EventId} column
      */
@@ -69,11 +68,11 @@ public class SeparateTablePerAggregateTypeEventStreamConfigurationFactory implem
     /**
      * The SQL column type for the {@link JSONEventSerializer} serialized Event
      */
-    public final JSONColumnType       eventJsonColumnType;
+    public final JSONColumnType                  eventJsonColumnType;
     /**
      * The SQL column type for the {@link JSONEventSerializer} serialized {@link EventMetaData}
      */
-    public final JSONColumnType       eventMetadataJsonColumnType;
+    public final JSONColumnType                  eventMetadataJsonColumnType;
     /**
      * The serializer for the {@link Tenant} value (or {@link TenantSerializer.TenantIdSerializer.NoSupportForMultiTenancySerializer} if it's a single tenant application)
      */
@@ -126,18 +125,18 @@ public class SeparateTablePerAggregateTypeEventStreamConfigurationFactory implem
      * {@link SeparateTablePerAggregateEventStreamConfiguration#tenantSerializer} = {@link TenantSerializer.NoSupportForMultiTenancySerializer}<br>
      * {@link SeparateTablePerAggregateEventStreamConfiguration#jsonSerializer} = {@link JacksonJSONEventSerializer}<br>
      *
-     * @param objectMapper                              The {@link ObjectMapper} that will be wrapped in a {@link JacksonJSONEventSerializer}
+     * @param jsonSerializer                            The {@link JSONEventSerializer}
      * @param identifierColumnTypeUsedForAllIdentifiers The SQL Column type used for all identifier columns (aggregate id, event id, correlation id, etc.)
      * @param jsonColumnTypeUsedForAllJSONColumns       The SQL JSON column type used for all JSON columns (Event and {@link EventMetaData})
      * @return the event stream configuration factory
      */
-    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardSingleTenantConfigurationUsingJackson(ObjectMapper objectMapper,
-                                                                                                                             IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
-                                                                                                                             JSONColumnType jsonColumnTypeUsedForAllJSONColumns) {
-        return standardConfigurationUsingJackson(objectMapper,
-                                                 identifierColumnTypeUsedForAllIdentifiers,
-                                                 jsonColumnTypeUsedForAllJSONColumns,
-                                                 new TenantSerializer.NoSupportForMultiTenancySerializer());
+    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardSingleTenantConfiguration(JSONEventSerializer jsonSerializer,
+                                                                                                                 IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
+                                                                                                                 JSONColumnType jsonColumnTypeUsedForAllJSONColumns) {
+        return standardConfiguration(jsonSerializer,
+                                     identifierColumnTypeUsedForAllIdentifiers,
+                                     jsonColumnTypeUsedForAllJSONColumns,
+                                     new TenantSerializer.NoSupportForMultiTenancySerializer());
     }
 
     /**
@@ -149,22 +148,22 @@ public class SeparateTablePerAggregateTypeEventStreamConfigurationFactory implem
      * @param resolveEventStreamTableName               The Function that resolves the unique name of the Postgresql table name where ONLY {@link PersistedEvent}'s related to supplied {@link AggregateType} will be stored stored<br>
      *                                                  <b>Note: The table name provided will automatically be converted to <u>lower case</u></b>
      * @param eventStreamTableColumnNames               Defines the names of the eventStreamTableColumnNames - e.g. {@link EventStreamTableColumnNames#defaultColumnNames()}
-     * @param objectMapper                              The {@link ObjectMapper} that will be wrapped in a {@link JacksonJSONEventSerializer}
+     * @param jsonSerializer                            The {@link JSONEventSerializer}
      * @param identifierColumnTypeUsedForAllIdentifiers The SQL Column type used for all identifier columns (aggregate id, event id, correlation id, etc.)
      * @param jsonColumnTypeUsedForAllJSONColumns       The SQL JSON column type used for all JSON columns (Event and {@link EventMetaData})
      * @return the event stream configuration factory
      */
-    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardSingleTenantConfigurationUsingJackson(Function<AggregateType, String> resolveEventStreamTableName,
-                                                                                                                             EventStreamTableColumnNames eventStreamTableColumnNames,
-                                                                                                                             ObjectMapper objectMapper,
-                                                                                                                             IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
-                                                                                                                             JSONColumnType jsonColumnTypeUsedForAllJSONColumns) {
-        return standardConfigurationUsingJackson(resolveEventStreamTableName,
-                                                 eventStreamTableColumnNames,
-                                                 objectMapper,
-                                                 identifierColumnTypeUsedForAllIdentifiers,
-                                                 jsonColumnTypeUsedForAllJSONColumns,
-                                                 new TenantSerializer.NoSupportForMultiTenancySerializer());
+    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardSingleTenantConfiguration(Function<AggregateType, String> resolveEventStreamTableName,
+                                                                                                                 EventStreamTableColumnNames eventStreamTableColumnNames,
+                                                                                                                 JSONEventSerializer jsonSerializer,
+                                                                                                                 IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
+                                                                                                                 JSONColumnType jsonColumnTypeUsedForAllJSONColumns) {
+        return standardConfiguration(resolveEventStreamTableName,
+                                     eventStreamTableColumnNames,
+                                     jsonSerializer,
+                                     identifierColumnTypeUsedForAllIdentifiers,
+                                     jsonColumnTypeUsedForAllJSONColumns,
+                                     new TenantSerializer.NoSupportForMultiTenancySerializer());
     }
 
     /**
@@ -174,19 +173,19 @@ public class SeparateTablePerAggregateTypeEventStreamConfigurationFactory implem
      * {@link SeparateTablePerAggregateEventStreamConfiguration#queryFetchSize} = 100<br>
      * {@link SeparateTablePerAggregateEventStreamConfiguration#jsonSerializer} = {@link JacksonJSONEventSerializer}<br>
      *
-     * @param objectMapper                              The {@link ObjectMapper} that will be wrapped in a {@link JacksonJSONEventSerializer}
+     * @param jsonSerializer                            The {@link JSONEventSerializer}
      * @param identifierColumnTypeUsedForAllIdentifiers The SQL Column type used for all identifier columns (aggregate id, event id, correlation id, etc.)
      * @param jsonColumnTypeUsedForAllJSONColumns       The SQL JSON column type used for all JSON columns (Event and {@link EventMetaData})
      * @return the event stream configuration factory
      */
-    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardConfigurationUsingJackson(ObjectMapper objectMapper,
-                                                                                                                 IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
-                                                                                                                 JSONColumnType jsonColumnTypeUsedForAllJSONColumns,
-                                                                                                                 TenantSerializer<?> tenantSerializer) {
+    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardConfiguration(JSONEventSerializer jsonSerializer,
+                                                                                                     IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
+                                                                                                     JSONColumnType jsonColumnTypeUsedForAllJSONColumns,
+                                                                                                     TenantSerializer<?> tenantSerializer) {
         return new SeparateTablePerAggregateTypeEventStreamConfigurationFactory(aggregateType -> aggregateType + "_events",
                                                                                 EventStreamTableColumnNames.defaultColumnNames(),
                                                                                 100,
-                                                                                new JacksonJSONEventSerializer(objectMapper),
+                                                                                jsonSerializer,
                                                                                 identifierColumnTypeUsedForAllIdentifiers,
                                                                                 identifierColumnTypeUsedForAllIdentifiers,
                                                                                 identifierColumnTypeUsedForAllIdentifiers,
@@ -203,21 +202,21 @@ public class SeparateTablePerAggregateTypeEventStreamConfigurationFactory implem
      * @param resolveEventStreamTableName               The Function that resolves the unique name of the Postgresql table name where ONLY {@link PersistedEvent}'s related to supplied {@link AggregateType} will be stored stored<br>
      *                                                  <b>Note: The table name provided will automatically be converted to <u>lower case</u></b>
      * @param eventStreamTableColumnNames               Defines the names of the eventStreamTableColumnNames - e.g. {@link EventStreamTableColumnNames#defaultColumnNames()}
-     * @param objectMapper                              The {@link ObjectMapper} that will be wrapped in a {@link JacksonJSONEventSerializer}
+     * @param jsonSerializer                            The {@link JSONEventSerializer}
      * @param identifierColumnTypeUsedForAllIdentifiers The SQL Column type used for all identifier columns (aggregate id, event id, correlation id, etc.)
      * @param jsonColumnTypeUsedForAllJSONColumns       The SQL JSON column type used for all JSON columns (Event and {@link EventMetaData})
      * @return the event stream configuration factory
      */
-    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardConfigurationUsingJackson(Function<AggregateType, String> resolveEventStreamTableName,
-                                                                                                                 EventStreamTableColumnNames eventStreamTableColumnNames,
-                                                                                                                 ObjectMapper objectMapper,
-                                                                                                                 IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
-                                                                                                                 JSONColumnType jsonColumnTypeUsedForAllJSONColumns,
-                                                                                                                 TenantSerializer<?> tenantSerializer) {
+    public static SeparateTablePerAggregateTypeEventStreamConfigurationFactory standardConfiguration(Function<AggregateType, String> resolveEventStreamTableName,
+                                                                                                     EventStreamTableColumnNames eventStreamTableColumnNames,
+                                                                                                     JSONEventSerializer jsonSerializer,
+                                                                                                     IdentifierColumnType identifierColumnTypeUsedForAllIdentifiers,
+                                                                                                     JSONColumnType jsonColumnTypeUsedForAllJSONColumns,
+                                                                                                     TenantSerializer<?> tenantSerializer) {
         return new SeparateTablePerAggregateTypeEventStreamConfigurationFactory(resolveEventStreamTableName,
                                                                                 eventStreamTableColumnNames,
                                                                                 100,
-                                                                                new JacksonJSONEventSerializer(objectMapper),
+                                                                                jsonSerializer,
                                                                                 identifierColumnTypeUsedForAllIdentifiers,
                                                                                 identifierColumnTypeUsedForAllIdentifiers,
                                                                                 identifierColumnTypeUsedForAllIdentifiers,

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategy.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
@@ -165,6 +165,19 @@ public abstract class EventProcessor implements Lifecycle {
     private PatternMatchingMessageHandler   patternMatchingInboxMessageHandlerDelegate;
     private List<MessageHandlerInterceptor> messageHandlerInterceptors;
 
+    /**
+     * Create a new {@link EventProcessor} instance
+     *
+     * @param eventProcessorDependencies The {@link EventProcessorDependencies} that encapsulates all
+     *                                   the dependencies required by an instance of an {@link EventProcessor}
+     * @see EventProcessor#EventProcessor(EventStoreSubscriptionManager, Inboxes, DurableLocalCommandBus, List)
+     */
+    protected EventProcessor(EventProcessorDependencies eventProcessorDependencies) {
+        this(requireNonNull(eventProcessorDependencies, "No eventProcessorDependencies provided").eventStoreSubscriptionManager,
+             eventProcessorDependencies.inboxes,
+             eventProcessorDependencies.commandBus,
+             eventProcessorDependencies.messageHandlerInterceptors);
+    }
 
     /**
      * Create a new {@link EventProcessor} instance

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependencies.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependencies.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependencies.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+
+import java.util.List;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * Encapsulates all the dependencies required by an instance of an {@link EventProcessor}
+ */
+public class EventProcessorDependencies {
+    public final EventStoreSubscriptionManager   eventStoreSubscriptionManager;
+    public final Inboxes                         inboxes;
+    public final DurableLocalCommandBus          commandBus;
+    public final List<MessageHandlerInterceptor> messageHandlerInterceptors;
+
+    public static EventProcessorDependenciesBuilder builder() {
+        return new EventProcessorDependenciesBuilder();
+    }
+
+    public EventProcessorDependencies(EventStoreSubscriptionManager eventStoreSubscriptionManager,
+                                      Inboxes inboxes,
+                                      DurableLocalCommandBus commandBus,
+                                      List<MessageHandlerInterceptor> messageHandlerInterceptors) {
+        this.eventStoreSubscriptionManager = requireNonNull(eventStoreSubscriptionManager, "No eventStoreSubscriptionManager provided");
+        this.inboxes = requireNonNull(inboxes, "No inboxes provided");
+        this.commandBus = requireNonNull(commandBus, "No commandBus provided");
+        this.messageHandlerInterceptors = requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors provided");
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependenciesBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependenciesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependenciesBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependenciesBuilder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+
+import java.util.List;
+
+/**
+ * Builder for {@link EventProcessorDependencies}, which encapsulates all the dependencies
+ * required by an instance of an {@link EventProcessor}
+ */
+public class EventProcessorDependenciesBuilder {
+    private EventStoreSubscriptionManager   eventStoreSubscriptionManager;
+    private Inboxes                         inboxes;
+    private DurableLocalCommandBus          commandBus;
+    private List<MessageHandlerInterceptor> messageHandlerInterceptors = List.of();
+
+    public EventProcessorDependenciesBuilder setEventStoreSubscriptionManager(EventStoreSubscriptionManager eventStoreSubscriptionManager) {
+        this.eventStoreSubscriptionManager = eventStoreSubscriptionManager;
+        return this;
+    }
+
+    public EventProcessorDependenciesBuilder setInboxes(Inboxes inboxes) {
+        this.inboxes = inboxes;
+        return this;
+    }
+
+    public EventProcessorDependenciesBuilder setCommandBus(DurableLocalCommandBus commandBus) {
+        this.commandBus = commandBus;
+        return this;
+    }
+
+    public EventProcessorDependenciesBuilder setMessageHandlerInterceptors(List<MessageHandlerInterceptor> messageHandlerInterceptors) {
+        this.messageHandlerInterceptors = messageHandlerInterceptors;
+        return this;
+    }
+
+    public EventProcessorDependencies build() {
+        return new EventProcessorDependencies(eventStoreSubscriptionManager, inboxes, commandBus, messageHandlerInterceptors);
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/AggregateIdSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/AggregateIdSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/TenantSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/TenantSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSON.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSON.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JSONEventSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JSONEventSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JacksonJSONEventSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JacksonJSONEventSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/DurableSubscriptionRepository.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/DurableSubscriptionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManagerBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/FencedLockAwareSubscriber.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/FencedLockAwareSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionResumePoint.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionResumePoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/TransactionalPersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/TransactionalPersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWorkFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWork.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWorkFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/PersistedEventsCommitLifecycleCallback.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/PersistedEventsCommitLifecycleCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventName.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventOrder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventRevision.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventRevision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventType.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeOrName.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeOrName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/GlobalEventOrder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/GlobalEventOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/Revision.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/Revision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/MultiTenantPostgresqlEventStoreIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/MultiTenantPostgresqlEventStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStoreBenchmark.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStoreBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStoreBenchmark.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStoreBenchmark.java
@@ -25,6 +25,7 @@ import com.zaxxer.hikari.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
@@ -89,9 +90,9 @@ public class PostgresqlEventStoreBenchmark {
             var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                            unitOfWorkFactory,
                                                                                            new TestPersistableEventMapper(),
-                                                                                           SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                                                      IdentifierColumnType.UUID,
-                                                                                                                                                                                                      JSONColumnType.JSONB));
+                                                                                           SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                          IdentifierColumnType.UUID,
+                                                                                                                                                                                          JSONColumnType.JSONB));
             eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                     persistenceStrategy);
             eventStore.addAggregateEventStreamConfiguration(aggregateType,

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
@@ -27,6 +27,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.g
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
@@ -51,8 +52,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.*;
 
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfigurationUsingJackson;
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration;
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 import static org.assertj.core.api.Assertions.*;
@@ -91,11 +91,11 @@ class SingleTenantPostgresqlEventStoreIT {
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
                                                                                        eventMapper,
-                                                                                       standardSingleTenantConfigurationUsingJackson(aggregateType_ -> aggregateType_ + "_events",
-                                                                                                                                     EventStreamTableColumnNames.defaultColumnNames(),
-                                                                                                                                     createObjectMapper(),
-                                                                                                                                     IdentifierColumnType.UUID,
-                                                                                                                                     JSONColumnType.JSONB));
+                                                                                       standardSingleTenantConfiguration(aggregateType_ -> aggregateType_ + "_events",
+                                                                                                                         EventStreamTableColumnNames.defaultColumnNames(),
+                                                                                                                         new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                         IdentifierColumnType.UUID,
+                                                                                                                         JSONColumnType.JSONB));
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 persistenceStrategy,
                                                 Optional.empty(),
@@ -877,11 +877,11 @@ class SingleTenantPostgresqlEventStoreIT {
     @Test
     void test_loadEventsByGlobalOrder() {
         // Add support for the Product aggregate
-        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfigurationUsingJackson(PRODUCTS,
-                                                                                                      createObjectMapper(),
-                                                                                                      AggregateIdSerializer.serializerFor(ProductId.class),
-                                                                                                      IdentifierColumnType.TEXT,
-                                                                                                      JSONColumnType.JSON));
+        eventStore.addAggregateEventStreamConfiguration(SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration(PRODUCTS,
+                                                                                                                                            new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                            AggregateIdSerializer.serializerFor(ProductId.class),
+                                                                                                                                            IdentifierColumnType.TEXT,
+                                                                                                                                            JSONColumnType.JSON));
         var testEvents = createTestEvents();
 
         // Persist all test events
@@ -986,11 +986,11 @@ class SingleTenantPostgresqlEventStoreIT {
         requireNonNull(productsFluxSupplier);
         requireNonNull(ordersFluxSupplier);
         // Add support for the Product aggregate
-        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfigurationUsingJackson(PRODUCTS,
-                                                                                                      createObjectMapper(),
-                                                                                                      AggregateIdSerializer.serializerFor(ProductId.class),
-                                                                                                      IdentifierColumnType.TEXT,
-                                                                                                      JSONColumnType.JSON));
+        eventStore.addAggregateEventStreamConfiguration(SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration(PRODUCTS,
+                                                                                                                                            new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                            AggregateIdSerializer.serializerFor(ProductId.class),
+                                                                                                                                            IdentifierColumnType.TEXT,
+                                                                                                                                            JSONColumnType.JSON));
         var testEvents = createTestEvents();
 
         var productEventsReceived = new ArrayList<PersistedEvent>();
@@ -1133,11 +1133,11 @@ class SingleTenantPostgresqlEventStoreIT {
     @Test
     void test_pollEvents_with_pauses() throws InterruptedException {
         // Add support for the Product aggregate
-        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfigurationUsingJackson(PRODUCTS,
-                                                                                                      createObjectMapper(),
-                                                                                                      AggregateIdSerializer.serializerFor(ProductId.class),
-                                                                                                      IdentifierColumnType.TEXT,
-                                                                                                      JSONColumnType.JSON));
+        eventStore.addAggregateEventStreamConfiguration(SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration(PRODUCTS,
+                                                                                                                                            new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                            AggregateIdSerializer.serializerFor(ProductId.class),
+                                                                                                                                            IdentifierColumnType.TEXT,
+                                                                                                                                            JSONColumnType.JSON));
 
         var productEventsReceived = new ArrayList<PersistedEvent>();
         var productsSubscriberId  = SubscriberId.of("ProductsSub1");

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandlerIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandlerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandlerIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandlerIT.java
@@ -26,6 +26,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.e
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler.ResolveTransientGapsToPermanentGapsPromotionStrategy;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
@@ -48,7 +49,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
@@ -84,9 +84,9 @@ class PostgresqlEventStreamGapHandlerIT {
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
                                                                                        eventMapper,
-                                                                                       standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                     IdentifierColumnType.UUID,
-                                                                                                                                     JSONColumnType.JSONB));
+                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                                                      JSONColumnType.JSONB));
         persistenceStrategy.addAggregateEventStreamConfiguration(aggregateType,
                                                                  OrderId.class);
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
@@ -27,6 +27,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.e
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
@@ -49,7 +50,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.*;
 import java.util.stream.*;
 
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfigurationUsingJackson;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -83,23 +84,23 @@ class EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchr
         aggregateType = ORDERS;
         unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
         eventMapper = new TestPersistableEventMapper();
-        var objectMapper = createObjectMapper();
+        var jsonSerializer = new JacksonJSONEventSerializer(createObjectMapper());
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
                                                                                        eventMapper,
-                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(objectMapper,
-                                                                                                                                                                                                  IdentifierColumnType.UUID,
-                                                                                                                                                                                                  JSONColumnType.JSONB));
+                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(jsonSerializer,
+                                                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                                                      JSONColumnType.JSONB));
 
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 persistenceStrategy);
         eventStore.addAggregateEventStreamConfiguration(aggregateType,
                                                         OrderId.class);
-        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfigurationUsingJackson(PRODUCTS,
-                                                                                                      objectMapper,
-                                                                                                      AggregateIdSerializer.serializerFor(ProductId.class),
-                                                                                                      IdentifierColumnType.TEXT,
-                                                                                                      JSONColumnType.JSON));
+        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfiguration(PRODUCTS,
+                                                                                          jsonSerializer,
+                                                                                          AggregateIdSerializer.serializerFor(ProductId.class),
+                                                                                          IdentifierColumnType.TEXT,
+                                                                                          JSONColumnType.JSON));
 
     }
 

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
@@ -27,6 +27,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.e
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
@@ -48,7 +49,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.*;
 import java.util.stream.*;
 
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfigurationUsingJackson;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,23 +83,23 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
         aggregateType = ORDERS;
         unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
         eventMapper = new TestPersistableEventMapper();
-        var objectMapper = createObjectMapper();
+        var jsonSerializer = new JacksonJSONEventSerializer(createObjectMapper());
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
                                                                                        eventMapper,
-                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(objectMapper,
-                                                                                                                                                                                                  IdentifierColumnType.UUID,
-                                                                                                                                                                                                  JSONColumnType.JSONB));
+                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(jsonSerializer,
+                                                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                                                      JSONColumnType.JSONB));
 
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 persistenceStrategy);
         eventStore.addAggregateEventStreamConfiguration(aggregateType,
                                                         OrderId.class);
-        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfigurationUsingJackson(PRODUCTS,
-                                                                                                      objectMapper,
-                                                                                                      AggregateIdSerializer.serializerFor(ProductId.class),
-                                                                                                      IdentifierColumnType.TEXT,
-                                                                                                      JSONColumnType.JSON));
+        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfiguration(PRODUCTS,
+                                                                                          jsonSerializer,
+                                                                                          AggregateIdSerializer.serializerFor(ProductId.class),
+                                                                                          IdentifierColumnType.TEXT,
+                                                                                          JSONColumnType.JSON));
 
     }
 

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
@@ -27,6 +27,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.e
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
@@ -46,7 +47,7 @@ import java.time.*;
 import java.util.*;
 import java.util.stream.*;
 
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfigurationUsingJackson;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,23 +81,23 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT {
         aggregateType = ORDERS;
         unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
         eventMapper = new TestPersistableEventMapper();
-        var objectMapper = createObjectMapper();
+        var jsonSerializer = new JacksonJSONEventSerializer(createObjectMapper());
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
                                                                                        eventMapper,
-                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(objectMapper,
-                                                                                                                                                                                                  IdentifierColumnType.UUID,
-                                                                                                                                                                                                  JSONColumnType.JSONB));
+                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(jsonSerializer,
+                                                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                                                      JSONColumnType.JSONB));
 
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 persistenceStrategy);
         eventStore.addAggregateEventStreamConfiguration(aggregateType,
                                                         OrderId.class);
-        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfigurationUsingJackson(PRODUCTS,
-                                                                                                      objectMapper,
-                                                                                                      AggregateIdSerializer.serializerFor(ProductId.class),
-                                                                                                      IdentifierColumnType.TEXT,
-                                                                                                      JSONColumnType.JSON));
+        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfiguration(PRODUCTS,
+                                                                                          jsonSerializer,
+                                                                                          AggregateIdSerializer.serializerFor(ProductId.class),
+                                                                                          IdentifierColumnType.TEXT,
+                                                                                          JSONColumnType.JSON));
     }
 
     @AfterEach

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandlerTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandlerTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/CustomerId.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderEvent.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderId.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductEvent.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductId.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/resources/logback-test.xml
+++ b/components/postgresql-event-store/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -10,7 +10,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/postgresql-queue/pom.xml
+++ b/components/postgresql-queue/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueueConsumer.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 import static dk.cloudcreate.essentials.shared.FailFast.*;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.NamedArgumentBinding.arg;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.*;
+import static dk.cloudcreate.essentials.shared.interceptor.DefaultInterceptorChain.sortInterceptorsByOrder;
 import static dk.cloudcreate.essentials.shared.interceptor.InterceptorChain.newInterceptorChainForOperation;
 
 /**
@@ -323,6 +324,7 @@ public class PostgresqlDurableQueues implements DurableQueues {
             started = true;
             log.info("Starting");
             interceptors.forEach(durableQueuesInterceptor -> durableQueuesInterceptor.setDurableQueues(this));
+            sortInterceptorsByOrder(interceptors);
             durableQueueConsumers.values().forEach(PostgresqlDurableQueueConsumer::start);
             multiTableChangeListener.ifPresent(listener -> {
                 listener.listenToNotificationsFor(sharedQueueTableName,
@@ -1093,6 +1095,7 @@ public class PostgresqlDurableQueues implements DurableQueues {
         log.info("Adding interceptor: {}", interceptor);
         interceptor.setDurableQueues(this);
         interceptors.add(interceptor);
+        sortInterceptorsByOrder(interceptors);
         return this;
     }
 
@@ -1101,6 +1104,7 @@ public class PostgresqlDurableQueues implements DurableQueues {
         requireNonNull(interceptor, "No interceptor provided");
         log.info("Removing interceptor: {}", interceptor);
         interceptors.remove(interceptor);
+        sortInterceptorsByOrder(interceptors);
         return this;
     }
 

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -839,7 +839,7 @@ public class PostgresqlDurableQueues implements DurableQueues {
                                                        log.debug("Deleted Message with id '{}'", operation.queueEntryId);
                                                        return true;
                                                    } else {
-                                                       log.error("Failed to Delete Message with id '{}'", operation.queueEntryId);
+                                                       log.error("Couldn't Delete Message with id '{}' - it may already have been deleted", operation.queueEntryId);
                                                        return false;
                                                    }
                                                }).proceed();

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -1156,7 +1156,7 @@ public class PostgresqlDurableQueues implements DurableQueues {
         requireNonNull(messagePayloadType, "No messagePayloadType provided");
         try {
             return jsonSerializer.deserialize(messagePayload, Classes.forName(messagePayloadType));
-        } catch (JSONDeserializationException e) {
+        } catch (Throwable e) {
             throw new DurableQueueException(msg("Failed to deserialize message payload of type {}", messagePayloadType), e, queueName);
         }
     }
@@ -1166,7 +1166,7 @@ public class PostgresqlDurableQueues implements DurableQueues {
         requireNonNull(metaData, "No messagePayload provided");
         try {
             return jsonSerializer.deserialize(metaData, MessageMetaData.class);
-        } catch (JSONDeserializationException e) {
+        } catch (Throwable e) {
             throw new DurableQueueException(msg("Failed to deserialize message meta-data"), e, queueName);
         }
     }

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesBuilder.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdArgumentFactory.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdColumnMapper.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameArgumentFactory.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameColumnMapper.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBusIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBusIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBus_withSingleOperationTransactionIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBus_withSingleOperationTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/CustomerId.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderEvent.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderId.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductEvent.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductId.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/resources/logback-test.xml
+++ b/components/postgresql-queue/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/pom.xml
+++ b/components/spring-boot-starter-mongodb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalCharSequenceTypesSupported.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalCharSequenceTypesSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalConverters.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -18,6 +18,7 @@ package dk.cloudcreate.essentials.components.boot.autoconfigure.mongodb;
 
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -50,7 +51,6 @@ import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
 import org.slf4j.*;
 import org.springframework.beans.BeansException;
-import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -83,21 +83,21 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     }
 
     @Bean
-    @ConditionalOnEnabledTracing
-    public DurableQueuesMicrometerTracingInterceptor durableQueuesMicrometerTracingInterceptor(Tracer tracer,
-                                                                                               Propagator propagator,
-                                                                                               ObservationRegistry observationRegistry,
+    @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
+    public DurableQueuesMicrometerTracingInterceptor durableQueuesMicrometerTracingInterceptor(Optional<Tracer> tracer,
+                                                                                               Optional<Propagator> propagator,
+                                                                                               Optional<ObservationRegistry> observationRegistry,
                                                                                                EssentialsComponentsProperties properties) {
-        return new DurableQueuesMicrometerTracingInterceptor(tracer,
-                                                             propagator,
-                                                             observationRegistry,
+        return new DurableQueuesMicrometerTracingInterceptor(tracer.get(),
+                                                             propagator.get(),
+                                                             observationRegistry.get(),
                                                              properties.getDurableQueues().isVerboseTracing());
     }
 
     @Bean
-    @ConditionalOnEnabledTracing
-    public DurableQueuesMicrometerInterceptor durableQueuesMicrometerInterceptor(MeterRegistry meterRegistry) {
-        return new DurableQueuesMicrometerInterceptor(meterRegistry);
+    @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
+    public DurableQueuesMicrometerInterceptor durableQueuesMicrometerInterceptor(Optional<MeterRegistry> meterRegistry) {
+        return new DurableQueuesMicrometerInterceptor(meterRegistry.get());
     }
 
     /**
@@ -367,11 +367,13 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
      * {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      *
      * @param optionalEssentialsImmutableJacksonModule the optional {@link EssentialsImmutableJacksonModule}
+     * @param additionalModules additional {@link Module}'s found in the {@link ApplicationContext}
      * @return the {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      */
     @Bean
     @ConditionalOnMissingBean
-    public ObjectMapper essentialComponentsObjectMapper(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule) {
+    public ObjectMapper essentialComponentsObjectMapper(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule,
+                                                        List<Module> additionalModules) {
         var objectMapperBuilder = JsonMapper.builder()
                                             .disable(MapperFeature.AUTO_DETECT_GETTERS)
                                             .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
@@ -386,6 +388,8 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
                                             .addModule(new Jdk8Module())
                                             .addModule(new JavaTimeModule())
                                             .addModule(new EssentialTypesJacksonModule());
+
+        additionalModules.forEach(objectMapperBuilder::addModule);
 
         optionalEssentialsImmutableJacksonModule.ifPresent(essentialsImmutableJacksonModule -> {
             objectMapperBuilder.addModule(new EssentialsImmutableJacksonModule());

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/pom.xml
+++ b/components/spring-boot-starter-postgresql-event-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EssentialsEventStoreProperties.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EssentialsEventStoreProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
@@ -39,7 +39,6 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
 import org.jdbi.v3.core.Jdbi;
-import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -193,14 +192,14 @@ public class EventStoreConfiguration {
     }
 
     @Bean
-    @ConditionalOnEnabledTracing
-    public MicrometerTracingEventStoreInterceptor micrometerTracingEventStoreInterceptor(Tracer tracer,
-                                                                                         Propagator propagator,
-                                                                                         ObservationRegistry observationRegistry,
+    @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
+    public MicrometerTracingEventStoreInterceptor micrometerTracingEventStoreInterceptor(Optional<Tracer> tracer,
+                                                                                         Optional<Propagator> propagator,
+                                                                                         Optional<ObservationRegistry> observationRegistry,
                                                                                          EssentialsEventStoreProperties essentialsComponentsProperties) {
-        return new MicrometerTracingEventStoreInterceptor(tracer,
-                                                          propagator,
-                                                          observationRegistry,
+        return new MicrometerTracingEventStoreInterceptor(tracer.get(),
+                                                          propagator.get(),
+                                                          observationRegistry.get(),
                                                           essentialsComponentsProperties.isVerboseTracing());
     }
 }

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -8,7 +8,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/pom.xml
+++ b/components/spring-boot-starter-postgresql/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -18,6 +18,7 @@ package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql;
 
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -50,7 +51,6 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.postgres.PostgresPlugin;
 import org.slf4j.*;
 import org.springframework.beans.BeansException;
-import org.springframework.boot.actuate.autoconfigure.tracing.ConditionalOnEnabledTracing;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -81,21 +81,21 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     }
 
     @Bean
-    @ConditionalOnEnabledTracing
-    public DurableQueuesMicrometerTracingInterceptor durableQueuesMicrometerTracingInterceptor(Tracer tracer,
-                                                                                               Propagator propagator,
-                                                                                               ObservationRegistry observationRegistry,
+    @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
+    public DurableQueuesMicrometerTracingInterceptor durableQueuesMicrometerTracingInterceptor(Optional<Tracer> tracer,
+                                                                                               Optional<Propagator> propagator,
+                                                                                               Optional<ObservationRegistry> observationRegistry,
                                                                                                EssentialsComponentsProperties properties) {
-        return new DurableQueuesMicrometerTracingInterceptor(tracer,
-                                                             propagator,
-                                                             observationRegistry,
+        return new DurableQueuesMicrometerTracingInterceptor(tracer.get(),
+                                                             propagator.get(),
+                                                             observationRegistry.get(),
                                                              properties.getDurableQueues().isVerboseTracing());
     }
 
     @Bean
-    @ConditionalOnEnabledTracing
-    public DurableQueuesMicrometerInterceptor durableQueuesMicrometerInterceptor(MeterRegistry meterRegistry) {
-        return new DurableQueuesMicrometerInterceptor(meterRegistry);
+    @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
+    public DurableQueuesMicrometerInterceptor durableQueuesMicrometerInterceptor(Optional<MeterRegistry> meterRegistry) {
+        return new DurableQueuesMicrometerInterceptor(meterRegistry.get());
     }
 
     /**
@@ -320,11 +320,13 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
      * {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      *
      * @param optionalEssentialsImmutableJacksonModule the optional {@link EssentialsImmutableJacksonModule}
+     * @param additionalModules additional {@link Module}'s found in the {@link ApplicationContext}
      * @return the {@link ObjectMapper} responsible for serializing/deserializing the raw Java events to and from JSON
      */
     @Bean
     @ConditionalOnMissingBean
-    public ObjectMapper essentialComponentsObjectMapper(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule) {
+    public ObjectMapper essentialComponentsObjectMapper(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule,
+                                                        List<Module> additionalModules) {
         var objectMapperBuilder = JsonMapper.builder()
                                             .disable(MapperFeature.AUTO_DETECT_GETTERS)
                                             .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
@@ -339,6 +341,8 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
                                             .addModule(new Jdk8Module())
                                             .addModule(new JavaTimeModule())
                                             .addModule(new EssentialTypesJacksonModule());
+
+        additionalModules.forEach(objectMapperBuilder::addModule);
 
         optionalEssentialsImmutableJacksonModule.ifPresent(essentialsImmutableJacksonModule -> {
             objectMapperBuilder.addModule(new EssentialsImmutableJacksonModule());
@@ -370,6 +374,17 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
                     lifecycleBean.start();
                 }
             });
+
+            var callbacks = applicationContext.getBeansOfType(JdbiConfigurationCallback.class).values();
+            if (!callbacks.isEmpty()) {
+                var jdbi = applicationContext.getBean(Jdbi.class);
+                callbacks.forEach(configureJdbiCallback -> {
+                    log.info("Calling {}: {}",
+                             JdbiConfigurationCallback.class.getSimpleName(),
+                             configureJdbiCallback.getClass().getName());
+                    configureJdbiCallback.configure(jdbi);
+                });
+            }
         } else if (event instanceof ContextClosedEvent) {
             log.info("{} - has Context already been closed: {}", event.getClass().getSimpleName(), closed);
             if (!closed) {

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/JdbiConfigurationCallback.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/JdbiConfigurationCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/JdbiConfigurationCallback.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/JdbiConfigurationCallback.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql;
+
+import org.jdbi.v3.core.Jdbi;
+import org.springframework.lang.NonNull;
+
+/**
+ * Instances of this callback, typically defined as Spring {@literal @Bean}'s,
+ * will be called right after the application context has been refreshed
+ */
+public interface JdbiConfigurationCallback {
+    void configure(@NonNull Jdbi jdbi);
+}

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -40,7 +40,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/pom.xml
+++ b/components/spring-postgresql-event-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory.java
+++ b/components/spring-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/ApplicationTests.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/ApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/OrderAggregateRootRepositoryTest.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/OrderAggregateRootRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/OrderAggregateRootRepositoryTest.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/OrderAggregateRootRepositoryTest.java
@@ -27,6 +27,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.spring.test_data.Order;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.spring.test_data.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
@@ -108,9 +109,9 @@ abstract class OrderAggregateRootRepositoryTest {
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
                                                                                        eventMapper,
-                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfigurationUsingJackson(createObjectMapper(),
-                                                                                                                                                                                                  IdentifierColumnType.UUID,
-                                                                                                                                                                                                  JSONColumnType.JSONB));
+                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                                                      JSONColumnType.JSONB));
 
         eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
                                                 persistenceStrategy);

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryTest.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryTest.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/CustomerId.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/Order.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderEvent.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderId.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderState.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/ProductId.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/resources/logback-test.xml
+++ b/components/spring-postgresql-event-store/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/pom.xml
+++ b/components/springdata-mongo-distributed-fenced-lock/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManager.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerBuilder.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockStorage.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/ApplicationTests.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/ApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/resources/logback-test.xml
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -10,7 +10,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/pom.xml
+++ b/components/springdata-mongo-queue/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueueConsumer.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 
 import static dk.cloudcreate.essentials.shared.FailFast.*;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+import static dk.cloudcreate.essentials.shared.interceptor.DefaultInterceptorChain.sortInterceptorsByOrder;
 import static dk.cloudcreate.essentials.shared.interceptor.InterceptorChain.newInterceptorChainForOperation;
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -386,6 +387,7 @@ public class MongoDurableQueues implements DurableQueues {
             started = true;
             log.info("Starting");
             interceptors.forEach(durableQueuesInterceptor -> durableQueuesInterceptor.setDurableQueues(this));
+            sortInterceptorsByOrder(interceptors);
             durableQueueConsumers.values().forEach(MongoDurableQueueConsumer::start);
             startCollectionListener();
             log.info("Started");
@@ -478,6 +480,7 @@ public class MongoDurableQueues implements DurableQueues {
         log.info("Adding interceptor: {}", interceptor);
         interceptor.setDurableQueues(this);
         interceptors.add(interceptor);
+        sortInterceptorsByOrder(interceptors);
         return this;
     }
 
@@ -486,6 +489,7 @@ public class MongoDurableQueues implements DurableQueues {
         requireNonNull(interceptor, "No interceptor provided");
         log.info("Removing interceptor: {}", interceptor);
         interceptors.remove(interceptor);
+        sortInterceptorsByOrder(interceptors);
         return this;
     }
 

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -853,7 +853,7 @@ public class MongoDurableQueues implements DurableQueues {
                                                        log.debug("Deleted Message with id '{}'", queueEntryId);
                                                        return true;
                                                    } else {
-                                                       log.error("Failed to Delete Message with id '{}'", queueEntryId);
+                                                       log.error("Couldn't Delete Message with id '{}' - it may already have been deleted", queueEntryId);
                                                        return false;
                                                    }
                                                }).proceed();

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -615,7 +615,7 @@ public class MongoDurableQueues implements DurableQueues {
     private Object deserializeMessagePayload(QueueName queueName, byte[] messagePayload, String messagePayloadType) {
         try {
             return jsonSerializer.deserialize(messagePayload, Classes.forName(messagePayloadType));
-        } catch (JSONDeserializationException e) {
+        } catch (Throwable e) {
             throw new DurableQueueException(msg("Failed to deserialize message payload of type {}", messagePayloadType), e, queueName);
         }
     }

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ApplicationTests.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBusIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBusIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBus_withSingleOperationTransactionIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBus_withSingleOperationTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIndexIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/resources/logback-test.xml
+++ b/components/springdata-mongo-queue/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -46,7 +46,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/immutable-jackson/pom.xml
+++ b/immutable-jackson/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModule.java
+++ b/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/ImmutableObjectsValueInstantiator.java
+++ b/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/ImmutableObjectsValueInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModuleTest.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/AccountId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/CustomerId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableOrder.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableSerializationTestSubject.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableSerializationTestSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/OrderId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductIdKeyDeserializer.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/Quantity.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -18,7 +18,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/immutable/pom.xml
+++ b/immutable/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/immutable/src/main/java/dk/cloudcreate/essentials/immutable/Immutable.java
+++ b/immutable/src/main/java/dk/cloudcreate/essentials/immutable/Immutable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/main/java/dk/cloudcreate/essentials/immutable/ImmutableValueObject.java
+++ b/immutable/src/main/java/dk/cloudcreate/essentials/immutable/ImmutableValueObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/main/java/dk/cloudcreate/essentials/immutable/annotations/Exclude.java
+++ b/immutable/src/main/java/dk/cloudcreate/essentials/immutable/annotations/Exclude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/ImmutableValueObjectTest.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/ImmutableValueObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/AccountId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/CustomerId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ImmutableOrder.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ImmutableOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/OrderId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ProductId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/Quantity.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -66,27 +66,27 @@
 
         <objenesis.version>3.3</objenesis.version>
         <postgresql.version>42.7.1</postgresql.version>
-        <slf4j.version>2.0.10</slf4j.version>
-        <spring-boot.version>3.1.7</spring-boot.version>
+        <slf4j.version>2.0.11</slf4j.version>
+        <spring-boot.version>3.1.8</spring-boot.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <spring-data-mongodb.version>4.1.7</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.1.7</spring-data-jpa.version>
+        <spring-data-mongodb.version>4.1.8</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.1.8</spring-data-jpa.version>
         <objenesis.version>3.3</objenesis.version>
-        <assertj.version>3.25.1</assertj.version>
+        <assertj.version>3.25.3</assertj.version>
         <mongodb-driver-sync.version>4.11.1</mongodb-driver-sync.version>
         <log4j-to-slf4j.version>2.22.1</log4j-to-slf4j.version>
         <json-smart.version>2.5.0</json-smart.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <micrometer.version>1.12.1</micrometer.version>
-        <micrometer-tracing.version>1.2.1</micrometer-tracing.version>
-        <netty-bom.version>4.1.104.Final</netty-bom.version>
-        <junit-bom.version>5.10.1</junit-bom.version>
-        <testcontainers-bom.version>1.19.3</testcontainers-bom.version>
-        <jdbi3-bom.version>3.43.0</jdbi3-bom.version>
+        <micrometer.version>1.12.2</micrometer.version>
+        <micrometer-tracing.version>1.2.2</micrometer-tracing.version>
+        <netty-bom.version>4.1.106.Final</netty-bom.version>
+        <junit-bom.version>5.10.2</junit-bom.version>
+        <testcontainers-bom.version>1.19.4</testcontainers-bom.version>
+        <jdbi3-bom.version>3.44.0</jdbi3-bom.version>
         <jackson-bom.version>2.16.1</jackson-bom.version>
-        <reactor-bom.version>2023.0.1</reactor-bom.version>
-        <spring-framework-bom.version>6.0.15</spring-framework-bom.version>
-        <mockito-bom.version>5.8.0</mockito-bom.version>
+        <reactor-bom.version>2023.0.2</reactor-bom.version>
+        <spring-framework-bom.version>6.0.16</spring-framework-bom.version>
+        <mockito-bom.version>5.10.0</mockito-bom.version>
         <logback.version>1.4.14</logback.version>
 
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
@@ -99,14 +99,14 @@
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-        <maven-failsafe-plugin.version>3.2.3</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>9.0.8</dependency-check-maven.version>
-        <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+        <dependency-check-maven.version>9.0.9</dependency-check-maven.version>
+        <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
     </properties>
@@ -250,6 +250,30 @@
     </distributionManagement>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>${maven.multiModuleProjectDirectory}</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE.txt</include>
+                </includes>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>${maven.multiModuleProjectDirectory}</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE.txt</include>
+                </includes>
+            </testResource>
+        </testResources>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -291,27 +315,56 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin.version}</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <License>Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt</License>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${maven-source-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <configuration>
+                                <archive>
+                                    <manifestEntries>
+                                        <License>Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt</License>
+                                    </manifestEntries>
+                                </archive>
+                            </configuration>
+                        </execution>
+                    </executions>
+
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin.version}</version>
-                    <configuration>
-                        <doclint>none</doclint>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>
                             <goals>
                                 <goal>jar</goal>
                             </goals>
+                            <configuration>
+                                <doclint>none</doclint>
+                                <archive>
+                                    <manifestEntries>
+                                        <License>Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt</License>
+                                    </manifestEntries>
+                                </archive>
+                            </configuration>
                         </execution>
                     </executions>
+
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -481,29 +534,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <doclint>none</doclint>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -515,29 +549,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <doclint>none</doclint>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -14,7 +14,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/reactive/pom.xml
+++ b/reactive/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/Handler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/LocalEventBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/LocalEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/OnErrorHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/OnErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/PublishException.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/PublishException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+import static dk.cloudcreate.essentials.shared.interceptor.DefaultInterceptorChain.sortInterceptorsByOrder;
 
 /**
  * Base implementation of the {@link CommandBus} - provides default implementation for all
@@ -69,6 +70,7 @@ public abstract class AbstractCommandBus implements CommandBus {
             log.info("Adding CommandBusInterceptor: {}", interceptor);
             interceptors.add(requireNonNull(interceptor, "No interceptor provided"));
         }
+        sortInterceptorsByOrder(this.interceptors);
         return this;
     }
 
@@ -81,6 +83,7 @@ public abstract class AbstractCommandBus implements CommandBus {
     public CommandBus removeInterceptor(CommandBusInterceptor interceptor) {
         log.info("Removing CommandBusInterceptor: {}", interceptor);
         interceptors.remove(requireNonNull(interceptor, "No interceptor provided"));
+        sortInterceptorsByOrder(this.interceptors);
         return this;
     }
 

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CmdHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CmdHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/MultipleCommandHandlersFoundException.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/MultipleCommandHandlersFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/NoCommandHandlerFoundException.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/NoCommandHandlerFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendAndDontWaitErrorHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendAndDontWaitErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendCommandException.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendCommandException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptor.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptorChain.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptorChain.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptorChain.java
@@ -87,7 +87,7 @@ public interface CommandBusInterceptorChain {
          *
          * @param command                     the command instance
          * @param matchedCommandHandler       the single {@link CommandHandler} the responded true to {@link CommandHandler#canHandle(Class)}
-         * @param interceptors                the {@link CommandBusInterceptor}'s (can be an empty List if no interceptors have been configured)
+         * @param interceptors                the ordered {@link CommandBusInterceptor}'s (can be an empty List if no interceptors have been configured)
          * @param interceptorOperationInvoker the function responsible for calling the correct {@link CommandBusInterceptor} <code>send</code> method
          * @param defaultCommandBusBehaviour  the function invoking the default {@link LocalCommandBus} <code>send</code> method logic
          */

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/AsyncEventHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/AsyncEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessor.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandlerTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/LocalEventBusTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/LocalEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandlerTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBusTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/interceptor/DefaultCommandBusInterceptorChainTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/interceptor/DefaultCommandBusInterceptorChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessorTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersConfiguration.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/resources/logback-test.xml
+++ b/reactive/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/shared/README.md
+++ b/shared/README.md
@@ -14,7 +14,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/Exceptions.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/Exceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/FailFast.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/FailFast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/MessageFormatter.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/MessageFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Lists.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Lists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Streams.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Streams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/concurrent/ThreadFactoryBuilder.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/concurrent/ThreadFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumer.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedExceptionRethrownException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedExceptionRethrownException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnable.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplier.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/TripleFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/TripleFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Either.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Either.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Empty.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Empty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Pair.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Single.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Triple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Triple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Tuple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableEmpty.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparablePair.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparablePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableSingle.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTriple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTriple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTuple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChain.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChain.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChain.java
@@ -42,7 +42,7 @@ public class DefaultInterceptorChain<OPERATION, RESULT, INTERCEPTOR_TYPE extends
      * Create a new {@link InterceptorChain} instance for the provided <code>operation</code>
      *
      * @param operation                the operation to intercept, aka. the argument to the interceptor
-     * @param interceptors             the {@link Interceptor}'s (can be an empty List if no interceptors have been configured)
+     * @param interceptors             the ordered {@link Interceptor}'s (can be an empty List if no interceptors have been configured)
      * @param interceptorMethodInvoker the function that's responsible for invoking the matching {@link Interceptor} method
      * @param defaultBehaviour         the default behaviour for the given <code>operation</code> in case none of the interceptors provided a different result and stopped the interceptor chain
      */
@@ -54,6 +54,21 @@ public class DefaultInterceptorChain<OPERATION, RESULT, INTERCEPTOR_TYPE extends
         this.interceptorIterator = requireNonNull(interceptors, "No interceptors provided").iterator();
         this.interceptorMethodInvoker = requireNonNull(interceptorMethodInvoker, "No interceptorMethodInvoker provided");
         this.defaultBehaviour = requireNonNull(defaultBehaviour, "No defaultBehaviour supplier provided");
+    }
+
+    /**
+     * Order the interceptors according to the specified {@link InterceptorOrder} annotation (if the annotation is left out
+     * then the default order is 10)
+     *
+     * @param interceptors       the list of interceptors that should be ordered (expects a mutable list that can be reordered)
+     * @param <INTERCEPTOR_TYPE> the type of interceptor contained in the list
+     * @return the <code>interceptors</code> parameter after it has been reordered
+     */
+    public static <INTERCEPTOR_TYPE> List<INTERCEPTOR_TYPE> sortInterceptorsByOrder(List<INTERCEPTOR_TYPE> interceptors) {
+        interceptors.sort(Comparator.comparingInt(interceptor ->
+                                                          interceptor.getClass().getAnnotation(InterceptorOrder.class) != null ?
+                                                          interceptor.getClass().getAnnotation(InterceptorOrder.class).value() : 10));
+        return interceptors;
     }
 
     @Override

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/Interceptor.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/Interceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorChain.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.shared.interceptor;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InterceptorOrder {
+    /**
+     * The interceptor order. The lower the number the higher the priority.<br>
+     * An interceptor with order 1 will be invoked before an interceptor with order 10.
+     * @return
+     */
+    int value() default 10;
+}

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/ElseIfExpression.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/ElseIfExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfExpression.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfPredicate.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfThenElseLogic.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfThenElseLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/AbstractMessageTemplate.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/AbstractMessageTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/Message.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/Message.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/Message.java
@@ -18,7 +18,7 @@ package dk.cloudcreate.essentials.shared.messages;
 
 import java.io.Serializable;
 import java.text.MessageFormat;
-import java.util.List;
+import java.util.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -60,7 +60,7 @@ public class Message implements Serializable {
      */
     public Message(MessageTemplate template, Object... parameters) {
         this.template = requireNonNull(template, "No template provided");
-        this.parameters = List.of(requireNonNull(parameters, "No parameters provided"));
+        this.parameters = Arrays.asList(requireNonNull(parameters, "No parameters provided"));
         this.message = MessageFormat.format(template.getDefaultMessage(),
                                             parameters);
     }

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate0.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate1.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate2.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate3.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate4.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplates.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/network/Network.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/network/Network.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Accessibles.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Accessibles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/BoxedTypes.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/BoxedTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Classes.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Classes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Constructors.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Constructors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Fields.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Fields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/GetFieldException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/GetFieldException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Interfaces.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Interfaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/LoadingClassFailedException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/LoadingClassFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/MethodInvocationFailedException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/MethodInvocationFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Methods.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Methods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoFieldFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoFieldFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoMatchingMethodFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoMatchingMethodFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Parameters.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/ReflectionException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/ReflectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Reflector.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Reflector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/SetFieldException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/SetFieldException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingFieldsFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingFieldsFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingMethodsFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingMethodsFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationStrategy.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/MethodPatternMatcher.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/MethodPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/NoMatchingMethodsHandler.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/NoMatchingMethodsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/SingleArgumentAnnotatedMethodPatternMatcher.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/SingleArgumentAnnotatedMethodPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/time/StopWatch.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/time/StopWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/time/Timing.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/time/Timing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/time/TimingWithResult.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/time/TimingWithResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/types/GenericType.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/types/GenericType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/MessageFormatterTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/MessageFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/ListsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/ListsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/StreamsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/StreamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunctionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumerTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedFunctionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnableTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplierTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunctionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/PairTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/PairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/TupleTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/TupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTupleTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChainTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChainTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChainTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.shared.interceptor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultInterceptorChainTest {
+    @Test
+    void verifyInterceptorOrdering() {
+        var defaultOrder = new DefaultOrderInterceptor();
+        var defaultOrder2 = new DefaultOrder2Interceptor();
+        var interceptors = new ArrayList<>(List.of(new LowImportanceInterceptor(),
+                                                   defaultOrder2,
+                                                   new MostImportantInterceptor(),
+                                                   defaultOrder,
+                                                   new MediumImportantInterceptor()));
+
+        DefaultInterceptorChain.sortInterceptorsByOrder(interceptors);
+
+        assertThat(interceptors.get(0)).isInstanceOf(MostImportantInterceptor.class);
+        assertThat(interceptors.get(1)).isInstanceOf(MediumImportantInterceptor.class);
+        assertThat(interceptors.get(2)).isIn(defaultOrder, defaultOrder2);
+        assertThat(interceptors.get(3)).isIn(defaultOrder, defaultOrder2);
+        assertThat(interceptors.get(2)).isNotEqualTo(interceptors.get(3));
+        assertThat(interceptors.get(4)).isInstanceOf(LowImportanceInterceptor.class);
+    }
+
+    @InterceptorOrder(1)
+    static class MostImportantInterceptor implements Interceptor {
+
+    }
+
+    @InterceptorOrder(5)
+    static class MediumImportantInterceptor implements Interceptor {
+
+    }
+
+    @InterceptorOrder
+    static class DefaultOrderInterceptor implements Interceptor {
+
+    }
+
+    static class DefaultOrder2Interceptor implements Interceptor {
+
+    }
+
+    @InterceptorOrder(20)
+    static class LowImportanceInterceptor implements Interceptor {
+
+    }
+
+}

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/logic/IfExpressionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/logic/IfExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MessageTemplatesTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MessageTemplatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MyMessageTemplates.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MyMessageTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ClassesTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ConstructorsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ConstructorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/FieldsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/FieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/InterfacesTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/InterfacesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/MethodsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/MethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ParametersTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ReflectorTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ReflectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvokerTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvokerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker_with_MessageHandlerTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker_with_MessageHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/EventHandler.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/Message.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandler.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithoutFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithoutFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderAccepted.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderAccepted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCancelled.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCancelled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCreated.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCreated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEvent.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithoutFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithoutFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseInterface.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseTestReflectionClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseTestReflectionClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/ConcreteClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/ConcreteClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericInterface.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestInterface.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestReflectionClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestReflectionClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/time/StopWatchTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/time/StopWatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/types/GenericTypeTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/types/GenericTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/types/TestSubject.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/types/TestSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/resources/logback-test.xml
+++ b/shared/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -14,7 +14,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/types-avro/pom.xml
+++ b/types-avro/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseBigDecimalTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseBigDecimalTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseCharSequenceConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseCharSequenceConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseDoubleTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseDoubleTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseFloatTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseFloatTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseInstantTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseInstantTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseIntegerTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseIntegerTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLongTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLongTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseOffsetDateTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseOffsetDateTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseZonedDateTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseZonedDateTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BigDecimalTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BigDecimalTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CharSequenceTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CharSequenceTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/DoubleTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/DoubleTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/FloatTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/FloatTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/InstantTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/InstantTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/IntegerTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/IntegerTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/OffsetDateTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/OffsetDateTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/SingleConcreteBigDecimalTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/SingleConcreteBigDecimalTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/ZonedDateTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/ZonedDateTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/package-info.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/Created.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/DueDate.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/LastUpdated.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/OrderId.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TimeOfDay.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransactionTime.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransferTime.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/test/java/dk/cloudcreate/essentials/types/avro/CustomConversionsTest.java
+++ b/types-avro/src/test/java/dk/cloudcreate/essentials/types/avro/CustomConversionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -20,7 +20,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/types-jackson/pom.xml
+++ b/types-jackson/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/CharSequenceTypeJsonSerializer.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/CharSequenceTypeJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/EssentialTypesJacksonModule.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/EssentialTypesJacksonModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/MoneyDeserializer.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/MoneyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/NumberTypeJsonSerializer.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/NumberTypeJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/EssentialTypesJacksonModuleTest.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/EssentialTypesJacksonModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/AccountId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Created.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/CustomerId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/DueDate.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/LastUpdated.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/OrderId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductIdKeyDeserializer.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Quantity.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/SerializationTestSubject.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/SerializationTestSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TimeOfDay.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransactionTime.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransferTime.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -19,7 +19,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/types-jdbi/pom.xml
+++ b/types-jdbi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeColumnMapper.java
@@ -35,16 +35,16 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  *
  * @param <T> the concrete {@link LocalDateType} this instance is mapping
  */
-public abstract class LocalDateColumnMapper<T extends LocalDateType<T>> implements ColumnMapper<T> {
+public abstract class LocalDateTypeColumnMapper<T extends LocalDateType<T>> implements ColumnMapper<T> {
     private final Class<T> concreteType;
 
     @SuppressWarnings("unchecked")
-    public LocalDateColumnMapper() {
+    public LocalDateTypeColumnMapper() {
         concreteType = (Class<T>) GenericType.resolveGenericTypeOnSuperClass(this.getClass(),
                                                                              0);
     }
 
-    public LocalDateColumnMapper(Class<T> concreteType) {
+    public LocalDateTypeColumnMapper(Class<T> concreteType) {
         this.concreteType = requireNonNull(concreteType, "No concreteType provided");
     }
 

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/Created.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDate.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateColumnMapper.java
@@ -16,7 +16,7 @@
 
 package dk.cloudcreate.essentials.types.jdbi.model;
 
-import dk.cloudcreate.essentials.types.jdbi.LocalDateColumnMapper;
+import dk.cloudcreate.essentials.types.jdbi.LocalDateTypeColumnMapper;
 
-public class DueDateColumnMapper extends LocalDateColumnMapper<DueDate> {
+public class DueDateColumnMapper extends LocalDateTypeColumnMapper<DueDate> {
 }

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdated.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDay.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTime.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTime.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/resources/logback-test.xml
+++ b/types-jdbi/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -20,7 +20,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/types-spring-web/pom.xml
+++ b/types-spring-web/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-spring-web/src/main/java/dk/cloudcreate/essentials/types/spring/web/SingleValueTypeConverter.java
+++ b/types-spring-web/src/main/java/dk/cloudcreate/essentials/types/spring/web/SingleValueTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxConfig.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxControllerIT.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxControllerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcConfig.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcControllerTest.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcSpringWebApplication.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcSpringWebApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebFluxController.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebFluxController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebMvcController.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebMvcController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/AccountId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Created.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/CustomerId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/DueDate.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/LastUpdated.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Order.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/OrderId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductIdKeyDeserializer.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Quantity.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TimeOfDay.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransactionTime.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransferTime.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/resources/logback-test.xml
+++ b/types-spring-web/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -12,7 +12,7 @@ many of the most popular libraries and frameworks such as Jackson, Spring Boot, 
 This library focuses purely on providing [Spring Data JPA](https://spring.io/projects/spring-data-jpa) persistence support for the **types** defined in the
 Essentials `types` library.
 
-> Warning: Not ready for production use !!!
+> Warning: This module is very experimental & unstable
 
 To use `Types-SpringData-JPA` just add the following Maven dependency:
 ```
@@ -50,11 +50,6 @@ public class Order {
     public OrderId    id;
     public CustomerId customerId;
     public AccountId  accountId;
-    
-    @ElementCollection
-    @Column(name = "quantity")
-    @CollectionTable(name = "order_lines")
-    public  Map<ProductId, Quantity> orderLines;
     
     ...
 }

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/pom.xml
+++ b/types-springdata-jpa/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AmountAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AmountAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseBigDecimalTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseBigDecimalTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseByteTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseByteTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseCharSequenceTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseCharSequenceTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseDoubleTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseDoubleTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseFloatTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseFloatTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseInstantTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseInstantTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseIntegerTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseIntegerTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLongTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLongTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseOffsetDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseOffsetDateTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseShortTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseShortTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseZonedDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseZonedDateTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CountryCodeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CountryCodeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CurrencyCodeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CurrencyCodeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/EmailAddressAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/EmailAddressAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/PercentageAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/PercentageAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
@@ -31,7 +31,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
 
 import java.time.temporal.ChronoUnit;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -73,9 +72,9 @@ class OrderRepositoryIT {
         var storedOrder = transactionTemplate.execute(status -> orderRepository.save(new Order(OrderId.random(),
                                                                                                CustomerId.random(),
                                                                                                AccountId.random(),
-                                                                                               Map.of(ProductId.random(), Quantity.of(10),
-                                                                                                      ProductId.random(), Quantity.of(5),
-                                                                                                      ProductId.random(), Quantity.of(1)),
+//                                                                                               Map.of(ProductId.random(), Quantity.of(10),
+//                                                                                                      ProductId.random(), Quantity.of(5),
+//                                                                                                      ProductId.random(), Quantity.of(1)),
                                                                                                amount,
                                                                                                percentage,
                                                                                                currencyCode,
@@ -119,7 +118,9 @@ class OrderRepositoryIT {
             assertThat(actualOrder.getId().value()).isEqualTo(storedOrder.getId().value());
             assertThat((CharSequence) actualOrder.getCustomerId()).isEqualTo(storedOrder.getCustomerId());
             assertThat(actualOrder.getAccountId()).isEqualTo(storedOrder.getAccountId());
-            assertThat(actualOrder.getOrderLines()).isEqualTo(storedOrder.getOrderLines());
+//            assertThat(actualOrder.orderLines.size()).isEqualTo(3);
+//            assertThat(actualOrder.orderLines.keySet()).doesNotContainNull();
+//            assertThat(actualOrder.getOrderLines()).isEqualTo(storedOrder.getOrderLines());
             assertThat(actualOrder.getAmount()).isEqualTo(storedOrder.getAmount());
             assertThat(actualOrder.getPercentage()).isEqualTo(storedOrder.getPercentage());
             assertThat((CharSequence) actualOrder.getCountry()).isEqualTo(storedOrder.getCountry());

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
@@ -63,8 +63,11 @@ class ProductRepositoryIT {
     @Test
     void test_we_can_store_a_product_and_load_it_again() {
         var storedProduct = transactionTemplate.execute(status -> productRepository.save(new Product(ProductId.random(),
-                                                                              "Test Product",
-                                                                              new Price(Amount.of("100.5"), CurrencyCode.of("DKK")))));
+                                                                                                     "Test Product",
+                                                                                                     new Price(Amount.of("100.5"), CurrencyCode.of("DKK")),
+                                                                                                     OrderId.random())));
+
+        assertThat(productRepository.findById(storedProduct.getId()).get()).isEqualTo(storedProduct);
 
         var jdbi = Jdbi.create(postgreSQLContainer.getJdbcUrl(), postgreSQLContainer.getUsername(), postgreSQLContainer.getPassword());
         var rawResults = jdbi.withHandle(handle -> handle.createQuery("select * from products")
@@ -85,7 +88,6 @@ class ProductRepositoryIT {
             }
         });
         softAssertions.assertAll();
-
 
 
         transactionTemplate.execute(status -> {

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/TypesSpringDataJpaApplicationTests.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/TypesSpringDataJpaApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AccountIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AccountIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CreatedAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CreatedAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CustomerIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CustomerIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/DueDateAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/DueDateAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/LastUpdatedAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/LastUpdatedAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/OrderIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/OrderIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/ProductIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/ProductIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/QuantityAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/QuantityAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TimeOfDayAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TimeOfDayAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransactionTimeAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransactionTimeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransferTimeAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransferTimeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/AccountId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Created.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/CustomerId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/DueDate.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/LastUpdated.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
@@ -19,19 +19,24 @@ package dk.cloudcreate.essentials.types.springdata.jpa.model;
 import dk.cloudcreate.essentials.types.*;
 import jakarta.persistence.*;
 
-import java.util.*;
+import java.util.Objects;
 
 @Entity
 @Table(name = "orders")
 public class Order {
     @EmbeddedId
-    public OrderId    id;
-    public CustomerId customerId;
+    @Column(name = "order_id") // Aligned with the generated column name from the embeddable id
+    public  OrderId                  id;
+    public  CustomerId               customerId;
     public  AccountId                accountId;
-    @ElementCollection
-    @Column(name = "quantity")
-    @CollectionTable(name = "order_lines")
-    public  Map<ProductId, Quantity> orderLines;
+    /**
+     * Does not work at the moment
+//     */
+//    @ElementCollection(fetch = FetchType.EAGER)
+//    @MapKeyColumn(name = "product_id")
+//    @Column(name = "quantity")
+//    @CollectionTable(name = "order_lines")
+//    public  Map<ProductId, Quantity> orderLines;
     private Amount                   amount;
     private Percentage               percentage;
 
@@ -41,28 +46,30 @@ public class Order {
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name="amount", column=@Column(name="total_price_amount")),
-            @AttributeOverride(name="currency", column=@Column(name="total_price_currency"))
+            @AttributeOverride(name = "amount", column = @Column(name = "total_price_amount")),
+            @AttributeOverride(name = "currency", column = @Column(name = "total_price_currency"))
     })
     private Money totalPrice;
 
     // Dates
-    private Created created;
-    private DueDate dueDate;
-    private LastUpdated lastUpdated;
-    private TimeOfDay timeOfDay;
+    private Created         created;
+    private DueDate         dueDate;
+    private LastUpdated     lastUpdated;
+    private TimeOfDay       timeOfDay;
     private TransactionTime transactionTime;
-    private TransferTime transferTime;
+    private TransferTime    transferTime;
 
     public Order() {
     }
 
-    public Order(OrderId id, CustomerId customerId, AccountId accountId, Map<ProductId, Quantity> orderLines, Amount amount, Percentage percentage,
+    public Order(OrderId id, CustomerId customerId, AccountId accountId,
+//                 Map<ProductId, Quantity> orderLines,
+                 Amount amount, Percentage percentage,
                  CurrencyCode currency, CountryCode country, EmailAddress email, Money totalPrice, Created created, DueDate dueDate, LastUpdated lastUpdated, TimeOfDay timeOfDay, TransactionTime transactionTime, TransferTime transferTime) {
         this.id = id;
         this.customerId = customerId;
         this.accountId = accountId;
-        this.orderLines = orderLines;
+//        this.orderLines = orderLines;
         this.amount = amount;
         this.percentage = percentage;
         this.currency = currency;
@@ -97,13 +104,13 @@ public class Order {
         this.accountId = accountId;
     }
 
-    public Map<ProductId, Quantity> getOrderLines() {
-        return orderLines;
-    }
-
-    public void setOrderLines(Map<ProductId, Quantity> orderLines) {
-        this.orderLines = orderLines;
-    }
+//    public Map<ProductId, Quantity> getOrderLines() {
+//        return orderLines;
+//    }
+//
+//    public void setOrderLines(Map<ProductId, Quantity> orderLines) {
+//        this.orderLines = orderLines;
+//    }
 
     public Amount getAmount() {
         return amount;
@@ -206,12 +213,12 @@ public class Order {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Order order = (Order) o;
-        return Objects.equals(id, order.id) && Objects.equals(customerId, order.customerId) && Objects.equals(accountId, order.accountId) && Objects.equals(orderLines, order.orderLines) && Objects.equals(amount, order.amount) && Objects.equals(percentage, order.percentage) && Objects.equals(currency, order.currency) && Objects.equals(country, order.country) && Objects.equals(email, order.email) && Objects.equals(totalPrice, order.totalPrice) && Objects.equals(created, order.created) && Objects.equals(dueDate, order.dueDate) && Objects.equals(lastUpdated, order.lastUpdated) && Objects.equals(timeOfDay, order.timeOfDay) && Objects.equals(transactionTime, order.transactionTime) && Objects.equals(transferTime, order.transferTime);
+        return Objects.equals(id, order.id) && Objects.equals(customerId, order.customerId) && Objects.equals(accountId, order.accountId) && /*Objects.equals(orderLines, order.orderLines) &&*/ Objects.equals(amount, order.amount) && Objects.equals(percentage, order.percentage) && Objects.equals(currency, order.currency) && Objects.equals(country, order.country) && Objects.equals(email, order.email) && Objects.equals(totalPrice, order.totalPrice) && Objects.equals(created, order.created) && Objects.equals(dueDate, order.dueDate) && Objects.equals(lastUpdated, order.lastUpdated) && Objects.equals(timeOfDay, order.timeOfDay) && Objects.equals(transactionTime, order.transactionTime) && Objects.equals(transferTime, order.transferTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, customerId, accountId, orderLines, amount, percentage, currency, country, email, totalPrice, created, dueDate, lastUpdated, timeOfDay, transactionTime, transferTime);
+        return Objects.hash(id, customerId, accountId, /*orderLines,*/ amount, percentage, currency, country, email, totalPrice, created, dueDate, lastUpdated, timeOfDay, transactionTime, transferTime);
     }
 
     @Override
@@ -220,7 +227,7 @@ public class Order {
                 "id=" + id +
                 ", customerId=" + customerId +
                 ", accountId=" + accountId +
-                ", orderLines=" + orderLines +
+//                ", orderLines=" + orderLines +
                 ", amount=" + amount +
                 ", percentage=" + percentage +
                 ", currency=" + currency +

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderRepository.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderRepository.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderRepository.java
@@ -16,7 +16,7 @@
 
 package dk.cloudcreate.essentials.types.springdata.jpa.model;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends CrudRepository<Order, OrderId> {
+public interface OrderRepository extends JpaRepository<Order, OrderId> {
 }

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Price.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Price.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
@@ -25,23 +25,29 @@ import java.util.Objects;
 @Table(name = "products")
 public class Product {
     @EmbeddedId
+    @Column(name = "product_id")  // Aligned with the generated column name from the embeddable id
     private ProductId id;
     private String    name;
     @Embedded
     private Price     price;
+    private OrderId   orderId;
 
     public Product() {
     }
 
-    public Product(ProductId id, String name, Price price) {
+    public Product(ProductId id, String name, Price price, OrderId orderId) {
         this.id = id;
         this.name = name;
         this.price = price;
+        this.orderId = orderId;
     }
 
-    public Product(String name, Price price) {
-        this.name = name;
-        this.price = price;
+    public OrderId getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(OrderId orderId) {
+        this.orderId = orderId;
     }
 
     public ProductId getId() {
@@ -67,13 +73,12 @@ public class Product {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Product product = (Product) o;
-        return Objects.equals(id, product.id) && Objects.equals(name, product.name) && Objects.equals(price, product.price);
+        if (!(o instanceof Product product)) return false;
+        return Objects.equals(id, product.id) && Objects.equals(name, product.name) && Objects.equals(price, product.price) && Objects.equals(orderId, product.orderId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, price);
+        return Objects.hash(id, name, price, orderId);
     }
 }

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductRepository.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Quantity.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TimeOfDay.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransactionTime.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransferTime.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/resources/logback-test.xml
+++ b/types-springdata-jpa/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -19,7 +19,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/pom.xml
+++ b/types-springdata-mongo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeConverter.java
+++ b/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeRandomIdGenerator.java
+++ b/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeRandomIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/TypesSpringDataMongoApplicationTests.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/TypesSpringDataMongoApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/AccountId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Created.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/CustomerId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/DueDate.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/LastUpdated.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Order.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderRepository.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Price.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Price.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Product.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductRepository.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Quantity.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/TimeOfDay.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/resources/logback-test.xml
+++ b/types-springdata-mongo/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types/README.md
+++ b/types/README.md
@@ -20,7 +20,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.30.5</version>
+    <version>0.30.6</version>
 </dependency>
 ```
 

--- a/types/pom.xml
+++ b/types/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Amount.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Amount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/BigDecimalType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/BigDecimalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/BigIntegerType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/BigIntegerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/ByteType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/ByteType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/CharSequenceType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/CharSequenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/CountryCode.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/CountryCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/CurrencyCode.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/CurrencyCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/DoubleType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/DoubleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/EmailAddress.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/EmailAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/FloatType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/FloatType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Identifier.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Identifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/InstantType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/InstantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/IntegerType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/IntegerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/JSR310SingleValueType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/JSR310SingleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LocalTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LocalTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LongRange.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LongRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LongType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LongType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Money.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Money.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/NumberType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/NumberType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/OffsetDateTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/OffsetDateTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Percentage.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Percentage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/ShortType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/ShortType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/SingleValueType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/SingleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/TimeWindow.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/TimeWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/ZonedDateTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/ZonedDateTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/AmountTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/AmountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/CharSequenceTypeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/CharSequenceTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/CountryCodeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/CountryCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/CurrencyCodeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/CurrencyCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/DateTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/DateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/EmailAddressTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/EmailAddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/LongRangeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/LongRangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/LongTypeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/LongTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/MoneyTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/MoneyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/PercentageTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/PercentageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/SingleValueTypeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/SingleValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/TimeWindowTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/TimeWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/Created.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/DueDate.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/LastUpdated.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/TimeOfDay.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransactionTime.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransferTime.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/AccountId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/CustomerId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/MessageId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/MessageId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/OrderId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/ProductId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/TransactionId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/TransactionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/resources/logback-test.xml
+++ b/types/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/versions-update-rules.xml
+++ b/versions-update-rules.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2023 the original author or authors.
+  ~ Copyright 2021-2024 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
# General
- Root README.md updates
- Refined maven plugin configuration

## JSONSerializer cross module changes
- Changed all classes to depend on either `JSONSerializer` or `JSONEventSerializer` instead of allow `ObjectMapper` as input parameter
- Changed the default spring-boot-starters (Postgresql, EventStore and MongoDB) to encapsulate the `ObjectMapper` used by Essentials for `DurableQueues` message and `EventStore` `Event` JSON serialization.
  - Instead the spring-boot-starter configures a `JacksonJSONSerializer` (Postgresql/MongoDB) or `JacksonJSONEventSerializer` (EventStore)
  - The `EssentialTypesJacksonModule` is now defined as a `@Bean` such that it applies to the default `ObjectMapper`

# Module changes

## shared
- Switched from `List.of` to `Arrays.asList()` in `Message` to support null arguments in the array
- Introduced the concept of `InterceptorOrder` to control in which order an Interceptor is invoked

## types-jdbi
- Renamed `LocalDateColumnMapper` to `LocalDateTypeColumnMapper` 

## types-springdata-jpa
- **Added more clear warning that the types-jpa module is very experimental & unstable**
- Adjusted JPA tests - commented out `@ElementCollection` of `Order`'s `Map<ProductId, Quantity> orderLines` code as it doesn't work

## foundation
- Removed explicit call to `DurableQueues#acknowledgeMessageAsHandled` in `DurableLocalCommandBus#processSendAndDontWaitMessage` as this is already handled by the `DurableQueueConsumer`
- Added `InterceptorOrder` annotation to `UnitOfWorkControllingCommandBusInterceptor`
- Added support for delayed message sending in `Inbox` and `Outbox`
- Changed `JacksonJSONSerializer` to catch `Throwable` to catch deserialization errors such as `NoClassDefFoundError`
- Switched `DurableQueues` and `DefaultDurableQueueConsumer` to handle `Throwable` instead of Exception

## reactive
- Added support for `InterceptorOrder` in the `AbstractCommandBus`

## postgresql-event-store
- Added `InterceptorOrder` support to `PostgresqlEventStore` and added `UnableToExecuteStatementException` to the list of transient errors
- Added error logging to `EventProcessor` in case of JSON deserialization exception
- Added `StringValueTypeAggregateIdSerializer`
- Introduced `EventProcessorDependencies` to simplify `EventProcessor` configuration and implementations

## postgresql-queue
- Adjusted error message in `PostgresqlDurableQueues#deleteMessage`
- Added `InterceptorOrder` support to `PostgresqlDurableQueue`
- Switched `DurableQueues` and `DefaultDurableQueueConsumer` to handle `Throwable` instead of Exception

## springdata-mongo-queue
- Adjusted error message in `MongoDurableQueues#deleteMessage`
- Added `InterceptorOrder` support to `MongoDurableQueues`
- Switched `DurableQueues` and `DefaultDurableQueueConsumer` to handle `Throwable` instead of Exception

## eventsourced-aggregates
- Improved handling of eventOrderOfLastRehydratedEvent in `AggregateRoot`

## spring-boot-starter-postgresql
- Changed tracing/metric related Bean methods in `EssentialsComponentsConfiguration` to use `@ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")` instead of `@ConditionalOnEnabledTracing`. Also made all tracing/metric arguments `Optional`
- Added `additionalModules` parameter to `essentialComponentsObjectMapper` method in `EssentialsComponentsConfiguration` to include additional Jackson `Module`'s configured elsewhere
- Added support for `JdbiConfigurationCallback`

## spring-boot-starter-postgresql-event-store
- Changed tracing/metric related Bean methods in `EventStoreConfiguration` to use `@ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")` instead of `@ConditionalOnEnabledTracing`. Also made all tracing/metric arguments `Optional`
- Added `EventProcessorDependencies` `@Bean` to configuration to simplify `EventProcessor` configuration and implementations

## spring-boot-starter-mongodb
- Changed tracing/metric related Bean methods in `EssentialsComponentsConfiguration` to use `@ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")` instead of `@ConditionalOnEnabledTracing`. Also made all tracing/metric arguments `Optional`
- Added `additionalModules` parameter to `essentialComponentsObjectMapper` method in `EssentialsComponentsConfiguration` to include additional Jackson `Module`'s configured elsewhere

- Updated 3rd party dependencies:
- slf4j 2.0.11
- spring boot 3.1.8
- spring data mongodb 4.1.8
- spring data jpa 3.1.8
- micrometer 1.12.2
- micrometer-tracing 1.2.2
- netty 4.1.106.Final
- reactor 2023.0.2
- spring 6.0.16
- AssertJ 3.25.3
- Mockito 5.10.0
- testcontainers 1.19.4
- Junit 5.10.2
- jdbi 3.44.0

# Updated maven plugins:
- maven-failsafe-plugin/maven-surefire-plugin 3.2.5
- dependency-check-maven 9.0.9
- flatten-maven-plugin 1.6.0