### PR TITLE
Refined dependencies scopes and versions for 3rd party dependencies

### DIFF
--- a/components/foundation-test/pom.xml
+++ b/components/foundation-test/pom.xml
@@ -45,19 +45,23 @@
         <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -66,6 +70,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/components/foundation/pom.xml
+++ b/components/foundation/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
-            <version>4.3.0</version>
+            <version>5.0.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -98,7 +98,7 @@
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
             <version>${mongodb-driver-sync.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/components/spring-boot-starter-mongodb/pom.xml
+++ b/components/spring-boot-starter-mongodb/pom.xml
@@ -70,13 +70,13 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>${micrometer.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing</artifactId>
             <version>${micrometer-tracing.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/components/spring-boot-starter-postgresql-event-store/pom.xml
+++ b/components/spring-boot-starter-postgresql-event-store/pom.xml
@@ -76,13 +76,13 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>${micrometer.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing</artifactId>
             <version>${micrometer-tracing.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/components/spring-boot-starter-postgresql/pom.xml
+++ b/components/spring-boot-starter-postgresql/pom.xml
@@ -70,13 +70,13 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>${micrometer.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing</artifactId>
             <version>${micrometer-tracing.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/components/spring-postgresql-event-store/pom.xml
+++ b/components/spring-postgresql-event-store/pom.xml
@@ -50,6 +50,7 @@
             <groupId>dk.cloudcreate.essentials.components</groupId>
             <artifactId>eventsourced-aggregates</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -132,12 +133,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,34 +61,37 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <kotlin.version>1.9.22</kotlin.version>
+        <kotlin.version>1.9.23</kotlin.version>
         <revision>DEV-SNAPSHOT</revision>
         <skipDependencyCheck>false</skipDependencyCheck>
 
         <objenesis.version>3.3</objenesis.version>
-        <postgresql.version>42.7.1</postgresql.version>
+        <postgresql.version>42.7.3</postgresql.version>
         <slf4j.version>2.0.12</slf4j.version>
-        <spring-boot.version>3.2.2</spring-boot.version>
-        <awaitility.version>4.2.0</awaitility.version>
-        <spring-data-mongodb.version>4.2.2</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.2</spring-data-jpa.version>
+        <spring-boot.version>3.2.3</spring-boot.version>
+        <awaitility.version>4.2.1</awaitility.version>
+        <spring-data-mongodb.version>4.2.4</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.2.4</spring-data-jpa.version>
         <objenesis.version>3.3</objenesis.version>
         <assertj.version>3.25.3</assertj.version>
         <mongodb-driver-sync.version>4.11.1</mongodb-driver-sync.version>
-        <log4j-to-slf4j.version>2.22.1</log4j-to-slf4j.version>
+        <log4j-to-slf4j.version>2.23.1</log4j-to-slf4j.version>
         <json-smart.version>2.5.0</json-smart.version>
+        <json-path.version>2.9.0</json-path.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <micrometer.version>1.12.2</micrometer.version>
-        <micrometer-tracing.version>1.2.2</micrometer-tracing.version>
-        <netty-bom.version>4.1.106.Final</netty-bom.version>
+        <micrometer.version>1.12.4</micrometer.version>
+        <micrometer-tracing.version>1.2.4</micrometer-tracing.version>
+        <netty-bom.version>4.1.107.Final</netty-bom.version>
         <junit-bom.version>5.10.2</junit-bom.version>
-        <testcontainers-bom.version>1.19.4</testcontainers-bom.version>
-        <jdbi3-bom.version>3.44.0</jdbi3-bom.version>
-        <jackson-bom.version>2.16.1</jackson-bom.version>
-        <reactor-bom.version>2023.0.2</reactor-bom.version>
-        <spring-framework-bom.version>6.1.3</spring-framework-bom.version>
-        <mockito-bom.version>5.10.0</mockito-bom.version>
-        <logback.version>1.4.14</logback.version>
+        <testcontainers-bom.version>1.19.7</testcontainers-bom.version>
+        <jdbi3-bom.version>3.45.1</jdbi3-bom.version>
+        <jackson-bom.version>2.17.0</jackson-bom.version>
+        <reactor-bom.version>2023.0.4</reactor-bom.version>
+        <spring-framework-bom.version>6.1.5</spring-framework-bom.version>
+        <mockito-bom.version>5.11.0</mockito-bom.version>
+        <logback.version>1.5.3</logback.version>
+        <avro.version>1.11.3</avro.version>
+        <commons-compress.version>1.26.1</commons-compress.version>
 
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
@@ -106,10 +109,10 @@
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>9.0.9</dependency-check-maven.version>
+        <dependency-check-maven.version>9.0.10</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.2.0</maven-gpg-plugin.version>
     </properties>
 
     <modules>
@@ -136,7 +139,7 @@
         <module>components/spring-postgresql-event-store</module>
         <module>components/springdata-mongo-distributed-fenced-lock</module>
         <module>components/springdata-mongo-queue</module>
-<!--        <module>components/kotlin-eventsourcing</module>-->
+        <module>components/kotlin-eventsourcing</module>
     </modules>
 
 
@@ -198,6 +201,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Due to CVE-2023-42503, CVE-2024-26308, CVE-2024-25710 -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -239,8 +249,8 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <scope>test</scope>
             <version>${awaitility.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/reactive/pom.xml
+++ b/reactive/pom.xml
@@ -47,12 +47,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/types-avro/pom.xml
+++ b/types-avro/pom.xml
@@ -34,22 +34,11 @@
     <packaging>jar</packaging>
     <name>essentials-types-avro</name>
 
-    <properties>
-        <avro.version>1.11.3</avro.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>dk.cloudcreate.essentials</groupId>
             <artifactId>types</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <!-- Due to CVE-2023-42503 -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.25.0</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/types-jdbi/pom.xml
+++ b/types-jdbi/pom.xml
@@ -48,13 +48,13 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
             <version>${kotlin.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/types-springdata-jpa/pom.xml
+++ b/types-springdata-jpa/pom.xml
@@ -58,7 +58,6 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/types-springdata-mongo/pom.xml
+++ b/types-springdata-mongo/pom.xml
@@ -57,7 +57,6 @@
             <version>${snakeyaml.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/types/pom.xml
+++ b/types/pom.xml
@@ -46,13 +46,13 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
             <version>${kotlin.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
…rovided)

Updated 3rd party dependencies:
- java-uuid-generator 5.0.0
- kotlin 1.9.23
- postgresql 42.7.3
- spring-boot 3.2.3
- awaitility 4.2.1
- spring-data-mongodb 4.2.4
- spring-data-jpa 3.2.4
- log4j-to-slf4j 2.23.1
- json-path 2.9.0
- micrometer 1.12.4
- micrometer-tracing 1.2.4
- netty 4.1.107.Final
- testcontainers 1.19.7
- jdbi3 3.45.1
- jackson 2.17.0
- reactor 2023.0.4
- spring 6.1.5
- mockito 5.11.0
- logback 1.5.3
- commons-compress 1.26.1

Updated Maven plugins:
- dependency-check-maven 9.0.10
- maven-gpg-plugin 3.2.0