### PR TITLE
More refinements

### DIFF
--- a/components/foundation-types/pom.xml
+++ b/components/foundation-types/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
-            <version>5.0.0</version>
+            <version>5.1.0</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/ConfigurableEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/ConfigurableEventStore.java
@@ -126,7 +126,8 @@ public interface ConfigurableEventStore<CONFIG extends AggregateEventStreamConfi
     ConfigurableEventStore<CONFIG> removeSpecificInMemoryProjector(Class<?> projectionType);
 
     /**
-     * Add an {@link EventStoreInterceptor} to the {@link ConfigurableEventStore}
+     * Add an {@link EventStoreInterceptor} to the {@link ConfigurableEventStore}.<br>
+     * {@link EventStoreInterceptor}'s added will be ordered according to they {@link dk.cloudcreate.essentials.shared.interceptor.InterceptorOrder}
      *
      * @param eventStoreInterceptor the interceptor to add
      * @return this event store instance
@@ -152,6 +153,4 @@ public interface ConfigurableEventStore<CONFIG extends AggregateEventStreamConfi
      * @return this event store instance
      */
     ConfigurableEventStore<CONFIG> removeEventStoreInterceptor(EventStoreInterceptor eventStoreInterceptor);
-
-
 }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
@@ -17,6 +17,7 @@
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql;
 
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor.EventStoreInterceptor;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.operations.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.AggregateEventStreamConfiguration;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
@@ -66,6 +67,14 @@ public interface EventStore {
      * @return the local event bus
      */
     EventBus localEventBus();
+
+    /**
+     * Get an immutable list of all registered {@link EventStoreInterceptor}'s ordered according to their {@link dk.cloudcreate.essentials.shared.interceptor.InterceptorOrder}
+     * @return an immutable list of all registered {@link EventStoreInterceptor}'s ordered according to their {@link dk.cloudcreate.essentials.shared.interceptor.InterceptorOrder}
+     * @see ConfigurableEventStore#addEventStoreInterceptor(EventStoreInterceptor)
+     * @see ConfigurableEventStore#removeEventStoreInterceptor(EventStoreInterceptor)
+     */
+    List<EventStoreInterceptor> getEventStoreInterceptors();
 
     /**
      * Append the <code>eventsToAppend</code> to the {@link AggregateEventStream} related to the aggregate with id <code>aggregateId</code> and which

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/CommitStage.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/CommitStage.java
@@ -20,6 +20,7 @@ package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.
  * Commit stage
  */
 public enum CommitStage {
+    Flush,
     BeforeCommit,
     AfterCommit,
     AfterRollback;

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/EventStoreEventBus.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/EventStoreEventBus.java
@@ -82,17 +82,17 @@ public final class EventStoreEventBus implements EventBus {
     private void addUnitOfWorkLifeCycleCallback(EventStoreUnitOfWorkFactory<? extends EventStoreUnitOfWork> unitOfWorkFactory) {
         unitOfWorkFactory.registerPersistedEventsCommitLifeCycleCallback(new PersistedEventsCommitLifecycleCallback() {
             @Override
-            public void beforeCommit(UnitOfWork unitOfWork, List<PersistedEvent> persistedEvents) {
+            public void beforeCommit(EventStoreUnitOfWork unitOfWork, List<PersistedEvent> persistedEvents) {
                 eventBus.publish(new PersistedEvents(CommitStage.BeforeCommit, unitOfWork, persistedEvents));
             }
 
             @Override
-            public void afterCommit(UnitOfWork unitOfWork, List<PersistedEvent> persistedEvents) {
+            public void afterCommit(EventStoreUnitOfWork unitOfWork, List<PersistedEvent> persistedEvents) {
                 eventBus.publish(new PersistedEvents(CommitStage.AfterCommit, unitOfWork, persistedEvents));
             }
 
             @Override
-            public void afterRollback(UnitOfWork unitOfWork, List<PersistedEvent> persistedEvents) {
+            public void afterRollback(EventStoreUnitOfWork unitOfWork, List<PersistedEvent> persistedEvents) {
                 eventBus.publish(new PersistedEvents(CommitStage.AfterRollback, unitOfWork, persistedEvents));
             }
         });

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
@@ -17,6 +17,7 @@
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus;
 
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWork;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 
 import java.util.List;
@@ -28,10 +29,10 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  */
 public final class PersistedEvents {
     public final CommitStage          commitStage;
-    public final UnitOfWork           unitOfWork;
+    public final EventStoreUnitOfWork unitOfWork;
     public final List<PersistedEvent> events;
 
-    public PersistedEvents(CommitStage commitStage, UnitOfWork unitOfWork, List<PersistedEvent> events) {
+    public PersistedEvents(CommitStage commitStage, EventStoreUnitOfWork unitOfWork, List<PersistedEvent> events) {
         this.commitStage = requireNonNull(commitStage, "No commitStage provided");
         this.unitOfWork = requireNonNull(unitOfWork, "No unitOfWork provided");
         this.events = requireNonNull(events, "No events provided");

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateEventStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateEventStream.java
@@ -152,6 +152,20 @@ public interface AggregateEventStream<AGGREGATE_ID> {
      */
     PersistedEvent firstEvent();
 
+    /**
+     * Is this {@link AggregateEventStream#eventList()} NOT empty?
+     * @return true if this {@link AggregateEventStream#eventList()} is NOT empty
+     */
+    default boolean isNotEmpty() {
+        return !isEmpty();
+    }
+
+    /**
+     * Is this {@link AggregateEventStream#eventList()} is empty?
+     * @return true if this {@link AggregateEventStream#eventList()} is empty
+     */
+    boolean isEmpty();
+
     class DefaultAggregateEventStream<AGGREGATE_ID> implements AggregateEventStream<AGGREGATE_ID> {
 
         private final AggregateEventStreamConfiguration configuration;
@@ -207,6 +221,12 @@ public interface AggregateEventStream<AGGREGATE_ID> {
                 stream = null;
             }
             return eventList;
+        }
+
+
+        @Override
+        public boolean isEmpty() {
+            return eventList().isEmpty();
         }
 
         @Override

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.operations.AppendToStream;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
+import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
+
+import java.util.Optional;
+
+/**
+ * Add this interceptor to the {@link EventStore} if you want {@link EventStoreSubscriptionManager#subscribeToAggregateEventsInTransaction(SubscriberId, AggregateType, Optional, TransactionalPersistedEventHandler)}
+ * to receive {@link PersistedEvent}'s as soon as they are appended to the {@link EventStore} (i.e. {@link EventStore#appendToStream(AppendToStream)} is performed)
+ */
+public class FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream implements EventStoreInterceptor {
+    @Override
+    public <ID> AggregateEventStream<ID> intercept(AppendToStream<ID> operation, EventStoreInterceptorChain<AppendToStream<ID>, AggregateEventStream<ID>> eventStoreInterceptorChain) {
+        var eventsPersisted = eventStoreInterceptorChain.proceed();
+        if (eventsPersisted.isNotEmpty()) {
+            eventStoreInterceptorChain.eventStore().localEventBus().publish(new PersistedEvents(CommitStage.Flush, eventStoreInterceptorChain.eventStore().getUnitOfWorkFactory().getRequiredUnitOfWork(), eventsPersisted.eventList()));
+        }
+        return eventsPersisted;
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
@@ -47,6 +47,18 @@ final class EventStoreManagedUnitOfWork extends GenericHandleAwareUnitOfWorkFact
     }
 
     @Override
+    public void removeFlushedEventsPersisted(List<PersistedEvent> eventsPersistedToRemoveFromThisUnitOfWork) {
+        requireNonNull(eventsPersistedToRemoveFromThisUnitOfWork, "No eventsPersistedToRemoveFromThisUnitOfWork provided");
+        this.eventsPersisted.removeAll(eventsPersistedToRemoveFromThisUnitOfWork);
+    }
+
+    @Override
+    public void removeFlushedEventPersisted(PersistedEvent eventPersistedToRemoveFromThisUnitOfWork) {
+        requireNonNull(eventPersistedToRemoveFromThisUnitOfWork, "No eventPersistedToRemoveFromThisUnitOfWork provided");
+        this.eventsPersisted.remove(eventPersistedToRemoveFromThisUnitOfWork);
+    }
+
+    @Override
     protected void beforeCommitting() {
         for (PersistedEventsCommitLifecycleCallback callback : lifecycleCallbacks) {
             try {

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/PersistedEventsCommitLifecycleCallback.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/PersistedEventsCommitLifecycleCallback.java
@@ -29,22 +29,22 @@ import java.util.List;
  */
 public interface PersistedEventsCommitLifecycleCallback {
     /**
-     * Before the {@link UnitOfWork} is committed.<br/>
+     * Before the {@link EventStoreUnitOfWork} is committed.<br/>
      * This method is called AFTER {@link UnitOfWorkLifecycleCallback#beforeCommit(UnitOfWork, java.util.List)}!
      *
      * @param unitOfWork      the unit of work
      * @param persistedEvents ALL the {@link PersistedEvent}'s that were associated with the {@link UnitOfWork}
      */
-    void beforeCommit(UnitOfWork unitOfWork, List<PersistedEvent> persistedEvents);
+    void beforeCommit(EventStoreUnitOfWork unitOfWork, List<PersistedEvent> persistedEvents);
 
     /**
-     * After the {@link UnitOfWork} was committed.<br/>
+     * After the {@link EventStoreUnitOfWork} was committed.<br/>
      * This method is called AFTER {@link UnitOfWorkLifecycleCallback#afterCommit(UnitOfWork, java.util.List)}
      *
      * @param unitOfWork      the unit of work
      * @param persistedEvents ALL the {@link PersistedEvent}'s that were associated with the {@link UnitOfWork}
      */
-    void afterCommit(UnitOfWork unitOfWork, List<PersistedEvent> persistedEvents);
+    void afterCommit(EventStoreUnitOfWork unitOfWork, List<PersistedEvent> persistedEvents);
 
-    void afterRollback(UnitOfWork unitOfWork, List<PersistedEvent> persistedEvents);
+    void afterRollback(EventStoreUnitOfWork unitOfWork, List<PersistedEvent> persistedEvents);
 }

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStreamIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStreamIT.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.PostgresqlEventStore;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+import dk.cloudcreate.essentials.components.foundation.types.*;
+import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
+import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
+import dk.cloudcreate.essentials.reactive.EventHandler;
+import dk.cloudcreate.essentials.types.LongRange;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.postgres.PostgresPlugin;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.*;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@Testcontainers
+class FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStreamIT {
+    public static final EventMetaData META_DATA = EventMetaData.of("Key1", "Value1", "Key2", "Value2");
+    public static final AggregateType ORDERS    = AggregateType.of("Orders");
+
+    private Jdbi                                                                    jdbi;
+    private AggregateType                                                           aggregateType;
+    private EventStoreUnitOfWorkFactory<EventStoreUnitOfWork>                       unitOfWorkFactory;
+    private TestPersistableEventMapper                                              eventMapper;
+    private PostgresqlEventStore<SeparateTablePerAggregateEventStreamConfiguration> eventStore;
+
+    @Container
+    private final PostgreSQLContainer<?>         postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+            .withDatabaseName("event-store")
+            .withUsername("test-user")
+            .withPassword("secret-password");
+    private       RecordingLocalEventBusConsumer recordingLocalEventBusConsumer;
+
+
+    @BeforeEach
+    void setup() {
+        jdbi = Jdbi.create(postgreSQLContainer.getJdbcUrl(),
+                           postgreSQLContainer.getUsername(),
+                           postgreSQLContainer.getPassword());
+        jdbi.installPlugin(new PostgresPlugin());
+        jdbi.setSqlLogger(new SqlExecutionTimeLogger());
+
+        aggregateType = ORDERS;
+        unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
+        eventMapper = new TestPersistableEventMapper();
+        var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
+                                                                                       unitOfWorkFactory,
+                                                                                       eventMapper,
+                                                                                       standardSingleTenantConfiguration(aggregateType_ -> aggregateType_ + "_events",
+                                                                                                                         EventStreamTableColumnNames.defaultColumnNames(),
+                                                                                                                         new JacksonJSONEventSerializer(createObjectMapper()),
+                                                                                                                         IdentifierColumnType.UUID,
+                                                                                                                         JSONColumnType.JSONB));
+        eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
+                                                persistenceStrategy,
+                                                Optional.empty(),
+                                                eventStore -> new PostgresqlEventStreamGapHandler<>(eventStore,
+                                                                                                    unitOfWorkFactory));
+        eventStore.addAggregateEventStreamConfiguration(aggregateType,
+                                                        AggregateIdSerializer.serializerFor(OrderId.class));
+        eventStore.addEventStoreInterceptor(new FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream());
+        recordingLocalEventBusConsumer = new RecordingLocalEventBusConsumer();
+        eventStore.localEventBus()
+                  .addSyncSubscriber(recordingLocalEventBusConsumer);
+    }
+
+    @AfterEach
+    void cleanup() {
+        unitOfWorkFactory.getCurrentUnitOfWork().ifPresent(UnitOfWork::rollback);
+        assertThat(unitOfWorkFactory.getCurrentUnitOfWork()).isEmpty();
+    }
+
+
+    @Test
+    void persisting_events_related_to_two_different_aggregates_in_one_unitofwork() {
+        // Given
+        var orderId1     = OrderId.of("beed77fb-d911-1111-9c48-03ed5bfe8f89");
+        var customerId1  = CustomerId.of("Test-Customer-Id-10");
+        var orderNumber1 = 1234;
+        var orderId2     = OrderId.of("ceed77fb-d911-9c48-1111-03ed5bfe8f89");
+        var customerId2  = CustomerId.of("Test-Customer-Id2-10");
+        var orderNumber2 = 4321;
+
+        // When
+        var unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
+        var persistableEventsOrder1 = List.of(new OrderEvent.OrderAdded(orderId1,
+                                                                        customerId1,
+                                                                        orderNumber1));
+        var order1AggregateStream = eventStore.startStream(aggregateType,
+                                                           orderId1,
+                                                           persistableEventsOrder1);
+
+        var persistableEventsOrder2 = List.of(new OrderEvent.OrderAdded(orderId2,
+                                                                        customerId2,
+                                                                        orderNumber2));
+        var order2AggregateStream = eventStore.startStream(aggregateType,
+                                                           orderId2,
+                                                           persistableEventsOrder2);
+        
+        // Verify the two events appended to the stream
+        assertThat(order1AggregateStream.eventOrderRangeIncluded()).isEqualTo(LongRange.only(0));
+        var aggregateStreamEventOrder1 = order1AggregateStream.eventList().get(0);
+        assertThat((CharSequence) aggregateStreamEventOrder1.eventId()).isNotNull();
+        assertThat((CharSequence) aggregateStreamEventOrder1.aggregateId()).isEqualTo(orderId1);
+        assertThat((CharSequence) aggregateStreamEventOrder1.aggregateType()).isEqualTo(aggregateType);
+        assertThat(aggregateStreamEventOrder1.eventOrder()).isEqualTo(EventOrder.of(0));
+        assertThat(aggregateStreamEventOrder1.eventRevision()).isEqualTo(EventRevision.of(3));
+        assertThat(aggregateStreamEventOrder1.globalEventOrder()).isEqualTo(GlobalEventOrder.of(1));
+        assertThat(aggregateStreamEventOrder1.timestamp()).isBefore(OffsetDateTime.now());
+        assertThat(aggregateStreamEventOrder1.event().getEventName()).isEmpty();
+        assertThat(aggregateStreamEventOrder1.event().getEventType()).isEqualTo(Optional.of(EventType.of(OrderEvent.OrderAdded.class)));
+        assertThat(aggregateStreamEventOrder1.event().getEventTypeOrNamePersistenceValue()).isEqualTo(EventType.of(OrderEvent.OrderAdded.class).toString());
+        assertThat(aggregateStreamEventOrder1.event().getJsonDeserialized().get()).usingRecursiveComparison().isEqualTo(persistableEventsOrder1.get(0));
+        assertThat(aggregateStreamEventOrder1.event().getJson()).isEqualTo(
+                "{\"orderId\":\"beed77fb-d911-1111-9c48-03ed5bfe8f89\",\"orderingCustomerId\":\"Test-Customer-Id-10\",\"orderNumber\":1234}");
+        assertThat(aggregateStreamEventOrder1.metaData().getJson()).contains("\"Key1\":\"Value1\""); // Note formatting changed by postgresql
+        assertThat(aggregateStreamEventOrder1.metaData().getJson()).contains("\"Key2\":\"Value2\""); // Note formatting changed by postgresql
+        assertThat(aggregateStreamEventOrder1.metaData().getJavaType()).isEqualTo(Optional.of(EventMetaData.class.getName()));
+        assertThat(aggregateStreamEventOrder1.metaData().getJsonDeserialized()).isEqualTo(Optional.of(META_DATA));
+        assertThat(aggregateStreamEventOrder1.causedByEventId()).isEqualTo(Optional.of(eventMapper.causedByEventId));
+        assertThat(aggregateStreamEventOrder1.correlationId()).isEqualTo(Optional.of(eventMapper.correlationId));
+
+        assertThat(order2AggregateStream.eventOrderRangeIncluded()).isEqualTo(LongRange.only(0));
+        var aggregateStreamEventOrder2 = order2AggregateStream.eventList().get(0);
+        assertThat((CharSequence) aggregateStreamEventOrder2.eventId()).isNotNull();
+        assertThat((CharSequence) aggregateStreamEventOrder2.aggregateId()).isEqualTo(orderId2);
+        assertThat((CharSequence) aggregateStreamEventOrder2.aggregateType()).isEqualTo(aggregateType);
+        assertThat(aggregateStreamEventOrder2.eventOrder()).isEqualTo(EventOrder.of(0));
+        assertThat(aggregateStreamEventOrder2.eventRevision()).isEqualTo(EventRevision.of(3));
+        assertThat(aggregateStreamEventOrder2.globalEventOrder()).isEqualTo(GlobalEventOrder.of(2));
+        assertThat(aggregateStreamEventOrder2.timestamp()).isBefore(OffsetDateTime.now());
+        assertThat(aggregateStreamEventOrder2.event().getEventName()).isEmpty();
+        assertThat(aggregateStreamEventOrder2.event().getEventType()).isEqualTo(Optional.of(EventType.of(OrderEvent.OrderAdded.class)));
+        assertThat(aggregateStreamEventOrder2.event().getEventTypeOrNamePersistenceValue()).isEqualTo(EventType.of(OrderEvent.OrderAdded.class).toString());
+        assertThat(aggregateStreamEventOrder2.event().getJsonDeserialized().get()).usingRecursiveComparison().isEqualTo(persistableEventsOrder2.get(0));
+        assertThat(aggregateStreamEventOrder2.event().getJson()).isEqualTo(
+                "{\"orderId\":\"ceed77fb-d911-9c48-1111-03ed5bfe8f89\",\"orderingCustomerId\":\"Test-Customer-Id2-10\",\"orderNumber\":4321}");
+        assertThat(aggregateStreamEventOrder2.metaData().getJson()).contains("\"Key1\":\"Value1\""); // Note formatting changed by postgresql
+        assertThat(aggregateStreamEventOrder2.metaData().getJson()).contains("\"Key2\":\"Value2\""); // Note formatting changed by postgresql
+        assertThat(aggregateStreamEventOrder2.metaData().getJavaType()).isEqualTo(Optional.of(EventMetaData.class.getName()));
+        assertThat(aggregateStreamEventOrder2.metaData().getJsonDeserialized()).isEqualTo(Optional.of(META_DATA));
+        assertThat(aggregateStreamEventOrder2.causedByEventId()).isEqualTo(Optional.of(eventMapper.causedByEventId));
+        assertThat(aggregateStreamEventOrder2.correlationId()).isEqualTo(Optional.of(eventMapper.correlationId));
+
+        // And both events were published on the local events
+        assertThat(recordingLocalEventBusConsumer.flushPersistedEvents).hasSize(2);
+        assertThat((CharSequence) recordingLocalEventBusConsumer.flushPersistedEvents.get(0).eventId()).isEqualTo(aggregateStreamEventOrder1.eventId());
+        assertThat((CharSequence) recordingLocalEventBusConsumer.flushPersistedEvents.get(1).eventId()).isEqualTo(aggregateStreamEventOrder2.eventId());
+        
+        assertThat(recordingLocalEventBusConsumer.beforeCommitPersistedEvents).isEmpty();
+        assertThat(recordingLocalEventBusConsumer.afterCommitPersistedEvents).isEmpty();
+        assertThat(recordingLocalEventBusConsumer.afterRollbackPersistedEvents).isEmpty();
+        recordingLocalEventBusConsumer.clear();
+
+        unitOfWork.commit();
+
+        // Then
+        unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
+        assertThat(recordingLocalEventBusConsumer.flushPersistedEvents).isEmpty();
+        assertThat(recordingLocalEventBusConsumer.beforeCommitPersistedEvents).hasSize(2);
+        assertThat((CharSequence) recordingLocalEventBusConsumer.beforeCommitPersistedEvents.get(0).eventId()).isEqualTo(aggregateStreamEventOrder1.eventId());
+        assertThat((CharSequence) recordingLocalEventBusConsumer.beforeCommitPersistedEvents.get(1).eventId()).isEqualTo(aggregateStreamEventOrder2.eventId());
+        assertThat(recordingLocalEventBusConsumer.afterCommitPersistedEvents).hasSize(2);
+        assertThat((CharSequence) recordingLocalEventBusConsumer.afterCommitPersistedEvents.get(0).eventId()).isEqualTo(aggregateStreamEventOrder1.eventId());
+        assertThat((CharSequence) recordingLocalEventBusConsumer.afterCommitPersistedEvents.get(1).eventId()).isEqualTo(aggregateStreamEventOrder2.eventId());
+        assertThat(recordingLocalEventBusConsumer.afterRollbackPersistedEvents).isEmpty();
+
+        // Check events still got stored
+        var lastPersistedEventOrder1 = eventStore.loadLastPersistedEventRelatedTo(aggregateType, orderId1);
+        assertThat(lastPersistedEventOrder1).isPresent();
+        assertThat((CharSequence) lastPersistedEventOrder1.get().eventId()).isNotNull();
+        assertThat((CharSequence) lastPersistedEventOrder1.get().aggregateId()).isEqualTo(orderId1);
+        assertThat((CharSequence) lastPersistedEventOrder1.get().aggregateType()).isEqualTo(aggregateType);
+        assertThat(lastPersistedEventOrder1.get().eventOrder()).isEqualTo(EventOrder.of(0));
+        assertThat(lastPersistedEventOrder1.get().eventRevision()).isEqualTo(EventRevision.of(3));
+        assertThat(lastPersistedEventOrder1.get().globalEventOrder()).isEqualTo(GlobalEventOrder.of(1));
+        assertThat(lastPersistedEventOrder1.get().timestamp()).isBefore(OffsetDateTime.now());
+        assertThat(lastPersistedEventOrder1.get().event().getEventName()).isEmpty();
+        assertThat(lastPersistedEventOrder1.get().event().getEventType()).isEqualTo(Optional.of(EventType.of(OrderEvent.OrderAdded.class)));
+        assertThat(lastPersistedEventOrder1.get().event().getEventTypeOrNamePersistenceValue()).isEqualTo(EventType.of(OrderEvent.OrderAdded.class).toString());
+        assertThat(lastPersistedEventOrder1.get().event().getJsonDeserialized().get()).usingRecursiveComparison().isEqualTo(persistableEventsOrder1.get(0));
+        assertThat(lastPersistedEventOrder1.get().event().getJson()).isEqualTo(
+                "{\"orderId\": \"beed77fb-d911-1111-9c48-03ed5bfe8f89\", \"orderNumber\": 1234, \"orderingCustomerId\": \"Test-Customer-Id-10\"}"); // Note formatting changed by postgresql
+        assertThat(lastPersistedEventOrder1.get().metaData().getJson()).contains("\"Key1\": \"Value1\""); // Note formatting changed by postgresql
+        assertThat(lastPersistedEventOrder1.get().metaData().getJson()).contains("\"Key2\": \"Value2\""); // Note formatting changed by postgresql
+        assertThat(lastPersistedEventOrder1.get().metaData().getJavaType()).isEqualTo(Optional.of(EventMetaData.class.getName()));
+        assertThat(lastPersistedEventOrder1.get().metaData().getJsonDeserialized()).isEqualTo(Optional.of(META_DATA));
+        assertThat(lastPersistedEventOrder1.get().causedByEventId()).isEqualTo(Optional.of(eventMapper.causedByEventId));
+        assertThat(lastPersistedEventOrder1.get().correlationId()).isEqualTo(Optional.of(eventMapper.correlationId));
+
+        var lastPersistedEventOrder2 = eventStore.loadLastPersistedEventRelatedTo(aggregateType, orderId2);
+        assertThat(lastPersistedEventOrder2).isPresent();
+        assertThat((CharSequence) lastPersistedEventOrder2.get().eventId()).isNotNull();
+        assertThat((CharSequence) lastPersistedEventOrder2.get().aggregateId()).isEqualTo(orderId2);
+        assertThat((CharSequence) lastPersistedEventOrder2.get().aggregateType()).isEqualTo(aggregateType);
+        assertThat(lastPersistedEventOrder2.get().eventOrder()).isEqualTo(EventOrder.of(0));
+        assertThat(lastPersistedEventOrder2.get().eventRevision()).isEqualTo(EventRevision.of(3));
+        assertThat(lastPersistedEventOrder2.get().globalEventOrder()).isEqualTo(GlobalEventOrder.of(2));
+        assertThat(lastPersistedEventOrder2.get().timestamp()).isBefore(OffsetDateTime.now());
+        assertThat(lastPersistedEventOrder2.get().event().getEventName()).isEmpty();
+        assertThat(lastPersistedEventOrder2.get().event().getEventType()).isEqualTo(Optional.of(EventType.of(OrderEvent.OrderAdded.class)));
+        assertThat(lastPersistedEventOrder2.get().event().getEventTypeOrNamePersistenceValue()).isEqualTo(EventType.of(OrderEvent.OrderAdded.class).toString());
+        assertThat(lastPersistedEventOrder2.get().event().getJsonDeserialized().get()).usingRecursiveComparison().isEqualTo(persistableEventsOrder2.get(0));
+        assertThat(lastPersistedEventOrder2.get().event().getJson()).isEqualTo(
+                "{\"orderId\": \"ceed77fb-d911-9c48-1111-03ed5bfe8f89\", \"orderNumber\": 4321, \"orderingCustomerId\": \"Test-Customer-Id2-10\"}"); // Note formatting changed by postgresql
+        assertThat(lastPersistedEventOrder2.get().metaData().getJson()).contains("\"Key1\": \"Value1\""); // Note formatting changed by postgresql
+        assertThat(lastPersistedEventOrder2.get().metaData().getJson()).contains("\"Key2\": \"Value2\""); // Note formatting changed by postgresql
+        assertThat(lastPersistedEventOrder2.get().metaData().getJavaType()).isEqualTo(Optional.of(EventMetaData.class.getName()));
+        assertThat(lastPersistedEventOrder2.get().metaData().getJsonDeserialized()).isEqualTo(Optional.of(META_DATA));
+        assertThat(lastPersistedEventOrder2.get().causedByEventId()).isEqualTo(Optional.of(eventMapper.causedByEventId));
+        assertThat(lastPersistedEventOrder2.get().correlationId()).isEqualTo(Optional.of(eventMapper.correlationId));
+    }
+    
+
+    private static class RecordingLocalEventBusConsumer implements EventHandler {
+        private final List<PersistedEvent> beforeCommitPersistedEvents  = new ArrayList<>();
+        private final List<PersistedEvent> afterCommitPersistedEvents   = new ArrayList<>();
+        private final List<PersistedEvent> afterRollbackPersistedEvents = new ArrayList<>();
+        private final List<PersistedEvent> flushPersistedEvents = new ArrayList<>();
+
+        @Override
+        public void handle(Object event) {
+            var persistedEvents = (PersistedEvents) event;
+            if (persistedEvents.commitStage == CommitStage.Flush) {
+                flushPersistedEvents.addAll(persistedEvents.events);
+            } else if (persistedEvents.commitStage == CommitStage.BeforeCommit) {
+                beforeCommitPersistedEvents.addAll(persistedEvents.events);
+            } else if (persistedEvents.commitStage == CommitStage.AfterCommit) {
+                afterCommitPersistedEvents.addAll(persistedEvents.events);
+            } else {
+                afterRollbackPersistedEvents.addAll(persistedEvents.events);
+            }
+        }
+
+        private void clear() {
+            beforeCommitPersistedEvents.clear();
+            afterCommitPersistedEvents.clear();
+            afterRollbackPersistedEvents.clear();
+            flushPersistedEvents.clear();
+        }
+    }
+
+    private static class TestPersistableEventMapper implements PersistableEventMapper {
+        private final CorrelationId correlationId   = CorrelationId.random();
+        private final EventId       causedByEventId = EventId.random();
+
+        @Override
+        public PersistableEvent map(Object aggregateId, AggregateEventStreamConfiguration aggregateEventStreamConfiguration, Object event, EventOrder eventOrder) {
+            return PersistableEvent.from(EventId.random(),
+                                         aggregateEventStreamConfiguration.aggregateType,
+                                         aggregateId,
+                                         EventTypeOrName.with(event.getClass()),
+                                         event,
+                                         eventOrder,
+                                         null, // Leave reading the EventRevision to the PersistableEvent's from method
+                                         META_DATA,
+                                         OffsetDateTime.now(),
+                                         causedByEventId,
+                                         correlationId,
+                                         null);
+        }
+    }
+
+    private ObjectMapper createObjectMapper() {
+        var objectMapper = JsonMapper.builder()
+                                     .disable(MapperFeature.AUTO_DETECT_GETTERS)
+                                     .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+                                     .disable(MapperFeature.AUTO_DETECT_SETTERS)
+                                     .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                                     .enable(MapperFeature.AUTO_DETECT_CREATORS)
+                                     .enable(MapperFeature.AUTO_DETECT_FIELDS)
+                                     .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
+                                     .addModule(new Jdk8Module())
+                                     .addModule(new JavaTimeModule())
+                                     .addModule(new EssentialTypesJacksonModule())
+                                     .addModule(new EssentialsImmutableJacksonModule())
+                                     .build();
+
+        objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
+                                               .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                               .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                               .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                                               .withCreatorVisibility(JsonAutoDetect.Visibility.ANY));
+        return objectMapper;
+    }
+}

--- a/components/spring-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory.java
+++ b/components/spring-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory.java
@@ -142,5 +142,17 @@ public class SpringTransactionAwareEventStoreUnitOfWorkFactory
             requireNonNull(eventsPersistedInThisUnitOfWork, "No eventsPersistedInThisUnitOfWork provided");
             this.eventsPersisted.addAll(eventsPersistedInThisUnitOfWork);
         }
+
+        @Override
+        public void removeFlushedEventsPersisted(List<PersistedEvent> eventsPersistedToRemoveFromThisUnitOfWork) {
+            requireNonNull(eventsPersistedToRemoveFromThisUnitOfWork, "No eventsPersistedToRemoveFromThisUnitOfWork provided");
+            this.eventsPersisted.removeAll(eventsPersistedToRemoveFromThisUnitOfWork);
+        }
+
+        @Override
+        public void removeFlushedEventPersisted(PersistedEvent eventPersistedToRemoveFromThisUnitOfWork) {
+            requireNonNull(eventPersistedToRemoveFromThisUnitOfWork, "No eventPersistedToRemoveFromThisUnitOfWork provided");
+            this.eventsPersisted.remove(eventPersistedToRemoveFromThisUnitOfWork);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,12 @@
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
         <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
-        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
         <dependency-check-maven.version>9.2.0</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
@@ -18,12 +18,19 @@ package dk.cloudcreate.essentials.shared.interceptor;
 
 import java.lang.annotation.*;
 
+/**
+ * Annotation that can be applied to interceptors to control their order of execution
+ * in the {@link InterceptorChain}<br>
+ * The lower the number the higher the priority.<br>
+ * An interceptor with order 1 will be invoked before an interceptor with order 10.
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface InterceptorOrder {
     /**
      * The interceptor order. The lower the number the higher the priority.<br>
      * An interceptor with order 1 will be invoked before an interceptor with order 10.
+     *
      * @return
      */
     int value() default 10;


### PR DESCRIPTION
Added `ReentrantLock` to avoid local overlapping transactions during confirm locks
Documented `InterceptorOrder`
Added `CommitStage.Flush`
Added `removeFlushedEventPersisted` and `removeFlushedEventsPersisted` to `EventStoreUnitOfWork` and its subclasses
`PersistedEventsCommitLifecycleCallback` accepts `EventStoreUnitOfWork` as parameters instead of `UnitOfWork`
Added `isEmpty` and `isNotEmpty` to `AggregateEventStream`
Added `eventStore` method to `EventStoreInterceptorChain`
Added `FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream` which in combination with `DefaultEventStoreSubscriptionManager#NonExclusiveInTransactionSubscription` ensures in-transaction flushing of events (i.e. subscribers receive events right after `EventStore#appendToStream` has been performed)
Added `getEventStoreInterceptors` to `EventStore`

Updated 3rd party dependencies:
- java-uuid-generator 5.1.0
- 
Updated maven plugins:
- maven-javadoc-plugin 3.7.0
- maven-enforcer-plugin 3.5.0