### PR TITLE
Subscriber event order diff gauge

### DIFF
--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -16,29 +16,42 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription;
 
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreException;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreSubscription;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.CommitStage;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.PersistedEvents;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.EventJSON;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
 import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.LockCallback;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.LockName;
 import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inbox;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.OrderedMessage;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
-import dk.cloudcreate.essentials.components.foundation.types.*;
+import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
+import dk.cloudcreate.essentials.components.foundation.types.Tenant;
 import dk.cloudcreate.essentials.shared.FailFast;
 import dk.cloudcreate.essentials.shared.concurrent.ThreadFactoryBuilder;
 import dk.cloudcreate.essentials.shared.functional.tuple.Pair;
 import org.reactivestreams.Subscription;
-import org.slf4j.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.BaseSubscriber;
-
-import java.time.Duration;
-import java.util.Optional;
-import java.util.concurrent.*;
-import java.util.stream.Collectors;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
@@ -450,7 +463,13 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                                    FencedLockManager fencedLockManager,
                                                    Duration snapshotResumePointsEvery,
                                                    DurableSubscriptionRepository durableSubscriptionRepository) {
-        return builder().setEventStore(eventStore).setEventStorePollingBatchSize(eventStorePollingBatchSize).setEventStorePollingInterval(eventStorePollingInterval).setFencedLockManager(fencedLockManager).setSnapshotResumePointsEvery(snapshotResumePointsEvery).setDurableSubscriptionRepository(durableSubscriptionRepository).build();
+        return builder().setEventStore(eventStore)
+            .setEventStorePollingBatchSize(eventStorePollingBatchSize)
+            .setEventStorePollingInterval(eventStorePollingInterval)
+            .setFencedLockManager(fencedLockManager)
+            .setSnapshotResumePointsEvery(snapshotResumePointsEvery)
+            .setDurableSubscriptionRepository(durableSubscriptionRepository)
+            .build();
     }
 
     void unsubscribe(EventStoreSubscription eventStoreSubscription);
@@ -479,13 +498,15 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
         private final    ConcurrentMap<Pair<SubscriberId, AggregateType>, EventStoreSubscription> subscribers = new ConcurrentHashMap<>();
         private volatile boolean                                                                  started;
         private          ScheduledFuture<?>                                                       saveResumePointsFuture;
+        private final boolean startLifeCycles;
 
         public DefaultEventStoreSubscriptionManager(EventStore eventStore,
                                                     int eventStorePollingBatchSize,
                                                     Duration eventStorePollingInterval,
                                                     FencedLockManager fencedLockManager,
                                                     Duration snapshotResumePointsEvery,
-                                                    DurableSubscriptionRepository durableSubscriptionRepository) {
+                                                    DurableSubscriptionRepository durableSubscriptionRepository,
+                                                    boolean startLifeCycles) {
             FailFast.requireTrue(eventStorePollingBatchSize >= 1, "eventStorePollingBatchSize must be >= 1");
             this.eventStore = requireNonNull(eventStore, "No eventStore provided");
             this.eventStorePollingBatchSize = eventStorePollingBatchSize;
@@ -493,19 +514,26 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
             this.fencedLockManager = requireNonNull(fencedLockManager, "No fencedLockManager provided");
             this.durableSubscriptionRepository = requireNonNull(durableSubscriptionRepository, "No durableSubscriptionRepository provided");
             this.snapshotResumePointsEvery = requireNonNull(snapshotResumePointsEvery, "No snapshotResumePointsEvery provided");
+            this.startLifeCycles = startLifeCycles;
 
-            log.info("[{}] Using {} using {} with snapshotResumePointsEvery: {}, eventStorePollingBatchSize: {}, eventStorePollingInterval: {}",
+            log.info("[{}] Using {} using {} with snapshotResumePointsEvery: {}, eventStorePollingBatchSize: {}, eventStorePollingInterval: {}, " +
+                    "startLifeCycles: {}",
                      fencedLockManager.getLockManagerInstanceId(),
                      fencedLockManager,
                      durableSubscriptionRepository.getClass().getSimpleName(),
                      snapshotResumePointsEvery,
                      eventStorePollingBatchSize,
-                     eventStorePollingInterval
+                     eventStorePollingInterval,
+                     startLifeCycles
                     );
         }
 
         @Override
         public void start() {
+            if (!startLifeCycles) {
+                log.debug("Start of lifecycle beans is disabled");
+                return;
+            }
             if (!started) {
                 log.info("[{}] Starting EventStore Subscription Manager", fencedLockManager.getLockManagerInstanceId());
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManagerBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManagerBuilder.java
@@ -28,6 +28,7 @@ public final class EventStoreSubscriptionManagerBuilder {
     private FencedLockManager             fencedLockManager;
     private Duration                      snapshotResumePointsEvery  = Duration.ofSeconds(1);
     private DurableSubscriptionRepository durableSubscriptionRepository;
+    private boolean startLifeCycles = true;
 
     /**
      * @param eventStore the event store that the created {@link EventStoreSubscriptionManager} can manage event subscriptions against
@@ -83,12 +84,18 @@ public final class EventStoreSubscriptionManagerBuilder {
         return this;
     }
 
+    public EventStoreSubscriptionManagerBuilder setStartLifeCycles(boolean startLifeCycles) {
+        this.startLifeCycles = startLifeCycles;
+        return this;
+    }
+
     public EventStoreSubscriptionManager.DefaultEventStoreSubscriptionManager build() {
         return new EventStoreSubscriptionManager.DefaultEventStoreSubscriptionManager(eventStore,
                                                                                       eventStorePollingBatchSize,
                                                                                       eventStorePollingInterval,
                                                                                       fencedLockManager,
                                                                                       snapshotResumePointsEvery,
-                                                                                      durableSubscriptionRepository);
+                                                                                      durableSubscriptionRepository,
+                                                                                      startLifeCycles);
     }
 }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/EventStoreSubscriptionMonitor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/EventStoreSubscriptionMonitor.java
@@ -1,0 +1,11 @@
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
+import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
+
+/**
+ * Implements monitoring operations on event store subscriptions
+ */
+public interface EventStoreSubscriptionMonitor {
+    void monitor(SubscriberId subscriberId, AggregateType aggregateType);
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/EventStoreSubscriptionMonitorManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/EventStoreSubscriptionMonitorManager.java
@@ -1,0 +1,93 @@
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.foundation.Lifecycle;
+import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
+import dk.cloudcreate.essentials.shared.concurrent.ThreadFactoryBuilder;
+import dk.cloudcreate.essentials.shared.functional.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+import static dk.cloudcreate.essentials.shared.collections.Lists.nullSafeList;
+
+public class EventStoreSubscriptionMonitorManager implements Lifecycle {
+    private static final Logger log = LoggerFactory.getLogger(EventStoreSubscriptionMonitorManager.class);
+    private boolean started;
+    private final boolean enabled;
+    private final Duration interval;
+    private final List<EventStoreSubscriptionMonitor> monitors = new ArrayList<>();
+    private final EventStoreSubscriptionManager eventStoreSubscriptionManager;
+    private ScheduledFuture<?> scheduledFuture;
+
+    public EventStoreSubscriptionMonitorManager(boolean enabled,
+                                                Duration interval,
+                                                EventStoreSubscriptionManager eventStoreSubscriptionManager,
+                                                List<EventStoreSubscriptionMonitor> monitors) {
+        this.enabled = enabled;
+        this.interval = requireNonNull(interval, "Interval must be provided");
+        this.monitors.addAll(nullSafeList(monitors));
+        this.eventStoreSubscriptionManager = requireNonNull(eventStoreSubscriptionManager, "SubscriptionManager must be provided");
+    }
+
+    @Override
+    public void start() {
+        if (!enabled) {
+            log.info("[{}] is disabled", this.getClass().getSimpleName());
+            return;
+        }
+        if (this.monitors.isEmpty()) {
+            log.info("[{}] No monitors configured", this.getClass().getSimpleName());
+            return;
+        }
+        if (!started) {
+            log.info("Starting [{}]", this.getClass().getSimpleName());
+            scheduledFuture = Executors.newSingleThreadScheduledExecutor(ThreadFactoryBuilder.builder()
+                .nameFormat("EventStoreSubscriptionMonitoring")
+                .daemon(true)
+                .build())
+                .scheduleAtFixedRate(this::executeMonitoring,
+                    interval.toMillis(),
+                    interval.toMillis(),
+                    TimeUnit.MILLISECONDS);
+            started = true;
+        } else {
+            log.debug("[{}] was already started", this.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (started) {
+            log.info("Stopping [{}]", this.getClass().getSimpleName());
+            scheduledFuture.cancel(true);
+            started = false;
+        } else {
+            log.debug("[{}] was already stopped", this.getClass().getSimpleName());
+        }
+    }
+
+    private void executeMonitoring() {
+        Set<Pair<SubscriberId, AggregateType>> subscriptions = eventStoreSubscriptionManager.getActiveSubscriptions();
+        log.debug("[{}] executing monitoring for {} subscriptions and {} monitors", this.getClass().getSimpleName(), subscriptions.size(), monitors.size());
+        subscriptions.forEach(subscription -> executeMonitoring(subscription._1, subscription._2));
+    }
+
+    private void executeMonitoring(SubscriberId subscriberId, AggregateType aggregateType) {
+        monitors.forEach(monitor -> monitor.monitor(subscriberId, aggregateType));
+    }
+
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/SubscriberGlobalOrderMicrometerMonitor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/SubscriberGlobalOrderMicrometerMonitor.java
@@ -1,0 +1,63 @@
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
+import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
+import dk.cloudcreate.essentials.shared.functional.tuple.Pair;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import org.jetbrains.annotations.NotNull;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+import static java.lang.Long.max;
+
+/**
+ * Maintaining gauge to measure the difference between the current global event order and the event order
+ * of the subscriber. This to detect subscribers that are falling behind the global event order
+ */
+public class SubscriberGlobalOrderMicrometerMonitor implements EventStoreSubscriptionMonitor {
+    private static final String SUBSCRIPTION_EVENT_ORDER_DIFF_METRIC = "DurableSubscriptions_EventOrder_Diff";
+    private static final String SUBSCRIBER_ID_TAG = "SubscriberId";
+    private static final String AGGREGATE_TYPE_TAG = "AggregateType";
+
+    private final EventStoreSubscriptionManager eventStoreSubscriptionManager;
+    private final MeterRegistry meterRegistry;
+    private final ConcurrentHashMap<Pair<SubscriberId, AggregateType>, Gauge> subscriberGauges = new ConcurrentHashMap<>();
+
+    public SubscriberGlobalOrderMicrometerMonitor(EventStoreSubscriptionManager eventStoreSubscriptionManager,
+                                                  MeterRegistry meterRegistry) {
+        this.eventStoreSubscriptionManager = requireNonNull(eventStoreSubscriptionManager, "EventStoreSubscriptionManager must be provided");
+        this.meterRegistry = requireNonNull(meterRegistry, "MeterRegistry must be provided");
+    }
+
+    @Override
+    public void monitor(SubscriberId subscriberId, AggregateType aggregateType) {
+        var key = Pair.of(subscriberId, aggregateType);
+        subscriberGauges.computeIfAbsent(key, this::buildGauge);
+    }
+
+    @NotNull
+    private Gauge buildGauge(Pair<SubscriberId, AggregateType> pair) {
+        SubscriberId subscriberId = pair._1;
+        AggregateType aggregateType = pair._2;
+        return Gauge.builder(SUBSCRIPTION_EVENT_ORDER_DIFF_METRIC, () -> calculateEventOrderDiff(subscriberId, aggregateType))
+            .tags(List.of(Tag.of(SUBSCRIBER_ID_TAG, subscriberId.toString()), Tag.of(AGGREGATE_TYPE_TAG, aggregateType.toString())))
+            .register(meterRegistry);
+    }
+
+    private long calculateEventOrderDiff(SubscriberId subscriberId, AggregateType aggregateType) {
+        var globalEventOrder = getGlobalEventOrder(aggregateType);
+        var currentEventOrder = eventStoreSubscriptionManager.getCurrentEventOrder(subscriberId, aggregateType);
+        return max(0, globalEventOrder.longValue() - currentEventOrder.longValue());
+    }
+
+    @NotNull
+    private GlobalEventOrder getGlobalEventOrder(AggregateType aggregateType) {
+        return eventStoreSubscriptionManager.getEventStore().findHighestGlobalEventOrderPersisted(aggregateType).orElse(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER);
+    }
+}

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -91,7 +91,6 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 
 /**
@@ -473,4 +472,5 @@ public class EssentialsComponentsConfiguration {
     public LifecycleManager lifecycleController(EssentialsComponentsProperties properties) {
         return new DefaultLifecycleManager(properties.getLifeCycles().isStartLifecycles());
     }
+
 }

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EssentialsEventStoreProperties.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EssentialsEventStoreProperties.java
@@ -16,16 +16,23 @@
 
 package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.eventstore;
 
+import java.time.Duration;
+
 import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.EssentialsComponentsConfiguration;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.PostgresqlEventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.EventStreamTableColumnNames;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.IdentifierColumnType;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.JSONColumnType;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.NoEventStreamGapHandler;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypePersistenceStrategy;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.PostgresqlDurableSubscriptionRepository;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.SubscriptionResumePoint;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import java.time.Duration;
 
 /**
  * Properties for the Postgresql EventStore<br>
@@ -56,6 +63,8 @@ public class EssentialsEventStoreProperties {
     private boolean verboseTracing = false;
 
     private final EventStoreSubscriptionManagerProperties subscriptionManager = new EventStoreSubscriptionManagerProperties();
+
+    private final EventStoreSubscriptionMonitorProperties subscriptionMonitor = new EventStoreSubscriptionMonitorProperties();
 
 
     /**
@@ -138,6 +147,14 @@ public class EssentialsEventStoreProperties {
     }
 
     /**
+     * Get the {@link dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.EventStoreSubscriptionMonitorManager} properties
+     * @return the {@link dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.EventStoreSubscriptionMonitorManager} properties
+     */
+    public EventStoreSubscriptionMonitorProperties getSubscriptionMonitor() {
+        return this.subscriptionMonitor;
+    }
+
+    /**
      * {@link EventStoreSubscriptionManager} properties
      */
     public static class EventStoreSubscriptionManagerProperties {
@@ -197,6 +214,44 @@ public class EssentialsEventStoreProperties {
          */
         public void setSnapshotResumePointsEvery(Duration snapshotResumePointsEvery) {
             this.snapshotResumePointsEvery = snapshotResumePointsEvery;
+        }
+    }
+
+    public static class EventStoreSubscriptionMonitorProperties {
+        private boolean enabled = true;
+        private Duration interval = Duration.ofMinutes(1);
+
+        /**
+         * Is monitoring of event store subscribers enabled
+         * @return Is monitoring of event store subscribers enabled
+         */
+        public boolean isEnabled() {
+            return this.enabled;
+        }
+
+        /**
+         * Monitoring of event store subscribers using implementations of
+         * {@link dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.EventStoreSubscriptionMonitor}
+         * @param enabled Monitoring of event store subscribers
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        /**
+         * Monitoring interval
+         * @param interval Monitoring interval
+         */
+        public void setInterval(Duration interval) {
+            this.interval = interval;
+        }
+
+        /**
+         * The interval to execute the {@link dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.EventStoreSubscriptionMonitor}s
+         * @return monitoring interval
+         */
+        public Duration getInterval() {
+            return this.interval;
         }
     }
 }

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
@@ -16,48 +16,76 @@
 
 package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.eventstore;
 
+import java.util.List;
+import java.util.Optional;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.EssentialsComponentsConfiguration;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.*;
+import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.EssentialsComponentsProperties;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.ConfigurableEventStore;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreSubscription;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.PostgresqlEventStore;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.EventStoreEventBus;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.PersistedEvents;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.EventStreamTableColumnNames;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.NoEventStreamGapHandler;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor.EventStoreInterceptor;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor.micrometer.MicrometerTracingEventStoreInterceptor;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.AggregateEventStreamConfiguration;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.AggregateEventStreamPersistenceStrategy;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.PersistableEvent;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.PersistableEventMapper;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.PersistableEventEnricher;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypePersistenceStrategy;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.EventProcessor;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.EventProcessorDependencies;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JSONEventSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.spring.SpringTransactionAwareEventStoreUnitOfWorkFactory;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.PostgresqlDurableSubscriptionRepository;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWork;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWorkFactory;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventOrder;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventTypeOrName;
 import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
 import dk.cloudcreate.essentials.components.foundation.messaging.MessageHandler;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inbox;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inboxes;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.MessageHandlerInterceptor;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
 import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
-import dk.cloudcreate.essentials.reactive.*;
-import dk.cloudcreate.essentials.reactive.command.*;
+import dk.cloudcreate.essentials.reactive.Handler;
+import dk.cloudcreate.essentials.reactive.OnErrorHandler;
+import dk.cloudcreate.essentials.reactive.command.CmdHandler;
+import dk.cloudcreate.essentials.reactive.command.CommandBus;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.transaction.PlatformTransactionManager;
-
-import java.util.*;
 
 /**
  * {@link PostgresqlEventStore} auto configuration<br>
@@ -140,14 +168,16 @@ public class EventStoreConfiguration {
     public EventStoreSubscriptionManager eventStoreSubscriptionManager(EventStore eventStore,
                                                                        FencedLockManager fencedLockManager,
                                                                        Jdbi jdbi,
-                                                                       EssentialsEventStoreProperties properties) {
+                                                                       EssentialsEventStoreProperties eventStoreProperties,
+                                                                       EssentialsComponentsProperties essentialsComponentsProperties) {
         return EventStoreSubscriptionManager.builder()
                                             .setEventStore(eventStore)
                                             .setFencedLockManager(fencedLockManager)
                                             .setDurableSubscriptionRepository(new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory()))
-                                            .setEventStorePollingBatchSize(properties.getSubscriptionManager().getEventStorePollingBatchSize())
-                                            .setEventStorePollingInterval(properties.getSubscriptionManager().getEventStorePollingInterval())
-                                            .setSnapshotResumePointsEvery(properties.getSubscriptionManager().getSnapshotResumePointsEvery())
+                                            .setEventStorePollingBatchSize(eventStoreProperties.getSubscriptionManager().getEventStorePollingBatchSize())
+                                            .setEventStorePollingInterval(eventStoreProperties.getSubscriptionManager().getEventStorePollingInterval())
+                                            .setSnapshotResumePointsEvery(eventStoreProperties.getSubscriptionManager().getSnapshotResumePointsEvery())
+                                            .setStartLifeCycles(essentialsComponentsProperties.getLifeCycles().isStartLifeCycles())
                                             .build();
     }
 

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -384,7 +384,7 @@ public class EssentialsComponentsConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public LifecycleManager lifecycleController(EssentialsComponentsProperties properties) {
-        return new DefaultLifecycleManager(this::onContextRefreshedEvent, properties.getLifeCycles().isStartLifecycles());
+        return new DefaultLifecycleManager(this::onContextRefreshedEvent, properties.getLifeCycles().isStartLifeCycles());
     }
 
     private void onContextRefreshedEvent(ApplicationContext applicationContext) {

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -16,16 +16,20 @@
 
 package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql;
 
-import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.*;
+import java.time.Duration;
+
+import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager;
+import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockStorage;
 import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueName;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.TransactionalMode;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.ConsumeFromQueue;
-import dk.cloudcreate.essentials.components.foundation.postgresql.*;
+import dk.cloudcreate.essentials.components.foundation.postgresql.MultiTableChangeListener;
+import dk.cloudcreate.essentials.components.foundation.postgresql.PostgresqlUtil;
 import dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-
-import java.time.Duration;
 
 /**
  * Properties for the Postgresql focused Essentials Components auto-configuration<br>
@@ -430,7 +434,7 @@ public class EssentialsComponentsProperties {
          *
          * @return the property that determined if lifecycle beans should be started automatically
          */
-        public boolean isStartLifecycles() {
+        public boolean isStartLifeCycles() {
             return startLifeCycles;
         }
 

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Lists.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Lists.java
@@ -82,4 +82,8 @@ public final class Lists {
         }
         return Optional.of(list.get(list.size() - 1));
     }
+
+    public static <T> List<T> nullSafeList(List<T> list) {
+        return Optional.ofNullable(list).orElse(List.of());
+    }
 }


### PR DESCRIPTION
Added framework for implementing monitors for event store subscribers. Monitoring done in a fixed interval.

Using above framework to implement new micrometer gauge, measuring the diff between global event order and subscriber event order. 

Changing existing gauge for queues, to use tags instead of having the queue name in the metric id. 