### PR TITLE
Subscription reset side effects

### DIFF
--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/GlobalEventOrder.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/GlobalEventOrder.java
@@ -16,13 +16,13 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types;
 
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
-import dk.cloudcreate.essentials.types.LongRange;
-import dk.cloudcreate.essentials.types.LongType;
-
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
+import dk.cloudcreate.essentials.types.LongRange;
+import dk.cloudcreate.essentials.types.LongType;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -89,5 +89,9 @@ public final class GlobalEventOrder extends LongType<GlobalEventOrder> {
 
     public GlobalEventOrder decrement() {
         return new GlobalEventOrder(value - 1);
+    }
+
+    public boolean isFirstGlobalEventOrder() {
+        return this.equals(FIRST_GLOBAL_EVENT_ORDER);
     }
 }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreSubscription.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreSubscription.java
@@ -24,6 +24,7 @@ import dk.cloudcreate.essentials.components.foundation.types.*;
 import org.reactivestreams.Subscription;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 public interface EventStoreSubscription extends Lifecycle, Subscription {
     /**
@@ -52,8 +53,9 @@ public interface EventStoreSubscription extends Lifecycle, Subscription {
      *
      * @param subscribeFromAndIncludingGlobalOrder this {@link GlobalEventOrder} will become the new starting point in the
      *                                             EventStream associated with the {@link #aggregateType()}
+     * @param resetProcessor hook to add custom handling to perform when the subscriber is stopped during the reset process
      */
-    void resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder);
+    void resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder, Consumer<GlobalEventOrder> resetProcessor);
 
     /**
      * Get the subscriptions resume point (if supported by the subscription)


### PR DESCRIPTION
Only perform subscription reset side effects if the eventStoreSubscription.resetFrom is actually doing a reset.

It may happen, that the resetFrom does not actually perform the subscription reset, either because the subscription is not started, or if the appropriate lock is not taken (in a multi instance setup). Ensure, that side effects are not performed if the subscription is not properly reset. Side effects from event processors include deleting all messages on the event processor inbox. 