### PR TITLE
Removed `components/kotlin-eventsourcing` as Maven module for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <objenesis.version>3.3</objenesis.version>
         <postgresql.version>42.7.1</postgresql.version>
-        <slf4j.version>2.0.11</slf4j.version>
+        <slf4j.version>2.0.12</slf4j.version>
         <spring-boot.version>3.2.2</spring-boot.version>
         <awaitility.version>4.2.0</awaitility.version>
         <spring-data-mongodb.version>4.2.2</spring-data-mongodb.version>
@@ -136,7 +136,7 @@
         <module>components/spring-postgresql-event-store</module>
         <module>components/springdata-mongo-distributed-fenced-lock</module>
         <module>components/springdata-mongo-queue</module>
-        <module>components/kotlin-eventsourcing</module>
+<!--        <module>components/kotlin-eventsourcing</module>-->
     </modules>
 
 


### PR DESCRIPTION
Updated 3rd party dependency slf4j 2.0.12

Removed `components/kotlin-eventsourcing` as Maven module for now as JavaDoc generation hasn't been setup, which is required by Maven central to release.