### PR TITLE
Release 0.40.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -167,7 +167,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -183,7 +183,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -265,7 +265,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -339,7 +339,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -385,7 +385,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -432,7 +432,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -508,7 +508,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 
@@ -524,7 +524,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation;
+
+import com.mongodb.MongoSocketException;
+import dk.cloudcreate.essentials.shared.Exceptions;
+import org.jdbi.v3.core.ConnectionException;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+
+import java.io.*;
+import java.net.ConnectException;
+import java.sql.SQLException;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * Helper class to resolve IO, Connection, Transaction, Socket exception
+ */
+public final class IOExceptionUtil {
+
+    /**
+     * Is the exception provided an IO, Transaction, Connection or Socket style exception (across Mongo and Postgresql/JDBC/JPA) - i.e. a transient style of error
+     * @param e the exception that occurred
+     * @return true if the exception is determined to be an IO, Transaction, Connection or Socket style exception (across Mongo and Postgresql/JDBC/JPA) - i.e. a transient style of error
+     */
+    public static boolean isIOException(Throwable e) {
+        requireNonNull(e, "No exception provided");
+        var rootCause = Exceptions.getRootCause(e);
+        return (
+                (e.getMessage().contains("An I/O error occurred while sending to the backend") && rootCause instanceof EOFException) ||
+                        (e.getMessage().contains("Could not open JDBC Connection for transaction") && rootCause instanceof EOFException) ||
+                        (e.getMessage().contains("Could not open JDBC Connection for transaction") && rootCause instanceof ConnectException) ||
+                        (e.getMessage().contains("Could not open JDBC Connection for transaction") && rootCause instanceof SQLException && rootCause.getMessage().contains("has been closed")) ||
+                        e.getMessage().contains("has been closed") ||
+                        e.getMessage().contains("Connection is closed") ||
+                        e.getMessage().contains("Unable to acquire JDBC Connection") ||
+                        e.getMessage().contains("Could not open JPA EntityManager for transaction") ||
+                        rootCause.getClass().getSimpleName().equals("ConnectionException") ||
+                        rootCause.getClass().getSimpleName().equals("MongoSocketReadException") ||
+                        rootCause instanceof MongoSocketException ||
+                        rootCause instanceof ConnectionException ||
+                        rootCause instanceof UnableToExecuteStatementException ||
+                        rootCause instanceof IOException
+        );
+    }
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
@@ -215,12 +215,12 @@ public abstract class DefaultDurableQueueConsumer<DURABLE_QUEUES extends Durable
         } catch (Throwable e) {
             if (IOExceptionUtil.isIOException(e)) {
                 LOG.debug(msg("[{}] {} - Experienced a Connection issue while polling queue",
-                              consumeFromQueue.consumerName,
-                              queueName), e);
+                              queueName,
+                              consumeFromQueue.consumerName), e);
             } else {
                 LOG.error(msg("[{}] {} - Failed to poll queue",
-                              consumeFromQueue.consumerName,
-                              queueName), e);
+                              queueName,
+                              consumeFromQueue.consumerName), e);
             }
         }
     }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
@@ -16,14 +16,13 @@
 
 package dk.cloudcreate.essentials.components.foundation.messaging.queue;
 
+import dk.cloudcreate.essentials.components.foundation.IOExceptionUtil;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuedMessage.DeliveryMode;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.*;
-import dk.cloudcreate.essentials.shared.Exceptions;
 import dk.cloudcreate.essentials.shared.concurrent.ThreadFactoryBuilder;
 import org.slf4j.*;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.Consumer;
@@ -214,17 +213,20 @@ public abstract class DefaultDurableQueueConsumer<DURABLE_QUEUES extends Durable
                 postTransactionalSideEffect.run();
             }
         } catch (Throwable e) {
-            LOG.error(msg("[{}] {} - Failed to poll queue",
-                          consumeFromQueue.consumerName,
-                          queueName), e);
+            if (IOExceptionUtil.isIOException(e)) {
+                LOG.debug(msg("[{}] {} - Experienced a Connection issue while polling queue",
+                              consumeFromQueue.consumerName,
+                              queueName), e);
+            } else {
+                LOG.error(msg("[{}] {} - Failed to poll queue",
+                              consumeFromQueue.consumerName,
+                              queueName), e);
+            }
         }
     }
 
     private void handleProcessNextMessageReadyForDeliveryException(Exception e) {
-        var rootCause = Exceptions.getRootCause(e);
-        if (e.getMessage().contains("has been closed") || e.getMessage().contains("Connection is closed") ||
-                rootCause instanceof IOException || rootCause.getClass().getSimpleName().equals("ConnectionException") ||
-                rootCause.getClass().getSimpleName().equals("MongoSocketReadException")) {
+        if (IOExceptionUtil.isIOException(e)) {
             LOG.trace(msg("[{}] {} - Experienced a Connection issue, will retry later",
                           queueName,
                           consumeFromQueue.consumerName), e);
@@ -250,7 +252,15 @@ public abstract class DefaultDurableQueueConsumer<DURABLE_QUEUES extends Durable
                 return NO_POSTPROCESSING_AFTER_PROCESS_NEXT_MESSAGE;
             }
         } catch (Throwable e) {
-            LOG.error(msg("[{}] Error Polling Queue", queueName), e);
+            if (IOExceptionUtil.isIOException(e)) {
+                LOG.debug(msg("[{}] {} Can't Poll Queue - Connection seems to be broken or closed, this can happen during JVM or application shutdown",
+                             queueName,
+                             consumeFromQueue.consumerName));
+            } else {
+                LOG.error(msg("[{}] {} Error Polling Queue",
+                              queueName,
+                              consumeFromQueue.consumerName), e);
+            }
             return NO_POSTPROCESSING_AFTER_PROCESS_NEXT_MESSAGE;
         }
     }

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -784,6 +784,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
@@ -16,53 +16,30 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.ConfigurableEventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreSubscription;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.EventJSON;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.FencedLockAwareSubscriber;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.SubscriptionResumePoint;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventOrder;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventType;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
 import dk.cloudcreate.essentials.components.foundation.json.JSONDeserializationException;
-import dk.cloudcreate.essentials.components.foundation.messaging.MessageHandler;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inbox;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.InboxConfig;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.InboxName;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inboxes;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.MessageConsumptionMode;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.MessageHandlerInterceptor;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.PatternMatchingMessageHandler;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.Message;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.MessageMetaData;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.OrderedMessage;
+import dk.cloudcreate.essentials.components.foundation.messaging.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
 import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
 import dk.cloudcreate.essentials.reactive.Handler;
-import dk.cloudcreate.essentials.reactive.command.AnnotatedCommandHandler;
-import dk.cloudcreate.essentials.reactive.command.CmdHandler;
-import dk.cloudcreate.essentials.reactive.command.CommandBus;
+import dk.cloudcreate.essentials.reactive.command.*;
 import dk.cloudcreate.essentials.types.LongRange;
-import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
@@ -397,12 +374,13 @@ public abstract class EventProcessor implements Lifecycle {
      * {@link #onSubscriptionsReset(AggregateType, GlobalEventOrder)} will be called for each {@link AggregateType}<br>
      * <br>
      * This method also calls {@link Inbox#deleteAllMessages()}
+     *
      * @see #resetSubscriptions(Map)
      */
     public void resetAllSubscriptions() {
         Map<AggregateType, GlobalEventOrder> resetParameters = eventStoreSubscriptions.stream()
-            .map(EventStoreSubscription::aggregateType)
-            .collect(toMap(identity(), aggregateType -> GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER));
+                                                                                      .map(EventStoreSubscription::aggregateType)
+                                                                                      .collect(toMap(identity(), aggregateType -> GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER));
         var resetInbox = true;
         resetSubscriptions(resetParameters, resetInbox);
     }
@@ -425,16 +403,16 @@ public abstract class EventProcessor implements Lifecycle {
         AtomicBoolean isResetInbox = new AtomicBoolean(resetInbox);
         resetAggregateSubscriptionsFromAndIncluding.forEach((aggregateType, resubscribeFromAndIncluding) -> {
             findSubscription(aggregateType).ifPresentOrElse(eventStoreSubscription -> {
-                    doResetSubscription(eventStoreSubscription, resubscribeFromAndIncluding, isResetInbox.get());
-                    isResetInbox.set(false);
-                },
-                () -> {
-                    throw new IllegalArgumentException(msg("[{}] Cannot reset subscription for {} '{}' since the {} doesn't subscribe to events for this aggregate type",
-                        getProcessorName(),
-                        AggregateType.class.getSimpleName(),
-                        aggregateType,
-                        EventProcessor.class.getSimpleName()));
-                });
+                                                                doResetSubscription(eventStoreSubscription, resubscribeFromAndIncluding, isResetInbox.get());
+                                                                isResetInbox.set(false);
+                                                            },
+                                                            () -> {
+                                                                throw new IllegalArgumentException(msg("[{}] Cannot reset subscription for {} '{}' since the {} doesn't subscribe to events for this aggregate type",
+                                                                                                       getProcessorName(),
+                                                                                                       AggregateType.class.getSimpleName(),
+                                                                                                       aggregateType,
+                                                                                                       EventProcessor.class.getSimpleName()));
+                                                            });
         });
     }
 
@@ -456,11 +434,10 @@ public abstract class EventProcessor implements Lifecycle {
         });
     }
 
-    @NotNull
     private Optional<EventStoreSubscription> findSubscription(AggregateType aggregateType) {
         return eventStoreSubscriptions.stream()
-            .filter(eventStoreSubscription -> eventStoreSubscription.aggregateType().equals(aggregateType))
-            .findFirst();
+                                      .filter(eventStoreSubscription -> eventStoreSubscription.aggregateType().equals(aggregateType))
+                                      .findFirst();
     }
 
     /**

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -22,7 +22,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.b
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.EventJSON;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
+import dk.cloudcreate.essentials.components.foundation.*;
 import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inbox;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.OrderedMessage;
@@ -605,7 +605,11 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                                                           .map(eventStoreSubscription -> eventStoreSubscription.currentResumePoint().get())
                                                                           .collect(Collectors.toList()));
             } catch (Exception e) {
-                log.error(msg("Failed to store ResumePoint's for the {} subscriber(s)", subscribers.size()), e);
+                if (IOExceptionUtil.isIOException(e)) {
+                    log.debug(msg("Failed to store ResumePoint's for the {} subscriber(s) - Experienced a Connection issue, this can happen during JVM or application shutdown", subscribers.size()));
+                } else  {
+                    log.error(msg("Failed to store ResumePoint's for the {} subscriber(s)", subscribers.size()), e);
+                }
             }
         }
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -16,45 +16,30 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription;
 
-import java.time.Duration;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreException;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreSubscription;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.CommitStage;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.PersistedEvents;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.EventJSON;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
 import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.LockCallback;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.LockName;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inbox;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.OrderedMessage;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
-import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
-import dk.cloudcreate.essentials.components.foundation.types.Tenant;
+import dk.cloudcreate.essentials.components.foundation.types.*;
 import dk.cloudcreate.essentials.shared.FailFast;
 import dk.cloudcreate.essentials.shared.concurrent.ThreadFactoryBuilder;
 import dk.cloudcreate.essentials.shared.functional.tuple.Pair;
 import org.reactivestreams.Subscription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
 import reactor.core.publisher.BaseSubscriber;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
@@ -1086,6 +1071,9 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
 
             @Override
             public void resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder, Consumer<GlobalEventOrder> resetProcessor) {
+                requireNonNull(subscribeFromAndIncludingGlobalOrder, "subscribeFromAndIncludingGlobalOrder must not be null");
+                requireNonNull(resetProcessor, "resetProcessor must not be null");
+
                 if (started) {
                     log.info("[{}-{}] Resetting resume point and re-starts the subscriber from and including globalOrder {}",
                              subscriberId,
@@ -1406,6 +1394,9 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
 
             @Override
             public void resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder, Consumer<GlobalEventOrder> resetProcessor) {
+                requireNonNull(subscribeFromAndIncludingGlobalOrder, "subscribeFromAndIncludingGlobalOrder must not be null");
+                requireNonNull(resetProcessor, "resetProcessor must not be null");
+
                 if (isStarted() && isActive()) {
                     log.info("[{}-{}] Resetting resume point and re-starts the subscriber from and including globalOrder {}",
                              subscriberId,

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -21,8 +21,9 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.mongodb.*;
+import com.mongodb.MongoInterruptedException;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import dk.cloudcreate.essentials.components.foundation.IOExceptionUtil;
 import dk.cloudcreate.essentials.components.foundation.json.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.Message;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
@@ -1022,8 +1023,8 @@ public final class MongoDurableQueues implements DurableQueues {
                                                        } else if (e instanceof UncategorizedMongoDbException && e.getCause() instanceof MongoInterruptedException) {
                                                            log.trace("[{}] MongoInterruptedException", queueName);
                                                            return Optional.<QueuedMessage>empty();
-                                                       } else if (e instanceof MongoSocketReadException) {
-                                                           log.trace("[{}] MongoSocketReadException", queueName);
+                                                       } else if (IOExceptionUtil.isIOException(e)) {
+                                                           log.trace("[{}] Experienced a Mongo related IO exception '{}'", queueName, e.getClass().getSimpleName());
                                                            return Optional.<QueuedMessage>empty();
                                                        } else if (e instanceof IllegalStateException && Objects.equals(e.getMessage(), "state should be: open")) {
                                                            log.trace("[{}] Mongo Session is not open", queueName);

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,59 +61,59 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <kotlin.version>1.9.24</kotlin.version>
+        <kotlin.version>2.0.20</kotlin.version>
         <revision>DEV-SNAPSHOT</revision>
         <skipDependencyCheck>false</skipDependencyCheck>
 
         <objenesis.version>3.4</objenesis.version>
-        <postgresql.version>42.7.3</postgresql.version>
-        <slf4j.version>2.0.13</slf4j.version>
-        <spring-boot.version>3.2.7</spring-boot.version>
-        <awaitility.version>4.2.1</awaitility.version>
-        <spring-data-mongodb.version>4.2.7</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.7</spring-data-jpa.version>
-        <assertj.version>3.26.0</assertj.version>
-        <mongodb-driver-sync.version>4.11.2</mongodb-driver-sync.version>
+        <postgresql.version>42.7.4</postgresql.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <spring-boot.version>3.2.9</spring-boot.version>
+        <awaitility.version>4.2.2</awaitility.version>
+        <spring-data-mongodb.version>4.2.9</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.2.9</spring-data-jpa.version>
+        <assertj.version>3.26.3</assertj.version>
+        <mongodb-driver-sync.version>4.11.3</mongodb-driver-sync.version>
         <log4j-to-slf4j.version>2.23.1</log4j-to-slf4j.version>
         <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <micrometer.version>1.13.1</micrometer.version>
-        <micrometer-tracing.version>1.3.1</micrometer-tracing.version>
-        <netty-bom.version>4.1.111.Final</netty-bom.version>
-        <junit-bom.version>5.10.2</junit-bom.version>
-        <testcontainers-bom.version>1.19.8</testcontainers-bom.version>
-        <jdbi3-bom.version>3.45.1</jdbi3-bom.version>
-        <jackson-bom.version>2.17.1</jackson-bom.version>
-        <reactor-bom.version>2023.0.7</reactor-bom.version>
-        <spring-framework-bom.version>6.1.10</spring-framework-bom.version>
+        <micrometer.version>1.13.3</micrometer.version>
+        <micrometer-tracing.version>1.3.3</micrometer-tracing.version>
+        <netty-bom.version>4.1.112.Final</netty-bom.version>
+        <junit-bom.version>5.11.0</junit-bom.version>
+        <testcontainers-bom.version>1.20.1</testcontainers-bom.version>
+        <jdbi3-bom.version>3.45.4</jdbi3-bom.version>
+        <jackson-bom.version>2.17.2</jackson-bom.version>
+        <reactor-bom.version>2023.0.9</reactor-bom.version>
+        <spring-framework-bom.version>6.1.12</spring-framework-bom.version>
         <mockito-bom.version>5.12.0</mockito-bom.version>
-        <logback.version>1.5.6</logback.version>
-        <avro.version>1.11.3</avro.version>
-        <commons-compress.version>1.26.2</commons-compress.version>
+        <logback.version>1.5.7</logback.version>
+        <avro.version>1.12.0</avro.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
 
         <dokka.version>1.9.20</dokka.version>
-        <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
-        <maven-project-info-reports-plugin.version>3.6.0</maven-project-info-reports-plugin.version>
+        <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
+        <maven-project-info-reports-plugin.version>3.7.0</maven-project-info-reports-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-        <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
+        <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
-        <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
+        <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+        <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
-        <maven-failsafe-plugin.version>3.3.0</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.3.0</maven-surefire-plugin.version>
+        <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
+        <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>9.2.0</dependency-check-maven.version>
+        <dependency-check-maven.version>10.0.3</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-        <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
     </properties>
 
     <modules>
@@ -412,6 +412,9 @@
                                 <goal>jar</goal>
                             </goals>
                             <configuration>
+                                <additionalJOptions>
+                                    <additionalJOption>-J-Xmx1g</additionalJOption>
+                                </additionalJOptions>
                                 <doclint>none</doclint>
                                 <archive>
                                     <manifestEntries>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/types-jdbi/pom.xml
+++ b/types-jdbi/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.2.224</version>
+            <version>2.3.232</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.12</version>
+    <version>0.40.13</version>
 </dependency>
 ```
 


### PR DESCRIPTION
- Added `EventStoreSubscription#resetFrom(GlobalEventOrder, Consumer)` reset callback
- Changed `EventProcessor` reset inbox logic using the `EventStoreSubscription` reset callback
- Added null checks to `resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder, Consumer<GlobalEventOrder> resetProcessor)` in `EventStoreSubscriptionManager`
- Added `IOExceptionUtil` to encapsulate resolving if an exception is a transient IO/Transaction/Connection/Socket, etc. style exception across Mongo and Postgresql/JDBC/JPA
- Added calls to `IOExceptionUtil` from `PostgresqlEventStore`, `EventStoreSubscriptionManager`, `DefaultDurableQueueConsumer`, `MongoDurableQueues`
- Adjusted `PostgresqlDocumentDbRepository` to resolve compilation issues from upgrading to Kotlin 2.0

Updated 3rd party dependencies:
- h2 2.3.232
- kotlin 2.0.20
- postgresql 42.7.4
- slf4j 2.0.16
- spring 6.1.12
- spring-boot 3.2.9
- spring-data-mongodb 4.2.9
- spring-data-jpa 3.2.9
- awaitility 4.2.2
- assertj 3.26.3
- mongodb-driver-sync 4.11.3
- micrometer 1.13.3
- micrometer-tracing 1.3.3
- netty 4.1.112.Final
- junit 5.11.0
- testcontainers 1.20.1
- jdbi3 3.45.4
- jackson 2.17.2
- reactor-bom 2023.0.9
- logback 1.5.7
- avro 1.12.0
- commons-compress 1.27.1

Updated maven plugins:
- maven-dependency-plugin 3.8.0
- maven-project-info-reports-plugin 3.7.0
- maven-install-plugin 3.1.3
- maven-deploy-plugin 3.1.3
- maven-site-plugin 3.20.0
- maven-javadoc-plugin 3.8.0
- maven-failsafe-plugin 3.4.0
- maven-surefire-plugin 3.4.0
- versions-maven-plugin 2.17.1
- dependency-check-maven 10.0.3
- maven-gpg-plugin 3.2.5