### PR TITLE
Release 0.40.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -167,7 +167,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -183,7 +183,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -265,7 +265,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -339,7 +339,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -385,7 +385,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -432,7 +432,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -508,7 +508,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 
@@ -524,7 +524,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
@@ -90,4 +90,13 @@ public class JacksonJSONSerializer implements JSONSerializer {
                                                    e);
         }
     }
+
+    /**
+     * Direct access to the internal {@link ObjectMapper} used by the {@link JacksonJSONSerializer} (or subclasses)
+     *
+     * @return the internal {@link ObjectMapper}
+     */
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
 }

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -784,6 +784,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -17,81 +17,56 @@
 package dk.cloudcreate.essentials.components.boot.autoconfigure.mongodb;
 
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.mongodb.ReadConcern;
-import com.mongodb.TransactionOptions;
-import com.mongodb.WriteConcern;
+import com.mongodb.*;
 import dk.cloudcreate.essentials.components.distributed.fencedlock.springdata.mongo.MongoFencedLockManager;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockEvents;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
-import dk.cloudcreate.essentials.components.foundation.fencedlock.LockName;
-import dk.cloudcreate.essentials.components.foundation.json.JSONSerializer;
-import dk.cloudcreate.essentials.components.foundation.json.JacksonJSONSerializer;
-import dk.cloudcreate.essentials.components.foundation.lifecycle.DefaultLifecycleManager;
-import dk.cloudcreate.essentials.components.foundation.lifecycle.LifecycleManager;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
+import dk.cloudcreate.essentials.components.foundation.json.*;
+import dk.cloudcreate.essentials.components.foundation.lifecycle.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inboxes;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Outboxes;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueuesInterceptor;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueEntryId;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueueName;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuePollingOptimizer;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.TransactionalMode;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.DurableQueuesMicrometerInterceptor;
-import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.DurableQueuesMicrometerTracingInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.ConsumeFromQueue;
-import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
-import dk.cloudcreate.essentials.components.foundation.reactive.command.UnitOfWorkControllingCommandBusInterceptor;
-import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
-import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkFactory;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.*;
+import dk.cloudcreate.essentials.components.foundation.transaction.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.spring.mongo.SpringMongoTransactionAwareUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.queue.springdata.mongodb.MongoDurableQueues;
 import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
 import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
-import dk.cloudcreate.essentials.reactive.EventBus;
-import dk.cloudcreate.essentials.reactive.EventHandler;
-import dk.cloudcreate.essentials.reactive.LocalEventBus;
-import dk.cloudcreate.essentials.reactive.OnErrorHandler;
-import dk.cloudcreate.essentials.reactive.command.CommandBus;
-import dk.cloudcreate.essentials.reactive.command.CommandHandler;
-import dk.cloudcreate.essentials.reactive.command.SendAndDontWaitErrorHandler;
+import dk.cloudcreate.essentials.reactive.*;
+import dk.cloudcreate.essentials.reactive.command.*;
 import dk.cloudcreate.essentials.reactive.command.interceptor.CommandBusInterceptor;
 import dk.cloudcreate.essentials.reactive.spring.ReactiveHandlersBeanPostProcessor;
 import dk.cloudcreate.essentials.types.CharSequenceType;
-import dk.cloudcreate.essentials.types.springdata.mongo.SingleValueTypeConverter;
-import dk.cloudcreate.essentials.types.springdata.mongo.SingleValueTypeRandomIdGenerator;
+import dk.cloudcreate.essentials.types.springdata.mongo.*;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
+import org.slf4j.*;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.core.convert.converter.GenericConverter;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
-import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.context.event.EventListener;
+import org.springframework.context.event.*;
+import org.springframework.core.convert.converter.*;
+import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+import java.util.*;
+import java.util.function.Function;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
 /**
  * MongoDB focused Essentials Components auto configuration<br>
@@ -471,4 +446,31 @@ public class EssentialsComponentsConfiguration {
         return new DefaultLifecycleManager(properties.getLifeCycles().isStartLifeCycles());
     }
 
+    @Bean
+    @ConditionalOnClass(name = "org.springframework.boot.devtools.restart.RestartScope")
+    public SpringBootDevToolsClassLoaderChangeContextRefreshedListener contextRefreshedListener(JSONSerializer jsonSerializer) {
+        return new SpringBootDevToolsClassLoaderChangeContextRefreshedListener(jsonSerializer);
+    }
+
+    private static class SpringBootDevToolsClassLoaderChangeContextRefreshedListener {
+        private static final Logger log = LoggerFactory.getLogger(SpringBootDevToolsClassLoaderChangeContextRefreshedListener.class);
+        private final JacksonJSONSerializer jacksonJSONSerializer;
+
+        public SpringBootDevToolsClassLoaderChangeContextRefreshedListener(JSONSerializer jsonSerializer) {
+            requireNonNull(jsonSerializer, "No jsonSerializer provided");
+            this.jacksonJSONSerializer = jsonSerializer instanceof JacksonJSONSerializer ? (JacksonJSONSerializer) jsonSerializer : null;
+        }
+
+        @EventListener
+        public void handleContextRefresh(ContextRefreshedEvent event) {
+            if (jacksonJSONSerializer != null) {
+                log.info("Updating the '{}'s internal ObjectMapper's ClassLoader to {} from {}",
+                         jacksonJSONSerializer.getClass().getSimpleName(),
+                         event.getApplicationContext().getClassLoader(),
+                         jacksonJSONSerializer.getObjectMapper().getTypeFactory().getClassLoader()
+                        );
+                jacksonJSONSerializer.getObjectMapper().setTypeFactory(TypeFactory.defaultInstance().withClassLoader(event.getApplicationContext().getClassLoader()));
+            }
+        }
+    }
 }

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <micrometer.version>1.13.3</micrometer.version>
-        <micrometer-tracing.version>1.3.3</micrometer-tracing.version>
+        <micrometer.version>1.12.9</micrometer.version>
+        <micrometer-tracing.version>1.2.9</micrometer-tracing.version>
         <netty-bom.version>4.1.112.Final</netty-bom.version>
         <junit-bom.version>5.11.0</junit-bom.version>
         <testcontainers-bom.version>1.20.1</testcontainers-bom.version>
@@ -87,7 +87,7 @@
         <jackson-bom.version>2.17.2</jackson-bom.version>
         <reactor-bom.version>2023.0.9</reactor-bom.version>
         <spring-framework-bom.version>6.1.12</spring-framework-bom.version>
-        <mockito-bom.version>5.12.0</mockito-bom.version>
+        <mockito-bom.version>5.13.0</mockito-bom.version>
         <logback.version>1.5.7</logback.version>
         <avro.version>1.12.0</avro.version>
         <commons-compress.version>1.27.1</commons-compress.version>
@@ -103,7 +103,7 @@
         <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
         <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -412,9 +412,6 @@
                                 <goal>jar</goal>
                             </goals>
                             <configuration>
-                                <additionalJOptions>
-                                    <additionalJOption>-J-Xmx1g</additionalJOption>
-                                </additionalJOptions>
                                 <doclint>none</doclint>
                                 <archive>
                                     <manifestEntries>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.14</version>
+    <version>0.40.15</version>
 </dependency>
 ```
 


### PR DESCRIPTION
- Improved `DefaultDurableQueueConsumer` message handling error logging, plus adjusted behaviour in case `TransactionalMode.FullyTransactional` is used as TransactionalMode
- Added `#getObjectMapper` to `JacksonJSONSerializer` to support changes to `EssentialsComponentsConfiguration`
- `EssentialsComponentsConfiguration`: If `org.springframework.boot:spring-boot-devtools` is added to the classpath (to support class reloading during development time), then we add support for dynamically changing ClassLoaders, in order to avoid `ClassCastException`'s for messages/events/etc. that are deserialized from JSON
   - This is done by checked if `org.springframework.boot.devtools.restart.RestartScope` is on the classpath
   - In that case the `SpringBootDevToolsClassLoaderChangeContextRefreshedListener` is added to the `ApplicationContext` to ensure that `JacksonJSONSerializer#getObjectMapper` uses the same `ClassLoader` as the `ApplicationContext`

Upgraded 3rd party dependencies
- mockito 5.13.0

Downgraded 3rd party dependencies to retain Spring Boot 3.2.x compatibility:
- micrometer 1.12.9
- micrometer-tracing 1.2.9

Downgraded `maven-javadoc-plugin` to version 3.7.0 because version 3.8.0 was reporting VM memory errors, such as:
```
[INFO] The goal 'org.apache.maven.plugins:maven-javadoc-plugin:3.8.0:javadoc' has not been previously called for the module: 'dk.cloudcreate.essentials:types:jar:DEV-SNAPSHOT'. Trying to invoke it...
[ERROR] Error occurred during initialization of VM, trying to use an empty MAVEN_OPTS...
[ERROR] MavenInvocationException: Error occurred during initialization of VM, try to reduce the Java heap size for the MAVEN_OPTS environment variable using -Xms:<size> and -Xmx:<size>.
```