### PR TITLE
Release 0.40.7

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,4 +23,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B verify --file pom.xml -DskipDependencyCheck=true
+      run: mvn -B verify --file pom.xml

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -153,7 +153,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -168,7 +168,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -246,7 +246,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -294,7 +294,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -361,7 +361,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -407,7 +407,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -479,7 +479,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 
@@ -493,7 +493,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/pom.xml
+++ b/components/eventsourced-aggregates/pom.xml
@@ -47,6 +47,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>dk.cloudcreate.essentials</groupId>
+            <artifactId>immutable-jackson</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-postgres</artifactId>
             <scope>provided</scope>

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManagerIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManagerIT.java
@@ -307,9 +307,9 @@ public abstract class DBFencedLockManagerIT<LOCK_MANAGER extends DBFencedLockMan
         lockManagerNode1.resume();
         assertThat(lockNode2Callback.lockAcquired.isLocked()).isTrue();
         assertThat((CharSequence) lockNode2Callback.lockAcquired.getName()).isEqualTo(lockName);
-        assertThat(lockNode2Callback.lockAcquired.getCurrentToken()).isEqualTo(lockNode1Callback.lockReleased.getCurrentToken() + 1L);
-        assertThat(lockNode2Callback.lockAcquired.getLockAcquiredTimestamp()).isAfter(lastLockConfirmedTimestamp);
         assertThat(lockNode2Callback.lockAcquired.isLockedByThisLockManagerInstance()).isTrue();
+        assertThat(lockNode2Callback.lockAcquired.getLockAcquiredTimestamp()).isAfter(lastLockConfirmedTimestamp);
+        assertThat(lockNode2Callback.lockAcquired.getCurrentToken()).isEqualTo(lockNode1Callback.lockReleased.getCurrentToken() + 1L);
 
         assertThat(lockManagerNode1.isLockedByThisLockManagerInstance(lockName)).isFalse();
         assertThat(lockManagerNode1.isLockAcquired(lockName)).isTrue();

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/kotlin-eventsourcing/pom.xml
+++ b/components/kotlin-eventsourcing/pom.xml
@@ -120,6 +120,19 @@
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>dokka</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>

--- a/components/kotlin-eventsourcing/src/test/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/test/GivenWhenThenScenarioTest.kt
+++ b/components/kotlin-eventsourcing/src/test/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/test/GivenWhenThenScenarioTest.kt
@@ -175,7 +175,7 @@ data class OrderAccepted(override val id: OrderId) : OrderEvent
 data class OrderShipped(override val id: OrderId) : OrderEvent
 
 @JvmInline
-value class OrderId(override val value: String) : StringValueType {
+value class OrderId(override val value: String) : StringValueType<OrderId> {
     companion object {
         fun random(): OrderId {
             return OrderId(RandomIdGenerator.generate())

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -784,6 +784,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/pom.xml
+++ b/components/postgresql-event-store/pom.xml
@@ -74,6 +74,7 @@
             <groupId>dk.cloudcreate.essentials</groupId>
             <artifactId>immutable-jackson</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>dk.cloudcreate.essentials</groupId>

--- a/components/postgresql-event-store/src/main/kotlin/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/StringValueTypeAggregateIdSerializer.kt
+++ b/components/postgresql-event-store/src/main/kotlin/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/StringValueTypeAggregateIdSerializer.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.full.primaryConstructor
 /**
  * [AggregateIdSerializer] for semantic [StringValueType]'s
  */
-data class StringValueTypeAggregateIdSerializer<T : StringValueType>(private val concreteType: KClass<T>) : AggregateIdSerializer {
+data class StringValueTypeAggregateIdSerializer<T : StringValueType<T>>(private val concreteType: KClass<T>) : AggregateIdSerializer {
     override fun aggregateIdType(): Class<*> {
         return concreteType.java
     }

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/postgresql-queue/pom.xml
+++ b/components/postgresql-queue/pom.xml
@@ -71,6 +71,7 @@
             <groupId>dk.cloudcreate.essentials</groupId>
             <artifactId>immutable-jackson</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -33,7 +33,7 @@ then you need to check the component document to learn about the Security implic
 ### Beans provided by the `EssentialsComponentsConfiguration` auto-configuration:
 - Jackson/FasterXML JSON modules:
     - `EssentialTypesJacksonModule`
-    - `EssentialsImmutableJacksonModule` (if `Objenesis` is on the classpath)
+    - `EssentialsImmutableJacksonModule` (if `Objenesis` is on the classpath AND `essentials.immutable-jackson-module-enabled` has value `true`)
 - `JacksonJSONSerializer` which uses an internally configured `ObjectMapper`, which provides good defaults for JSON serialization, and includes all Jackson `Module`'s defined in the `ApplicationContext`
 - `SingleValueTypeRandomIdGenerator` to support server generated Id creations for SpringData Mongo classes with @Id fields of type `SingleValueType`
 - `MongoCustomConversions` with a `SingleValueTypeConverter` covering `LockName`, `QueueEntryId` and `QueueName`

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -471,7 +471,7 @@ public class EssentialsComponentsConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public LifecycleManager lifecycleController(EssentialsComponentsProperties properties) {
-        return new DefaultLifecycleManager(properties.getLifeCycles().isStartLifecycles());
+        return new DefaultLifecycleManager(properties.getLifeCycles().isStartLifeCycles());
     }
 
 }

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
@@ -370,7 +370,7 @@ public class EssentialsComponentsProperties {
          *
          * @return the property that determined if lifecycle beans should be started automatically
          */
-        public boolean isStartLifecycles() {
+        public boolean isStartLifeCycles() {
             return startLifeCycles;
         }
 

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
@@ -66,6 +66,7 @@ import org.springframework.context.annotation.Configuration;
  * It is highly recommended that the {@code sharedQueueCollectionName} value is only derived from a controlled and trusted source.<br>
  * To mitigate the risk of malicious input attacks, external or untrusted inputs should never directly provide the {@code sharedQueueCollectionName} value.<br>
  * <b>Failure to adequately sanitize and validate this value could expose the application to malicious input attacks, compromising the security and integrity of the database.</b>
+ *
  * @see dk.cloudcreate.essentials.components.queue.springdata.mongodb.MongoDurableQueues
  * @see dk.cloudcreate.essentials.components.distributed.fencedlock.springdata.mongo.MongoFencedLockManager
  * @see dk.cloudcreate.essentials.components.distributed.fencedlock.springdata.mongo.MongoFencedLockStorage
@@ -73,10 +74,30 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConfigurationProperties(prefix = "essentials")
 public class EssentialsComponentsProperties {
-    private final FencedLockManager   fencedLockManager = new FencedLockManager();
-    private final DurableQueues       durableQueues     = new DurableQueues();
-    private final LifeCycleProperties lifeCycles        = new LifeCycleProperties();
+    private final FencedLockManager   fencedLockManager       = new FencedLockManager();
+    private final DurableQueues       durableQueues           = new DurableQueues();
+    private final LifeCycleProperties lifeCycles              = new LifeCycleProperties();
     private final TracingProperties tracingProperties = new TracingProperties();
+    private boolean             immutableJacksonModuleEnabled = true;
+
+    /**
+     * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
+     * Setting this value to false will not include the EssentialsImmutableJacksonModule, in the ObjectMapper configuration, even if Objenesis is on the classpath
+     * @return Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration
+     */
+    public boolean isImmutableJacksonModuleEnabled() {
+        return immutableJacksonModuleEnabled;
+    }
+
+    /**
+     /**
+     * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
+     * Setting this value to false will not include the EssentialsImmutableJacksonModule, in the ObjectMapper configuration, even if Objenesis is on the classpath
+     * @param immutableJacksonModuleEnabled Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration
+     */
+    public void setImmutableJacksonModuleEnabled(boolean immutableJacksonModuleEnabled) {
+        this.immutableJacksonModuleEnabled = immutableJacksonModuleEnabled;
+    }
 
     public FencedLockManager getFencedLockManager() {
         return fencedLockManager;

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
@@ -73,7 +73,6 @@ import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_f
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
 import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
-import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
 import dk.cloudcreate.essentials.reactive.Handler;
 import dk.cloudcreate.essentials.reactive.OnErrorHandler;
 import dk.cloudcreate.essentials.reactive.command.CmdHandler;
@@ -283,14 +282,12 @@ public class EventStoreConfiguration {
     /**
      * The {@link JSONEventSerializer} that handles both {@link EventStore} event/metadata serialization as well as {@link DurableQueues} message payload serialization and deserialization
      *
-     * @param optionalEssentialsImmutableJacksonModule the optional {@link EssentialsImmutableJacksonModule}
      * @param additionalModules                        additional {@link Module}'s found in the {@link ApplicationContext}
      * @return the {@link JSONEventSerializer} responsible for serializing/deserializing the raw Java events to and from JSON
      */
     @Bean
     @ConditionalOnMissingBean
-    public JSONEventSerializer jsonSerializer(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule,
-                                              List<Module> additionalModules) {
+    public JSONEventSerializer jsonSerializer(List<Module> additionalModules) {
         var objectMapperBuilder = JsonMapper.builder()
                                             .disable(MapperFeature.AUTO_DETECT_GETTERS)
                                             .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
@@ -306,8 +303,6 @@ public class EventStoreConfiguration {
                                             .addModule(new JavaTimeModule());
 
         additionalModules.forEach(objectMapperBuilder::addModule);
-
-        optionalEssentialsImmutableJacksonModule.ifPresent(objectMapperBuilder::addModule);
 
         var objectMapper = objectMapperBuilder.build();
         objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -34,7 +34,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 ### Beans provided by the `EssentialsComponentsConfiguration` auto-configuration:
 - Jackson/FasterXML JSON modules:
     - `EssentialTypesJacksonModule`
-    - `EssentialsImmutableJacksonModule` (if `Objenesis` is on the classpath)
+    - `EssentialsImmutableJacksonModule` (if `Objenesis` is on the classpath AND `essentials.immutable-jackson-module-enabled` has value `true`)
 - `JSONSerializer` which uses an internally configured `ObjectMapper`, which provides good defaults for JSON serialization, and includes all Jackson `Module`'s defined in the `ApplicationContext`
     - This `JSONSerializer` will only be auto-registered if the `JSONEventSerializer` is not on the classpath (see `EventStoreConfiguration`)
 - `Jdbi` to use the provided Spring `DataSource`

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -151,7 +151,7 @@ public class EssentialsComponentsConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean
-    public com.fasterxml.jackson.databind.Module essentialJacksonModule() {
+    public EssentialTypesJacksonModule essentialJacksonModule() {
         return new EssentialTypesJacksonModule();
     }
 
@@ -162,6 +162,7 @@ public class EssentialsComponentsConfiguration {
      */
     @Bean
     @ConditionalOnClass(name = "org.objenesis.ObjenesisStd")
+    @ConditionalOnProperty(prefix = "essentials", name = "immutable-jackson-module-enabled", havingValue = "true")
     @ConditionalOnMissingBean
     public EssentialsImmutableJacksonModule essentialsImmutableJacksonModule() {
         return new EssentialsImmutableJacksonModule();
@@ -339,15 +340,13 @@ public class EssentialsComponentsConfiguration {
      * {@link JSONSerializer} responsible for serializing/deserializing the raw Java events to and from JSON
      * (including handling {@link DurableQueues} message payload serialization and deserialization)
      *
-     * @param optionalEssentialsImmutableJacksonModule the optional {@link EssentialsImmutableJacksonModule}
      * @param additionalModules                        additional {@link Module}'s found in the {@link ApplicationContext}
      * @return the {@link JSONSerializer} responsible for serializing/deserializing the raw Java events to and from JSON
      */
     @Bean
     @ConditionalOnMissingClass("dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JSONEventSerializer")
     @ConditionalOnMissingBean
-    public JSONSerializer jsonSerializer(Optional<EssentialsImmutableJacksonModule> optionalEssentialsImmutableJacksonModule,
-                                         List<Module> additionalModules) {
+    public JSONSerializer jsonSerializer(List<Module> additionalModules) {
         var objectMapperBuilder = JsonMapper.builder()
                                             .disable(MapperFeature.AUTO_DETECT_GETTERS)
                                             .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
@@ -363,8 +362,6 @@ public class EssentialsComponentsConfiguration {
                                             .addModule(new JavaTimeModule());
 
         additionalModules.forEach(objectMapperBuilder::addModule);
-
-        optionalEssentialsImmutableJacksonModule.ifPresent(objectMapperBuilder::addModule);
 
         var objectMapper = objectMapperBuilder.build();
         objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -87,6 +87,26 @@ public class EssentialsComponentsProperties {
     private final LifeCycleProperties lifeCycles = new LifeCycleProperties();
     private final TracingProperties tracingProperties = new TracingProperties();
 
+    private boolean             immutableJacksonModuleEnabled = true;
+
+    /**
+     * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
+     * Setting this value to false will not include the EssentialsImmutableJacksonModule, in the ObjectMapper configuration, even if Objenesis is on the classpath
+     * @return Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration
+     */
+    public boolean isImmutableJacksonModuleEnabled() {
+        return immutableJacksonModuleEnabled;
+    }
+
+    /**
+     /**
+     * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
+     * Setting this value to false will not include the EssentialsImmutableJacksonModule, in the ObjectMapper configuration, even if Objenesis is on the classpath
+     * @param immutableJacksonModuleEnabled Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration
+     */
+    public void setImmutableJacksonModuleEnabled(boolean immutableJacksonModuleEnabled) {
+        this.immutableJacksonModuleEnabled = immutableJacksonModuleEnabled;
+    }
 
     public FencedLockManagerProperties getFencedLockManager() {
         return fencedLockManager;

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/pom.xml
+++ b/components/spring-postgresql-event-store/pom.xml
@@ -53,6 +53,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>dk.cloudcreate.essentials</groupId>
+            <artifactId>immutable-jackson</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
             <scope>provided</scope>

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/components/springdata-mongo-queue/pom.xml
+++ b/components/springdata-mongo-queue/pom.xml
@@ -71,6 +71,7 @@
             <groupId>dk.cloudcreate.essentials</groupId>
             <artifactId>immutable-jackson</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <developerConnection>scm:https://github.com/cloudcreate-dk/essentials-project.git</developerConnection>
         <connection>scm:https://github.com/cloudcreate-dk/essentials-project.git</connection>
     </scm>
-  
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -67,41 +67,42 @@
 
         <objenesis.version>3.3</objenesis.version>
         <postgresql.version>42.7.3</postgresql.version>
-        <slf4j.version>2.0.12</slf4j.version>
-        <spring-boot.version>3.2.3</spring-boot.version>
+        <slf4j.version>2.0.13</slf4j.version>
+        <spring-boot.version>3.2.5</spring-boot.version>
         <awaitility.version>4.2.1</awaitility.version>
-        <spring-data-mongodb.version>4.2.4</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.4</spring-data-jpa.version>
+        <spring-data-mongodb.version>4.2.5</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.2.5</spring-data-jpa.version>
         <objenesis.version>3.3</objenesis.version>
         <assertj.version>3.25.3</assertj.version>
-        <mongodb-driver-sync.version>4.11.1</mongodb-driver-sync.version>
+        <mongodb-driver-sync.version>4.11.2</mongodb-driver-sync.version>
         <log4j-to-slf4j.version>2.23.1</log4j-to-slf4j.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <micrometer.version>1.12.4</micrometer.version>
-        <micrometer-tracing.version>1.2.4</micrometer-tracing.version>
-        <netty-bom.version>4.1.107.Final</netty-bom.version>
+        <micrometer.version>1.12.5</micrometer.version>
+        <micrometer-tracing.version>1.2.5</micrometer-tracing.version>
+        <netty-bom.version>4.1.109.Final</netty-bom.version>
         <junit-bom.version>5.10.2</junit-bom.version>
         <testcontainers-bom.version>1.19.7</testcontainers-bom.version>
         <jdbi3-bom.version>3.45.1</jdbi3-bom.version>
         <jackson-bom.version>2.17.0</jackson-bom.version>
-        <reactor-bom.version>2023.0.4</reactor-bom.version>
-        <spring-framework-bom.version>6.1.5</spring-framework-bom.version>
+        <reactor-bom.version>2023.0.5</reactor-bom.version>
+        <spring-framework-bom.version>6.1.6</spring-framework-bom.version>
         <mockito-bom.version>5.11.0</mockito-bom.version>
-        <logback.version>1.5.3</logback.version>
+        <logback.version>1.5.6</logback.version>
         <avro.version>1.11.3</avro.version>
         <commons-compress.version>1.26.1</commons-compress.version>
 
+        <dokka.version>1.9.20</dokka.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
         <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
-        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
+        <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
@@ -109,10 +110,10 @@
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>9.0.10</dependency-check-maven.version>
+        <dependency-check-maven.version>9.1.0</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-        <maven-gpg-plugin.version>3.2.1</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
     </properties>
 
     <modules>
@@ -289,6 +290,21 @@
         </testResources>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.jetbrains.dokka</groupId>
+                    <artifactId>dokka-maven-plugin</artifactId>
+                    <version>${dokka.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>dokka</goal>
+                                <goal>javadoc</goal>
+                                <goal>javadocJar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
@@ -552,6 +568,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -566,6 +586,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [BigDecimalValueType] value class
  */
-abstract class BigDecimalValueTypeArgumentFactory<T : BigDecimalValueType> : AbstractArgumentFactory<T>(Types.NUMERIC) {
+abstract class BigDecimalValueTypeArgumentFactory<T : BigDecimalValueType<T>> : AbstractArgumentFactory<T>(Types.NUMERIC) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setBigDecimal(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [BigDecimalValueType] this instance is mapping
  */
-abstract class BigDecimalValueTypeColumnMapper<T : BigDecimalValueType> : ColumnMapper<T?> {
+abstract class BigDecimalValueTypeColumnMapper<T : BigDecimalValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [BigIntegerValueType] value class
  */
-abstract class BigIntegerValueTypeArgumentFactory<T : BigIntegerValueType> : AbstractArgumentFactory<T>(Types.VARBINARY) {
+abstract class BigIntegerValueTypeArgumentFactory<T : BigIntegerValueType<T>> : AbstractArgumentFactory<T>(Types.VARBINARY) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setBytes(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeColumnMapper.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [BigIntegerValueType] this instance is mapping
  */
-abstract class BigIntegerValueTypeColumnMapper<T : BigIntegerValueType> : ColumnMapper<T?> {
+abstract class BigIntegerValueTypeColumnMapper<T : BigIntegerValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [ByteValueType] value class
  */
-abstract class ByteValueTypeArgumentFactory<T : ByteValueType> : AbstractArgumentFactory<T>(Types.TINYINT) {
+abstract class ByteValueTypeArgumentFactory<T : ByteValueType<T>> : AbstractArgumentFactory<T>(Types.TINYINT) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setByte(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [ByteValueType] this instance is mapping
  */
-abstract class ByteValueTypeColumnMapper<T : ByteValueType> : ColumnMapper<T?> {
+abstract class ByteValueTypeColumnMapper<T : ByteValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [DoubleValueType] value class
  */
-abstract class DoubleValueTypeArgumentFactory<T : DoubleValueType> : AbstractArgumentFactory<T>(Types.DOUBLE) {
+abstract class DoubleValueTypeArgumentFactory<T : DoubleValueType<T>> : AbstractArgumentFactory<T>(Types.DOUBLE) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setDouble(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [DoubleValueType] this instance is mapping
  */
-abstract class DoubleValueTypeColumnMapper<T : DoubleValueType> : ColumnMapper<T?> {
+abstract class DoubleValueTypeColumnMapper<T : DoubleValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [FloatValueType] value class
  */
-abstract class FloatValueTypeArgumentFactory<T : FloatValueType> : AbstractArgumentFactory<T>(Types.FLOAT) {
+abstract class FloatValueTypeArgumentFactory<T : FloatValueType<T>> : AbstractArgumentFactory<T>(Types.FLOAT) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setFloat(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [FloatValueType] this instance is mapping
  */
-abstract class FloatValueTypeColumnMapper<T : DoubleValueType> : ColumnMapper<T?> {
+abstract class FloatValueTypeColumnMapper<T : DoubleValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeArgumentFactory.kt
@@ -30,7 +30,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [InstantValueType] value class
  */
-abstract class InstantValueTypeArgumentFactory<T : InstantValueType> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
+abstract class InstantValueTypeArgumentFactory<T : InstantValueType<T>> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setTimestamp(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [InstantValueType] this instance is mapping
  */
-abstract class InstantValueTypeColumnMapper<T : InstantValueType> : ColumnMapper<T?> {
+abstract class InstantValueTypeColumnMapper<T : InstantValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [IntValueType] value class
  */
-abstract class IntValueTypeArgumentFactory<T : IntValueType> : AbstractArgumentFactory<T>(Types.FLOAT) {
+abstract class IntValueTypeArgumentFactory<T : IntValueType<T>> : AbstractArgumentFactory<T>(Types.FLOAT) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setInt(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [IntValueType] this instance is mapping
  */
-abstract class IntValueTypeColumnMapper<T : IntValueType> : ColumnMapper<T?> {
+abstract class IntValueTypeColumnMapper<T : IntValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeArgumentFactory.kt
@@ -30,7 +30,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [LocalDateTimeValueType] value class
  */
-abstract class LocalDateTimeValueTypeArgumentFactory<T : LocalDateTimeValueType> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
+abstract class LocalDateTimeValueTypeArgumentFactory<T : LocalDateTimeValueType<T>> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setTimestamp(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [LocalDateTimeValueType] this instance is mapping
  */
-abstract class LocalDateTimeValueTypeColumnMapper<T : LocalDateTimeValueType> : ColumnMapper<T?> {
+abstract class LocalDateTimeValueTypeColumnMapper<T : LocalDateTimeValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeArgumentFactory.kt
@@ -30,7 +30,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [LocalDateValueType] value class
  */
-abstract class LocalDateValueTypeArgumentFactory<T : LocalDateValueType> : AbstractArgumentFactory<T>(Types.DATE) {
+abstract class LocalDateValueTypeArgumentFactory<T : LocalDateValueType<T>> : AbstractArgumentFactory<T>(Types.DATE) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setDate(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [LocalDateValueType] this instance is mapping
  */
-abstract class LocalDateValueTypeColumnMapper<T : LocalDateValueType> : ColumnMapper<T?> {
+abstract class LocalDateValueTypeColumnMapper<T : LocalDateValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeArgumentFactory.kt
@@ -30,7 +30,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [LocalTimeValueType] value class
  */
-abstract class LocalTimeValueTypeArgumentFactory<T : LocalTimeValueType> : AbstractArgumentFactory<T>(Types.TIME) {
+abstract class LocalTimeValueTypeArgumentFactory<T : LocalTimeValueType<T>> : AbstractArgumentFactory<T>(Types.TIME) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setTime(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [LocalTimeValueType] this instance is mapping
  */
-abstract class LocalTimeValueTypeColumnMapper<T : LocalTimeValueType> : ColumnMapper<T?> {
+abstract class LocalTimeValueTypeColumnMapper<T : LocalTimeValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [LongValueType] value class
  */
-abstract class LongValueTypeArgumentFactory<T : LongValueType> : AbstractArgumentFactory<T>(Types.BIGINT) {
+abstract class LongValueTypeArgumentFactory<T : LongValueType<T>> : AbstractArgumentFactory<T>(Types.BIGINT) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setLong(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [LongValueType] this instance is mapping
  */
-abstract class LongValueTypeColumnMapper<T : LongValueType> : ColumnMapper<T?> {
+abstract class LongValueTypeColumnMapper<T : LongValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeArgumentFactory.kt
@@ -30,7 +30,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [OffsetDateTimeValueType] value class
  */
-abstract class OffsetDateTimeValueTypeArgumentFactory<T : OffsetDateTimeValueType> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
+abstract class OffsetDateTimeValueTypeArgumentFactory<T : OffsetDateTimeValueType<T>> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setTimestamp(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeColumnMapper.kt
@@ -32,7 +32,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [OffsetDateTimeValueType] this instance is mapping
  */
-abstract class OffsetDateTimeValueTypeColumnMapper<T : OffsetDateTimeValueType> : ColumnMapper<T?> {
+abstract class OffsetDateTimeValueTypeColumnMapper<T : OffsetDateTimeValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [ShortValueType] value class
  */
-abstract class ShortValueTypeArgumentFactory<T : ShortValueType> : AbstractArgumentFactory<T>(Types.SMALLINT) {
+abstract class ShortValueTypeArgumentFactory<T : ShortValueType<T>> : AbstractArgumentFactory<T>(Types.SMALLINT) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setShort(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [ShortValueType] this instance is mapping
  */
-abstract class ShortValueTypeColumnMapper<T : ShortValueType> : ColumnMapper<T?> {
+abstract class ShortValueTypeColumnMapper<T : ShortValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeArgumentFactory.kt
@@ -29,7 +29,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [StringValueType] value class
  */
-abstract class StringValueTypeArgumentFactory<T : StringValueType> : AbstractArgumentFactory<T>(Types.VARCHAR) {
+abstract class StringValueTypeArgumentFactory<T : StringValueType<T>> : AbstractArgumentFactory<T>(Types.VARCHAR) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setString(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeColumnMapper.kt
@@ -30,7 +30,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [StringValueType] this instance is mapping
  */
-abstract class StringValueTypeColumnMapper<T : StringValueType> : ColumnMapper<T?> {
+abstract class StringValueTypeColumnMapper<T : StringValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeArgumentFactory.kt
@@ -30,7 +30,7 @@ import java.sql.Types
  *
  * @param <T> the concrete [ZonedDateTimeValueType] value class
  */
-abstract class ZonedDateTimeValueTypeArgumentFactory<T : ZonedDateTimeValueType> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
+abstract class ZonedDateTimeValueTypeArgumentFactory<T : ZonedDateTimeValueType<T>> : AbstractArgumentFactory<T>(Types.TIMESTAMP) {
     override fun build(value: T, config: ConfigRegistry?): Argument {
         return Argument { position: Int, statement: PreparedStatement, ctx: StatementContext? ->
             statement.setTimestamp(

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeColumnMapper.kt
@@ -32,7 +32,7 @@ import kotlin.reflect.full.primaryConstructor
  *
  * @param <T> the concrete [ZonedDateTimeValueType] this instance is mapping
  */
-abstract class ZonedDateTimeValueTypeColumnMapper<T : ZonedDateTimeValueType> : ColumnMapper<T?> {
+abstract class ZonedDateTimeValueTypeColumnMapper<T : ZonedDateTimeValueType<T>> : ColumnMapper<T?> {
     private val concreteType: KClass<T>
 
     constructor() {

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/KotlinValueTypeArgumentsTest.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/KotlinValueTypeArgumentsTest.kt
@@ -283,44 +283,44 @@ internal class SingleValueTypeArgumentsTest {
                         ).toLocalTime()
                     )
                 }
-                if (columnValue is InstantValueType) {
+                if (columnValue is InstantValueType<*>) {
                     Assertions.assertThat(columnValue.value)
                         .describedAs(
                             "Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
                             column._1, column._2!!.javaClass, compareWithValue, columnValue, columnValue.javaClass
                         )
                         .isCloseTo(
-                            (compareWithValue as InstantValueType).value,
+                            (compareWithValue as InstantValueType<*>).value,
                             Assertions.within(100, ChronoUnit.MICROS)
                         )
-                } else if (columnValue is LocalDateTimeValueType) {
+                } else if (columnValue is LocalDateTimeValueType<*>) {
                     Assertions.assertThat(columnValue.value)
                         .describedAs(
                             "Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
                             column._1, column._2!!.javaClass, compareWithValue, columnValue, columnValue.javaClass
                         )
                         .isCloseTo(
-                            (compareWithValue as LocalDateTimeValueType)!!.value,
+                            (compareWithValue as LocalDateTimeValueType<*>).value,
                             Assertions.within(100, ChronoUnit.MICROS)
                         )
-                } else if (columnValue is OffsetDateTimeValueType) {
+                } else if (columnValue is OffsetDateTimeValueType<*>) {
                     Assertions.assertThat(columnValue.value)
                         .describedAs(
                             "Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
                             column._1, column._2!!.javaClass, compareWithValue, columnValue, columnValue.javaClass
                         )
                         .isCloseTo(
-                            (compareWithValue as OffsetDateTimeValueType).value,
+                            (compareWithValue as OffsetDateTimeValueType<*>).value,
                             Assertions.within(100, ChronoUnit.MICROS)
                         )
-                } else if (columnValue is ZonedDateTimeValueType) {
+                } else if (columnValue is ZonedDateTimeValueType<*>) {
                     Assertions.assertThat(columnValue.value)
                         .describedAs(
                             "Column: '%s' of type '%s' with original value: '%s' and returned value '%s' of type '%s'",
                             column._1, column._2!!.javaClass, compareWithValue, columnValue, columnValue.javaClass
                         )
                         .isCloseTo(
-                            (compareWithValue as ZonedDateTimeValueType).value,
+                            (compareWithValue as ZonedDateTimeValueType<*>).value,
                             Assertions.within(100, ChronoUnit.MICROS)
                         )
                 } else {

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/AccountId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/AccountId.kt
@@ -23,7 +23,7 @@ import dk.cloudcreate.essentials.types.Identifier
 import java.util.*
 
 @JvmInline
-value class AccountId(override val value: Long) : LongValueType, Identifier {
+value class AccountId(override val value: Long) : LongValueType<AccountId>, Identifier {
     companion object {
         private val RANDOM_ID_GENERATOR = Random()
 

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/Created.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/Created.kt
@@ -22,7 +22,7 @@ import dk.cloudcreate.essentials.kotlin.types.jdbi.LocalDateTimeValueTypeColumnM
 import java.time.LocalDateTime
 
 @JvmInline
-value class Created(override val value: LocalDateTime) : LocalDateTimeValueType {
+value class Created(override val value: LocalDateTime) : LocalDateTimeValueType<Created> {
     companion object {
         fun of(value: LocalDateTime): Created {
             return Created(value)

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/CustomertId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/CustomertId.kt
@@ -23,7 +23,7 @@ import dk.cloudcreate.essentials.types.Identifier
 import java.util.*
 
 @JvmInline
-value class CustomerId(override val value: String) : StringValueType, Identifier {
+value class CustomerId(override val value: String) : StringValueType<CustomerId>, Identifier {
     companion object {
         fun of(value: String): CustomerId {
             return CustomerId(value)

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/DueDate.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/DueDate.kt
@@ -22,7 +22,7 @@ import dk.cloudcreate.essentials.kotlin.types.jdbi.LocalDateValueTypeColumnMappe
 import java.time.LocalDate
 
 @JvmInline
-value class DueDate(override val value: LocalDate) : LocalDateValueType {
+value class DueDate(override val value: LocalDate) : LocalDateValueType<DueDate> {
     companion object {
         fun of(value: LocalDate): DueDate {
             return DueDate(value)

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/LastUpdated.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/LastUpdated.kt
@@ -22,7 +22,7 @@ import dk.cloudcreate.essentials.kotlin.types.jdbi.InstantValueTypeColumnMapper
 import java.time.Instant
 
 @JvmInline
-value class LastUpdated(override val value: Instant) : InstantValueType {
+value class LastUpdated(override val value: Instant) : InstantValueType<LastUpdated> {
     companion object {
         fun of(value: Instant): LastUpdated {
             return LastUpdated(value)

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/OrderId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/OrderId.kt
@@ -23,7 +23,7 @@ import dk.cloudcreate.essentials.types.Identifier
 import java.util.*
 
 @JvmInline
-value class OrderId(override val value: Long) : LongValueType, Identifier {
+value class OrderId(override val value: Long) : LongValueType<OrderId>, Identifier {
     companion object {
         private val RANDOM_ID_GENERATOR = Random()
 

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/ProductId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/ProductId.kt
@@ -23,7 +23,7 @@ import dk.cloudcreate.essentials.types.Identifier
 import java.util.*
 
 @JvmInline
-value class ProductId(override val value: String) : StringValueType, Identifier {
+value class ProductId(override val value: String) : StringValueType<ProductId>, Identifier {
     companion object {
         fun of(value: String): ProductId {
             return ProductId(value)

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TimeOfDay.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TimeOfDay.kt
@@ -19,10 +19,11 @@ package dk.cloudcreate.essentials.kotlin.types.jdbi.model
 import dk.cloudcreate.essentials.kotlin.types.LocalTimeValueType
 import dk.cloudcreate.essentials.kotlin.types.jdbi.LocalTimeValueTypeArgumentFactory
 import dk.cloudcreate.essentials.kotlin.types.jdbi.LocalTimeValueTypeColumnMapper
+import java.sql.Time
 import java.time.LocalTime
 
 @JvmInline
-value class TimeOfDay(override val value: LocalTime) : LocalTimeValueType {
+value class TimeOfDay(override val value: LocalTime) : LocalTimeValueType<TimeOfDay> {
     companion object {
         fun of(value: LocalTime): TimeOfDay {
             return TimeOfDay(value)

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransactionTime.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransactionTime.kt
@@ -22,7 +22,7 @@ import dk.cloudcreate.essentials.kotlin.types.jdbi.ZonedDateTimeValueTypeColumnM
 import java.time.ZonedDateTime
 
 @JvmInline
-value class TransactionTime(override val value: ZonedDateTime) : ZonedDateTimeValueType {
+value class TransactionTime(override val value: ZonedDateTime) : ZonedDateTimeValueType<TransactionTime> {
     companion object {
         fun of(value: ZonedDateTime): TransactionTime {
             return TransactionTime(value)

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransferTime.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransferTime.kt
@@ -22,7 +22,7 @@ import dk.cloudcreate.essentials.kotlin.types.jdbi.OffsetDateTimeValueTypeColumn
 import java.time.OffsetDateTime
 
 @JvmInline
-value class TransferTime(override val value: OffsetDateTime) : OffsetDateTimeValueType {
+value class TransferTime(override val value: OffsetDateTime) : OffsetDateTimeValueType<TransferTime> {
     companion object {
         fun of(value: OffsetDateTime): TransferTime {
             return TransferTime(value)

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.6</version>
+    <version>0.40.7</version>
 </dependency>
 ```
 

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/Amount.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/Amount.kt
@@ -28,7 +28,7 @@ import java.math.MathContext
  * @see Money
  */
 @JvmInline
-value class Amount(override val value: BigDecimal) : BigDecimalValueType {
+value class Amount(override val value: BigDecimal) : BigDecimalValueType<Amount> {
 
     constructor(value: Long) : this(BigDecimal.valueOf(value))
 

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigDecimalValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigDecimalValueType.kt
@@ -22,6 +22,10 @@ import java.math.BigDecimal
 /**
  * Semantic [BigDecimal] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface BigDecimalValueType : Serializable {
+interface BigDecimalValueType<SELF: BigDecimalValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: BigDecimal
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigIntegerValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigIntegerValueType.kt
@@ -22,6 +22,10 @@ import java.math.BigInteger
 /**
  * Semantic [BigInteger] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface BigIntegerValueType : Serializable {
+interface BigIntegerValueType<SELF: BigIntegerValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: BigInteger
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ByteValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ByteValueType.kt
@@ -21,6 +21,10 @@ import java.io.Serializable
 /**
  * Semantic [Byte] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface ByteValueType : Serializable {
+interface ByteValueType<SELF: ByteValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: Byte
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/CountryCode.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/CountryCode.kt
@@ -34,7 +34,7 @@ value class CountryCode
  * @param countryCode the ISO-3166 2 character country code with the `countryCode` as UPPER CASE value
  * @throws IllegalArgumentException in case the  ISO-3166 2 character country code is not known or otherwise invalid.
  */
-    (override val value: String) : StringValueType {
+    (override val value: String) : StringValueType<CountryCode> {
 
     init {
         validate(value)

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/DoubleValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/DoubleValueType.kt
@@ -21,6 +21,10 @@ import java.io.Serializable
 /**
  * Semantic [Double] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface DoubleValueType : Serializable {
+interface DoubleValueType<SELF: DoubleValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: Double
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/FloatValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/FloatValueType.kt
@@ -21,6 +21,10 @@ import java.io.Serializable
 /**
  * Semantic [Float] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface FloatValueType : Serializable {
+interface FloatValueType<SELF: FloatValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: Float
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/InstantValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/InstantValueType.kt
@@ -22,6 +22,10 @@ import java.time.Instant
 /**
  * Semantic [Instant] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface InstantValueType : Serializable {
+interface InstantValueType<SELF: InstantValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: Instant
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/IntValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/IntValueType.kt
@@ -21,6 +21,10 @@ import java.io.Serializable
 /**
  * Semantic [Int] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface IntValueType : Serializable {
+interface IntValueType<SELF: IntValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: Int
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateTimeValueType.kt
@@ -22,6 +22,10 @@ import java.time.LocalDateTime
 /**
  * Semantic [LocalDateTime] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface LocalDateTimeValueType : Serializable {
+interface LocalDateTimeValueType<SELF: LocalDateTimeValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: LocalDateTime
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateValueType.kt
@@ -22,6 +22,10 @@ import java.time.LocalDate
 /**
  * Semantic [LocalDate] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface LocalDateValueType : Serializable {
+interface LocalDateValueType<SELF: LocalDateValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: LocalDate
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalTimeValueType.kt
@@ -22,6 +22,10 @@ import java.time.LocalTime
 /**
  * Semantic [LocalTime] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface LocalTimeValueType : Serializable {
+interface LocalTimeValueType<SELF: LocalTimeValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: LocalTime
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LongValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LongValueType.kt
@@ -21,6 +21,10 @@ import java.io.Serializable
 /**
  * Semantic [Long] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface LongValueType : Serializable {
+interface LongValueType<SELF: LongValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: Long
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/OffsetDateTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/OffsetDateTimeValueType.kt
@@ -22,6 +22,10 @@ import java.time.OffsetDateTime
 /**
  * Semantic [OffsetDateTime] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface OffsetDateTimeValueType : Serializable {
+interface OffsetDateTimeValueType<SELF: OffsetDateTimeValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: OffsetDateTime
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ShortValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ShortValueType.kt
@@ -21,6 +21,10 @@ import java.io.Serializable
 /**
  * Semantic [Short] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface ShortValueType : Serializable {
+interface ShortValueType<SELF: ShortValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: Short
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/StringValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/StringValueType.kt
@@ -21,6 +21,10 @@ import java.io.Serializable
 /**
  * Semantic [String] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface StringValueType : Serializable {
+interface StringValueType<SELF: StringValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: String
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ZonedDateTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ZonedDateTimeValueType.kt
@@ -22,6 +22,10 @@ import java.time.ZonedDateTime
 /**
  * Semantic [ZonedDateTime] value type interface that allows infrastructure code to easily access the [value] of the value type
  */
-interface ZonedDateTimeValueType : Serializable {
+interface ZonedDateTimeValueType<SELF: ZonedDateTimeValueType<SELF>> : Serializable, Comparable<SELF> {
     val value: ZonedDateTime
+
+    override fun compareTo(other: SELF): Int {
+        return this.value.compareTo(other.value)
+    }
 }


### PR DESCRIPTION
## General
- Changed usage of `immutable-jackson` to be an optional or test only dependency in other essentials modules
- Enabled DependencyCheck during Github builds again.
- Added `dokka-maven-plugin` 1.9.20

## types, types-jdbi, kotlin-eventsourcing, postgresql-event-store
- Changed kotlin semantic types to include their self type and implement `Comparable`

## spring-boot-starter-mongodb
- MongoCorrected the Mongo starter EssentialsComponentsProperties LifeCycle `isStartLifecycles` property name to `isStartLifeCycles`
- Changed `EssentialsImmutableJacksonModule` SpringBoot starter configuration, by introducing property `immutable-jackson-module-enabled` to control if `EssentialsImmutableJacksonModule` is included, even if Objenesis is on the classpath.
- Removed `optionalEssentialsImmutableJacksonModule` from the configuration of the `JSONSerializer`

## spring-boot-starter-postgresql
- Changed `EssentialsImmutableJacksonModule` SpringBoot starter configuration, by introducing property `immutable-jackson-module-enabled` to control if `EssentialsImmutableJacksonModule` is included, even if Objenesis is on the classpath.
- Removed `optionalEssentialsImmutableJacksonModule` from the configuration of the `JSONSerializer`

## spring-boot-starter-postgresql-event-store
- Removed `optionalEssentialsImmutableJacksonModule` from the configuration of the `JSONEventSerializer`

## Updated maven plugins:
- maven-install-plugin 3.1.2
- maven-deploy-plugin 3.1.2
- maven-jar-plugin 3.4.1
- maven-source-plugin 3.3.1
- dependency-check-maven 9.1.0
- maven-gpg-plugin 3.2.4

## Updated 3rd party dependencies:
- slf4j 2.0.13
- spring-boot 3.2.5
- spring-data-mongodb 4.2.5
- spring-data-jpa 3.2.5
- mongodb-driver-sync 4.11.2
- json-smart 2.5.1
- micrometer 1.12.5
- micrometer-tracing 1.2.5
- netty 4.1.109.Final
- reactor 2023.0.5
- spring-framework 6.1.6
- logback 1.5.6