### PR TITLE
life cycle manager as bean

### DIFF
--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManager.java
@@ -1,0 +1,82 @@
+package dk.cloudcreate.essentials.components.foundation.lifecycle;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import dk.cloudcreate.essentials.components.foundation.Lifecycle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ApplicationContextEvent;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+public class DefaultLifecycleManager implements LifecycleManager, ApplicationListener<ApplicationContextEvent>, ApplicationContextAware {
+    public static final Logger log = LoggerFactory.getLogger(DefaultLifecycleManager.class);
+    private ApplicationContext applicationContext;
+    private boolean hasStartedLifeCycleBeans;
+    private Map<String, Lifecycle> lifeCycleBeans;
+    private final Consumer<ApplicationContext> contextRefreshedEventConsumer;
+    private final boolean isStartLifecycles;
+
+    public DefaultLifecycleManager(Consumer<ApplicationContext> contextRefreshedEventConsumer,
+                                   boolean isStartLifecycles) {
+        this.contextRefreshedEventConsumer = requireNonNull(contextRefreshedEventConsumer);
+        this.isStartLifecycles = isStartLifecycles;
+        log.info("Initializing {} with isStartLifecycles = {}", this.getClass().getSimpleName(), isStartLifecycles);
+    }
+
+    public DefaultLifecycleManager(boolean isStartLifecycles) {
+        this(event -> {}, isStartLifecycles);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationContextEvent event) {
+        if (event instanceof ContextRefreshedEvent) {
+            log.info(event.getClass().getSimpleName());
+            startLifecycleBeans();
+            contextRefreshedEventConsumer.accept(this.applicationContext);
+        } else if (event instanceof ContextClosedEvent) {
+            log.info("{} - has started life cycle beans: {}", event.getClass().getSimpleName(), hasStartedLifeCycleBeans);
+            onContextClosed();
+        }
+    }
+
+    private void onContextClosed() {
+        if (hasStartedLifeCycleBeans) {
+            lifeCycleBeans.forEach((beanName, lifecycleBean) -> {
+                if (lifecycleBean.isStarted()) {
+                    log.info("Stopping {} bean '{}' of type '{}'", Lifecycle.class.getSimpleName(), beanName, lifecycleBean.getClass().getName());
+                    lifecycleBean.stop();
+                }
+            });
+            hasStartedLifeCycleBeans = false;
+        }
+    }
+
+    private void startLifecycleBeans() {
+        if (!isStartLifecycles) {
+            log.debug("Start of lifecycle beans is disabled");
+            return;
+        }
+        hasStartedLifeCycleBeans = true;
+        lifeCycleBeans = applicationContext.getBeansOfType(Lifecycle.class);
+        lifeCycleBeans.forEach((beanName, lifecycleBean) -> {
+            if (!lifecycleBean.isStarted()) {
+                log.info("Starting {} bean '{}' of type '{}'", Lifecycle.class.getSimpleName(), beanName, lifecycleBean.getClass().getName());
+                lifecycleBean.start();
+            }
+        });
+    }
+
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/lifecycle/LifecycleManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/lifecycle/LifecycleManager.java
@@ -1,0 +1,7 @@
+package dk.cloudcreate.essentials.components.foundation.lifecycle;
+
+/**
+ * Interface that controls start and stopping of life cycle beeans
+ */
+public interface LifecycleManager {
+}

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManagerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManagerTest.java
@@ -1,0 +1,81 @@
+package dk.cloudcreate.essentials.components.foundation.lifecycle;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import dk.cloudcreate.essentials.components.foundation.Lifecycle;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DefaultLifecycleManagerTest {
+    private static final String BEAN_NAME = "beanName";
+
+    @Test
+    void startLifeCycleBeansTest() {
+        var applicationContext = mock(ApplicationContext.class);
+        var lifeCycleBean = mock(Lifecycle.class);
+        when(lifeCycleBean.isStarted()).thenReturn(false);
+        when(applicationContext.getBeansOfType(Lifecycle.class)).thenReturn(Map.of(BEAN_NAME, lifeCycleBean));
+
+        var manager = new DefaultLifecycleManager(true);
+        manager.setApplicationContext(applicationContext);
+
+        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
+        verify(lifeCycleBean).start();
+        verify(lifeCycleBean, times(0)).stop();
+
+        when(lifeCycleBean.isStarted()).thenReturn(true);
+        manager.onApplicationEvent(mock(ContextClosedEvent.class));
+        verify(lifeCycleBean).stop();
+    }
+
+    @Test
+    void lifeCycleBeanAlreadyStartedTest() {
+        var applicationContext = mock(ApplicationContext.class);
+        var lifecycleBean = mock(Lifecycle.class);
+        when(lifecycleBean.isStarted()).thenReturn(true);
+        when(applicationContext.getBeansOfType(Lifecycle.class)).thenReturn(Map.of(BEAN_NAME, lifecycleBean));
+
+        var manager = new DefaultLifecycleManager(true);
+        manager.setApplicationContext(applicationContext);
+
+        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
+        verify(lifecycleBean, times(0)).start();
+    }
+
+    @Test
+    void onContextRefreshedEventCustomConsumerTest() {
+        var applicationContext = mock(ApplicationContext.class);
+        when(applicationContext.getBeansOfType(Lifecycle.class)).thenReturn(Map.of());
+
+        Consumer<ApplicationContext> consumer = mock(Consumer.class);
+        var manager = new DefaultLifecycleManager(consumer, true);
+        manager.setApplicationContext(applicationContext);
+
+        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
+        verify(consumer).accept(applicationContext);
+    }
+
+    @Test
+    void dontStartLifeCycleBeansTest() {
+        var applicationContext = mock(ApplicationContext.class);
+        var manager = new DefaultLifecycleManager(false);
+        manager.setApplicationContext(applicationContext);
+        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
+
+        verifyNoInteractions(applicationContext);
+
+        manager.onApplicationEvent(mock(ContextClosedEvent.class));
+
+        verifyNoInteractions(applicationContext);
+    }
+
+}

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -17,70 +17,89 @@
 package dk.cloudcreate.essentials.components.boot.autoconfigure.mongodb;
 
 
-import com.fasterxml.jackson.annotation.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.mongodb.*;
+import com.mongodb.ReadConcern;
+import com.mongodb.TransactionOptions;
+import com.mongodb.WriteConcern;
 import dk.cloudcreate.essentials.components.distributed.fencedlock.springdata.mongo.MongoFencedLockManager;
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
-import dk.cloudcreate.essentials.components.foundation.json.*;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockEvents;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.LockName;
+import dk.cloudcreate.essentials.components.foundation.json.JSONSerializer;
+import dk.cloudcreate.essentials.components.foundation.json.JacksonJSONSerializer;
+import dk.cloudcreate.essentials.components.foundation.lifecycle.DefaultLifecycleManager;
+import dk.cloudcreate.essentials.components.foundation.lifecycle.LifecycleManager;
 import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inboxes;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Outboxes;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueuesInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueEntryId;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueName;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuePollingOptimizer;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.TransactionalMode;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.DurableQueuesMicrometerInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.DurableQueuesMicrometerTracingInterceptor;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.ConsumeFromQueue;
-import dk.cloudcreate.essentials.components.foundation.reactive.command.*;
-import dk.cloudcreate.essentials.components.foundation.transaction.*;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.UnitOfWorkControllingCommandBusInterceptor;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.queue.springdata.mongodb.MongoDurableQueues;
 import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
 import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
-import dk.cloudcreate.essentials.reactive.*;
-import dk.cloudcreate.essentials.reactive.command.*;
+import dk.cloudcreate.essentials.reactive.EventBus;
+import dk.cloudcreate.essentials.reactive.EventHandler;
+import dk.cloudcreate.essentials.reactive.LocalEventBus;
+import dk.cloudcreate.essentials.reactive.OnErrorHandler;
+import dk.cloudcreate.essentials.reactive.command.CommandBus;
+import dk.cloudcreate.essentials.reactive.command.CommandHandler;
+import dk.cloudcreate.essentials.reactive.command.SendAndDontWaitErrorHandler;
 import dk.cloudcreate.essentials.reactive.command.interceptor.CommandBusInterceptor;
 import dk.cloudcreate.essentials.reactive.spring.ReactiveHandlersBeanPostProcessor;
 import dk.cloudcreate.essentials.types.CharSequenceType;
-import dk.cloudcreate.essentials.types.springdata.mongo.*;
+import dk.cloudcreate.essentials.types.springdata.mongo.SingleValueTypeConverter;
+import dk.cloudcreate.essentials.types.springdata.mongo.SingleValueTypeRandomIdGenerator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
-import org.slf4j.*;
-import org.springframework.beans.BeansException;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.*;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.event.*;
-import org.springframework.core.convert.converter.*;
-import org.springframework.data.mongodb.*;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.convert.*;
-
-import java.util.*;
-import java.util.function.Function;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 
 /**
  * MongoDB focused Essentials Components auto configuration
  */
 @AutoConfiguration
 @EnableConfigurationProperties(EssentialsComponentsProperties.class)
-public class EssentialsComponentsConfiguration implements ApplicationListener<ApplicationContextEvent>, ApplicationContextAware {
-    public static final Logger log = LoggerFactory.getLogger(EssentialsComponentsConfiguration.class);
-
-    private ApplicationContext     applicationContext;
-    private boolean                closed;
-    private Map<String, Lifecycle> lifeCycleBeans;
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
-    }
+public class EssentialsComponentsConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
@@ -404,33 +423,14 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     }
 
     /**
-     * Callback to ensure Essentials components implementing {@link Lifecycle} are started
+     * The {@link LifecycleManager} that handles starting and stopping life cycle beans
      *
-     * @param event
+     * @param properties the auto configure properties
+     * @return the {@link LifecycleManager}
      */
-    @Override
-    public void onApplicationEvent(ApplicationContextEvent event) {
-        if (event instanceof ContextRefreshedEvent) {
-            log.info(event.getClass().getSimpleName());
-            closed = false;
-            lifeCycleBeans = applicationContext.getBeansOfType(Lifecycle.class);
-            lifeCycleBeans.forEach((beanName, lifecycleBean) -> {
-                if (!lifecycleBean.isStarted()) {
-                    log.info("Starting {} bean '{}' of type '{}'", dk.cloudcreate.essentials.components.foundation.Lifecycle.class.getSimpleName(), beanName, lifecycleBean.getClass().getName());
-                    lifecycleBean.start();
-                }
-            });
-        } else if (event instanceof ContextClosedEvent) {
-            log.info("{} - has Context already been closed: {}", event.getClass().getSimpleName(), closed);
-            if (!closed) {
-                lifeCycleBeans.forEach((beanName, lifecycleBean) -> {
-                    if (lifecycleBean.isStarted()) {
-                        log.info("Stopping {} bean '{}' of type '{}'", Lifecycle.class.getSimpleName(), beanName, lifecycleBean.getClass().getName());
-                        lifecycleBean.stop();
-                    }
-                });
-                closed = true;
-            }
-        }
+    @Bean
+    @ConditionalOnMissingBean
+    public LifecycleManager lifecycleController(EssentialsComponentsProperties properties) {
+        return new DefaultLifecycleManager(properties.getLifeCycles().isStartLifecycles());
     }
 }

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
@@ -16,16 +16,17 @@
 
 package dk.cloudcreate.essentials.components.boot.autoconfigure.mongodb;
 
+import java.time.Duration;
+import java.util.Optional;
+
 import dk.cloudcreate.essentials.components.distributed.fencedlock.springdata.mongo.MongoFencedLockStorage;
 import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueName;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.TransactionalMode;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.ConsumeFromQueue;
 import dk.cloudcreate.essentials.components.queue.springdata.mongodb.MongoDurableQueues;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import java.time.Duration;
-import java.util.Optional;
 
 /**
  * Properties for the MongoDB focused Essentials Components auto-configuration
@@ -35,6 +36,7 @@ import java.util.Optional;
 public class EssentialsComponentsProperties {
     private final FencedLockManager fencedLockManager = new FencedLockManager();
     private final DurableQueues     durableQueues     = new DurableQueues();
+    private final LifeCycleProperties lifeCycles = new LifeCycleProperties();
 
     public FencedLockManager getFencedLockManager() {
         return fencedLockManager;
@@ -42,6 +44,10 @@ public class EssentialsComponentsProperties {
 
     public DurableQueues getDurableQueues() {
         return durableQueues;
+    }
+
+    public LifeCycleProperties getLifeCycles() {
+        return this.lifeCycles;
     }
 
     public static class DurableQueues {
@@ -239,6 +245,28 @@ public class EssentialsComponentsProperties {
          */
         public void setFencedLocksCollectionName(String fencedLocksCollectionName) {
             this.fencedLocksCollectionName = fencedLocksCollectionName;
+        }
+    }
+
+    public static class LifeCycleProperties {
+        private boolean startLifeCycles = true;
+
+        /**
+         * Get property that determines if lifecycle beans should be started automatically
+         *
+         * @return the property that determined if lifecycle beans should be started automatically
+         */
+        public boolean isStartLifecycles() {
+            return startLifeCycles;
+        }
+
+        /**
+         * Set property that determines if lifecycle beans should be started automatically
+         *
+         * @param startLifeCycles the property that determines if lifecycle beans should be started automatically
+         */
+        public void setStartLifeCycles(boolean startLifeCycles) {
+            this.startLifeCycles = startLifeCycles;
         }
     }
 }

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -17,30 +17,55 @@
 package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql;
 
 
-import com.fasterxml.jackson.annotation.*;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager;
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
-import dk.cloudcreate.essentials.components.foundation.json.*;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockEvents;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
+import dk.cloudcreate.essentials.components.foundation.json.JSONSerializer;
+import dk.cloudcreate.essentials.components.foundation.json.JacksonJSONSerializer;
+import dk.cloudcreate.essentials.components.foundation.lifecycle.DefaultLifecycleManager;
+import dk.cloudcreate.essentials.components.foundation.lifecycle.LifecycleManager;
 import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.*;
-import dk.cloudcreate.essentials.components.foundation.postgresql.*;
-import dk.cloudcreate.essentials.components.foundation.reactive.command.*;
-import dk.cloudcreate.essentials.components.foundation.transaction.*;
-import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inboxes;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Outboxes;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueuesInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueName;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuePollingOptimizer;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.DurableQueuesMicrometerInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.DurableQueuesMicrometerTracingInterceptor;
+import dk.cloudcreate.essentials.components.foundation.postgresql.MultiTableChangeListener;
+import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
+import dk.cloudcreate.essentials.components.foundation.postgresql.TableChangeNotification;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.UnitOfWorkControllingCommandBusInterceptor;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkFactory;
+import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.HandleAwareUnitOfWork;
+import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.HandleAwareUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.jdbi.SpringTransactionAwareJdbiUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues;
 import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
 import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
-import dk.cloudcreate.essentials.reactive.*;
-import dk.cloudcreate.essentials.reactive.command.*;
+import dk.cloudcreate.essentials.reactive.EventBus;
+import dk.cloudcreate.essentials.reactive.EventHandler;
+import dk.cloudcreate.essentials.reactive.LocalEventBus;
+import dk.cloudcreate.essentials.reactive.OnErrorHandler;
+import dk.cloudcreate.essentials.reactive.command.CommandBus;
+import dk.cloudcreate.essentials.reactive.command.CommandHandler;
+import dk.cloudcreate.essentials.reactive.command.SendAndDontWaitErrorHandler;
 import dk.cloudcreate.essentials.reactive.command.interceptor.CommandBusInterceptor;
 import dk.cloudcreate.essentials.reactive.spring.ReactiveHandlersBeanPostProcessor;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -49,36 +74,26 @@ import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.postgres.PostgresPlugin;
-import org.slf4j.*;
-import org.springframework.beans.BeansException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.*;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.event.*;
 import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
 import org.springframework.transaction.PlatformTransactionManager;
-
-import javax.sql.DataSource;
-import java.util.*;
 
 /**
  * Postgresql focused Essentials Components auto configuration
  */
 @AutoConfiguration
 @EnableConfigurationProperties(EssentialsComponentsProperties.class)
-public class EssentialsComponentsConfiguration implements ApplicationListener<ApplicationContextEvent>, ApplicationContextAware {
+public class EssentialsComponentsConfiguration {
     public static final Logger log = LoggerFactory.getLogger(EssentialsComponentsConfiguration.class);
-
-    private ApplicationContext     applicationContext;
-    private boolean                closed;
-    private Map<String, Lifecycle> lifeCycleBeans;
-
-    @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-        this.applicationContext = applicationContext;
-    }
 
     @Bean
     @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
@@ -355,44 +370,27 @@ public class EssentialsComponentsConfiguration implements ApplicationListener<Ap
     }
 
     /**
-     * Callback to ensure Essentials components implementing {@link dk.cloudcreate.essentials.components.foundation.Lifecycle} are started
+     * The {@link LifecycleManager} that handles starting and stopping life cycle beans
      *
-     * @param event
+     * @param properties the auto configure properties
+     * @return the {@link LifecycleManager}
      */
-    @Override
-    public void onApplicationEvent(ApplicationContextEvent event) {
-        if (event instanceof ContextRefreshedEvent) {
-            log.info(event.getClass().getSimpleName());
-            closed = false;
-            lifeCycleBeans = applicationContext.getBeansOfType(Lifecycle.class);
-            lifeCycleBeans.forEach((beanName, lifecycleBean) -> {
-                if (!lifecycleBean.isStarted()) {
-                    log.info("Starting {} bean '{}' of type '{}'", dk.cloudcreate.essentials.components.foundation.Lifecycle.class.getSimpleName(), beanName, lifecycleBean.getClass().getName());
-                    lifecycleBean.start();
-                }
-            });
+    @Bean
+    @ConditionalOnMissingBean
+    public LifecycleManager lifecycleController(EssentialsComponentsProperties properties) {
+        return new DefaultLifecycleManager(this::onContextRefreshedEvent, properties.getLifeCycles().isStartLifecycles());
+    }
 
-            var callbacks = applicationContext.getBeansOfType(JdbiConfigurationCallback.class).values();
-            if (!callbacks.isEmpty()) {
-                var jdbi = applicationContext.getBean(Jdbi.class);
-                callbacks.forEach(configureJdbiCallback -> {
-                    log.info("Calling {}: {}",
-                             JdbiConfigurationCallback.class.getSimpleName(),
-                             configureJdbiCallback.getClass().getName());
-                    configureJdbiCallback.configure(jdbi);
-                });
-            }
-        } else if (event instanceof ContextClosedEvent) {
-            log.info("{} - has Context already been closed: {}", event.getClass().getSimpleName(), closed);
-            if (!closed) {
-                lifeCycleBeans.forEach((beanName, lifecycleBean) -> {
-                    if (lifecycleBean.isStarted()) {
-                        log.info("Stopping {} bean '{}' of type '{}'", Lifecycle.class.getSimpleName(), beanName, lifecycleBean.getClass().getName());
-                        lifecycleBean.stop();
-                    }
-                });
-                closed = true;
-            }
+    private void onContextRefreshedEvent(ApplicationContext applicationContext) {
+        var callbacks = applicationContext.getBeansOfType(JdbiConfigurationCallback.class).values();
+        if (!callbacks.isEmpty()) {
+            var jdbi = applicationContext.getBean(Jdbi.class);
+            callbacks.forEach(configureJdbiCallback -> {
+                log.info("Calling {}: {}",
+                    JdbiConfigurationCallback.class.getSimpleName(),
+                    configureJdbiCallback.getClass().getName());
+                configureJdbiCallback.configure(jdbi);
+            });
         }
     }
 }

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -16,16 +16,18 @@
 
 package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql;
 
+import java.time.Duration;
+
 import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockStorage;
 import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueName;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.TransactionalMode;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.ConsumeFromQueue;
 import dk.cloudcreate.essentials.components.foundation.postgresql.MultiTableChangeListener;
 import dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import java.time.Duration;
 
 /**
  * Properties for the Postgresql focused Essentials Components auto-configuration
@@ -38,6 +40,8 @@ public class EssentialsComponentsProperties {
 
     private final MultiTableChangeListenerProperties multiTableChangeListener = new MultiTableChangeListenerProperties();
 
+    private final LifeCycleProperties lifeCycles = new LifeCycleProperties();
+
 
     public FencedLockManagerProperties getFencedLockManager() {
         return fencedLockManager;
@@ -49,6 +53,10 @@ public class EssentialsComponentsProperties {
 
     public MultiTableChangeListenerProperties getMultiTableChangeListener() {
         return multiTableChangeListener;
+    }
+
+    public LifeCycleProperties getLifeCycles() {
+        return this.lifeCycles;
     }
 
     public static class MultiTableChangeListenerProperties {
@@ -266,6 +274,28 @@ public class EssentialsComponentsProperties {
          */
         public void setFencedLocksTableName(String fencedLocksTableName) {
             this.fencedLocksTableName = fencedLocksTableName;
+        }
+    }
+
+    public static class LifeCycleProperties {
+        private boolean startLifeCycles = true;
+
+        /**
+         * Get property that determines if lifecycle beans should be started automatically
+         *
+         * @return the property that determined if lifecycle beans should be started automatically
+         */
+        public boolean isStartLifecycles() {
+            return startLifeCycles;
+        }
+
+        /**
+         * Set property that determines if lifecycle beans should be started automatically
+         *
+         * @param startLifeCycles the property that determines if lifecycle beans should be started automatically
+         */
+        public void setStartLifeCycles(boolean startLifeCycles) {
+            this.startLifeCycles = startLifeCycles;
         }
     }
 }


### PR DESCRIPTION
Extract starting and stopping life cycles into it's own bean.
Additionally, providing the possibility to configure that life cycle beans should not be started at all. This may be relevant in scenarios where the entire service should not be started (db-migration only, etc).