### PR TITLE
fix missing unit of work when finding highest global event order

### DIFF
--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
@@ -334,10 +334,11 @@ public class EventStoreConfiguration {
     @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
     public SubscriberGlobalOrderMicrometerMonitor subscriberGlobalOrderMicrometerMonitor(EventStoreSubscriptionManager eventStoreSubscriptionManager,
                                                                                          Optional<MeterRegistry> meterRegistry,
+                                                                                         EventStoreUnitOfWorkFactory<? extends EventStoreUnitOfWork> eventStoreUnitOfWorkFactory,
                                                                                          EssentialsComponentsProperties properties) {
         requireTrue(meterRegistry.isPresent(), "MeterRegistry is not configured");
         return new SubscriberGlobalOrderMicrometerMonitor(eventStoreSubscriptionManager,
-            meterRegistry.orElse(null), properties.getTracingProperties().getModuleTag());
+            meterRegistry.orElse(null), eventStoreUnitOfWorkFactory, properties.getTracingProperties().getModuleTag());
     }
 
 }


### PR DESCRIPTION
SubscriberGlobalOrderMicrometerMonitor was missing unit of work to properly find the highest global event order.