### PR TITLE
Release 0.40.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -153,7 +153,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -168,7 +168,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -246,7 +246,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -294,7 +294,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -361,7 +361,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -407,7 +407,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -479,7 +479,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 
@@ -493,7 +493,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DistributedCompetingConsumersDurableQueuesIT.java
@@ -105,7 +105,9 @@ public abstract class DistributedCompetingConsumersDurableQueuesIT<DURABLE_QUEUE
         usingDurableQueue(() -> durableQueues1.queueMessages(queueName, messages));
 
         assertThat(durableQueues1.getTotalMessagesQueuedFor(queueName)).isEqualTo(numberOfMessages);
+        assertThat(durableQueues1.getQueuedMessageCountsFor(queueName)).isEqualTo(new QueuedMessageCounts(queueName, numberOfMessages, 0));
         assertThat(durableQueues2.getTotalMessagesQueuedFor(queueName)).isEqualTo(numberOfMessages);
+        assertThat(durableQueues2.getQueuedMessageCountsFor(queueName)).isEqualTo(new QueuedMessageCounts(queueName, numberOfMessages, 0));
         var recordingQueueMessageHandler1 = new RecordingQueuedMessageHandler();
         var recordingQueueMessageHandler2 = new RecordingQueuedMessageHandler();
 

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalCompetingConsumersDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalCompetingConsumersDurableQueueIT.java
@@ -107,6 +107,8 @@ public abstract class LocalCompetingConsumersDurableQueueIT<DURABLE_QUEUES exten
                                       () -> durableQueues.queueMessages(queueName, messages)));
 
         assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(numberOfMessages);
+        assertThat(durableQueues.getQueuedMessageCountsFor(queueName)).isEqualTo(new QueuedMessageCounts(queueName, numberOfMessages, 0));
+
 
         var recordingQueueMessageHandler = new RecordingQueuedMessageHandler();
 

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesDurableQueueIT.java
@@ -129,6 +129,7 @@ public abstract class LocalOrderedMessagesDurableQueueIT<DURABLE_QUEUES extends 
                                       () -> durableQueues.queueMessages(queueName, messages)));
 
         assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(numberOfMessages);
+        assertThat(durableQueues.getQueuedMessageCountsFor(queueName)).isEqualTo(new QueuedMessageCounts(queueName, numberOfMessages, 0));
 
         var recordingQueueMessageHandler = new RecordingQueuedMessageHandler();
 

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -130,6 +130,7 @@ public abstract class LocalOrderedMessagesRedeliveryDurableQueueIT<DURABLE_QUEUE
                                       () -> durableQueues.queueMessages(queueName, messages)));
 
         assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(numberOfMessages);
+        assertThat(durableQueues.getQueuedMessageCountsFor(queueName)).isEqualTo(new QueuedMessageCounts(queueName, numberOfMessages, 0));
 
         var recordingQueueMessageHandler = new RecordingQueuedMessageHandler();
 

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -625,6 +625,22 @@ public interface DurableQueues extends Lifecycle {
     long getTotalMessagesQueuedFor(GetTotalMessagesQueuedFor operation);
 
     /**
+     * Get the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
+     * @param queueName  the name of the Queue where we will query for the number of queued messages
+     * @return the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
+     */
+    default QueuedMessageCounts getQueuedMessageCountsFor(QueueName queueName) {
+        return getQueuedMessageCountsFor(new GetQueuedMessageCountsFor(queueName));
+    }
+
+    /**
+     * Get the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
+     * @param operation the {@link GetQueuedMessageCountsFor} operation
+     * @return the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
+     */
+    QueuedMessageCounts getQueuedMessageCountsFor(GetQueuedMessageCountsFor operation);
+
+    /**
      * Get the total number of dead-letter-messages/poison-messages queued for the given queue
      *
      * @param queueName the name of the Queue where we will query for the number of dead-letter-messages/poison-messages

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueuesInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueuesInterceptor.java
@@ -184,6 +184,17 @@ public interface DurableQueuesInterceptor extends Interceptor {
     }
 
     /**
+     * Intercept {@link GetQueuedMessageCountsFor} calls
+     *
+     * @param operation        the operation
+     * @param interceptorChain the interceptor chain (call {@link InterceptorChain#proceed()} to continue the processing chain)
+     * @return the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
+     */
+    default QueuedMessageCounts intercept(GetQueuedMessageCountsFor operation, InterceptorChain<GetQueuedMessageCountsFor, QueuedMessageCounts, DurableQueuesInterceptor> interceptorChain) {
+        return interceptorChain.proceed();
+    }
+
+    /**
      * Intercept {@link GetTotalDeadLetterMessagesQueuedFor} calls
      *
      * @param operation        the operation

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageCounts.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageCounts.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation.messaging.queue;
+
+/**
+ * The total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
+ *
+ * @param queueName                        the name of the queue
+ * @param numberOfQueuedMessages           the total number (non-dead-letter) messages queued
+ * @param numberOfQueuedDeadLetterMessages the total number of dead-letter messages queued
+ */
+public record QueuedMessageCounts(QueueName queueName,
+                                  long numberOfQueuedMessages,
+                                  long numberOfQueuedDeadLetterMessages) {
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsFor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsFor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation.messaging.queue.operations;
+
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.shared.interceptor.InterceptorChain;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * Get the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue<br>
+ * Operation also matched {@link DurableQueuesInterceptor#intercept(GetQueuedMessageCountsFor, InterceptorChain)}
+ */
+public final class GetQueuedMessageCountsFor {
+    /**
+     * the name of the Queue where we will query for the total number of messages queued and number of queued Dead Letter Messages for the given queue
+     */
+    public final QueueName           queueName;
+
+    /**
+     * Create a new builder that produces a new {@link GetQueuedMessageCountsFor} instance
+     *
+     * @return a new {@link GetQueuedMessageCountsForBuilder} instance
+     */
+    public static GetQueuedMessageCountsForBuilder builder() {
+        return new GetQueuedMessageCountsForBuilder();
+    }
+
+    /**
+     * Get the total number of messages queued (i.e. not including Dead Letter Messages) for the given queue
+     *
+     * @param queueName the name of the Queue where we will query for the number of queued messages
+     */
+    public GetQueuedMessageCountsFor(QueueName queueName) {
+        this.queueName = requireNonNull(queueName, "No queueName provided");
+    }
+
+    /**
+     *
+     * @return the name of the Queue where we will query for the number of queued messages
+     */
+    public QueueName getQueueName() {
+        return queueName;
+    }
+
+    @Override
+    public String toString() {
+        return "GetQueuedMessageCountsFor{" +
+                "queueName=" + queueName +
+                '}';
+    }
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsForBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsForBuilder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation.messaging.queue.operations;
+
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueName;
+
+/**
+ * Builder for {@link GetQueuedMessageCountsFor}
+ */
+public final class GetQueuedMessageCountsForBuilder {
+    private QueueName queueName;
+
+    /**
+     *
+     * @param queueName the name of the Queue where we will query for the number of queued messages
+     * @return this builder instance
+     */
+    public GetQueuedMessageCountsForBuilder setQueueName(QueueName queueName) {
+        this.queueName = queueName;
+        return this;
+    }
+
+    /**
+     * Builder an {@link GetQueuedMessageCountsFor} instance from the builder properties
+     * @return the {@link GetQueuedMessageCountsFor} instance
+     */
+    public GetQueuedMessageCountsFor build() {
+        return new GetQueuedMessageCountsFor(queueName);
+    }
+}

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -784,6 +784,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.7</version>
+    <version>0.40.8</version>
 </dependency>
 ```
 


### PR DESCRIPTION
- Fixed proper update of gauges in `DurableQueuesMicrometerInterceptor` and `SubscriberGlobalOrderMicrometerMonitor`
- Added support for `DurableQueues#getQueuedMessageCountsFor(QueueName)` in `MongoDurableQueues` and `PostgresqlDurableQueues` which fetches the total number of (non-dead-letter) messages queued and the number of queued dead-letter Messages for the given queue in one operation