### PR TITLE
Release 0.40.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -167,7 +167,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -183,7 +183,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -265,7 +265,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -339,7 +339,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -385,7 +385,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -432,7 +432,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -508,7 +508,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 
@@ -524,7 +524,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -465,13 +465,44 @@ public interface DurableQueues extends Lifecycle {
      * using {@link TransactionalMode#FullyTransactional}
      *
      * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
-     * @param causeForBeingMarkedAsDeadLetter the reason for the message being marked as a Dead Letter Message
+     * @param causeForBeingMarkedAsDeadLetter the optional reason for the message being marked as a Dead Letter Message
      * @return the {@link QueuedMessage} message wrapped in an {@link Optional} if the operation was successful, otherwise it returns an {@link Optional#empty()}
      */
     default Optional<QueuedMessage> markAsDeadLetterMessage(QueueEntryId queueEntryId,
                                                             Throwable causeForBeingMarkedAsDeadLetter) {
         return markAsDeadLetterMessage(new MarkAsDeadLetterMessage(queueEntryId,
                                                                    causeForBeingMarkedAsDeadLetter));
+    }
+
+    /**
+     * Mark an already Queued Message as a Dead Letter Message (or Poison Message).<br>
+     * Dead Letter Messages won't be delivered to any {@link DurableQueueConsumer} (called by the {@link DurableQueueConsumer})<br>
+     * To deliver a Dead Letter Message you must first resurrect the message using {@link #resurrectDeadLetterMessage(QueueEntryId, Duration)}<br>
+     * Note this method MUST be called within an existing {@link UnitOfWork} IF
+     * using {@link TransactionalMode#FullyTransactional}
+     *
+     * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
+     * @param causeForBeingMarkedAsDeadLetter the optional reason for the message being marked as a Dead Letter Message
+     * @return the {@link QueuedMessage} message wrapped in an {@link Optional} if the operation was successful, otherwise it returns an {@link Optional#empty()}
+     */
+    default Optional<QueuedMessage> markAsDeadLetterMessage(QueueEntryId queueEntryId,
+                                                            String causeForBeingMarkedAsDeadLetter) {
+        return markAsDeadLetterMessage(new MarkAsDeadLetterMessage(queueEntryId,
+                                                                   causeForBeingMarkedAsDeadLetter));
+    }
+
+    /**
+     * Mark an already Queued Message as a Dead Letter Message (or Poison Message).<br>
+     * Dead Letter Messages won't be delivered to any {@link DurableQueueConsumer} (called by the {@link DurableQueueConsumer})<br>
+     * To deliver a Dead Letter Message you must first resurrect the message using {@link #resurrectDeadLetterMessage(QueueEntryId, Duration)}<br>
+     * Note this method MUST be called within an existing {@link UnitOfWork} IF
+     * using {@link TransactionalMode#FullyTransactional}
+     *
+     * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
+     * @return the {@link QueuedMessage} message wrapped in an {@link Optional} if the operation was successful, otherwise it returns an {@link Optional#empty()}
+     */
+    default Optional<QueuedMessage> markAsDeadLetterMessage(QueueEntryId queueEntryId) {
+        return markAsDeadLetterMessage(new MarkAsDeadLetterMessage(queueEntryId));
     }
 
     /**

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
@@ -18,6 +18,7 @@ package dk.cloudcreate.essentials.components.foundation.messaging.queue.operatio
 
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+import dk.cloudcreate.essentials.shared.Exceptions;
 import dk.cloudcreate.essentials.shared.interceptor.InterceptorChain;
 
 import java.time.Duration;
@@ -34,7 +35,7 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  */
 public final class MarkAsDeadLetterMessage {
     public final QueueEntryId queueEntryId;
-    private      Throwable    causeForBeingMarkedAsDeadLetter;
+    private      String       causeForBeingMarkedAsDeadLetter;
 
     /**
      * Create a new builder that produces a new {@link MarkAsDeadLetterMessage} instance
@@ -52,15 +53,39 @@ public final class MarkAsDeadLetterMessage {
      * using {@link TransactionalMode#FullyTransactional}
      *
      * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
-     * @param causeForBeingMarkedAsDeadLetter the reason for the message being marked as a Dead Letter Message
+     */
+    public MarkAsDeadLetterMessage(QueueEntryId queueEntryId) {
+        this(queueEntryId, (String) null);
+    }
+
+    /**
+     * Mark a Message as a Dead Letter Message (or Poison Message).  Dead Letter Messages won't be delivered to any {@link DurableQueueConsumer} (called by the {@link DurableQueueConsumer})<br>
+     * To deliver a Dead Letter Message you must first resurrect the message using {@link DurableQueues#resurrectDeadLetterMessage(QueueEntryId, Duration)}<br>
+     * Note this method MUST be called within an existing {@link UnitOfWork} IF
+     * using {@link TransactionalMode#FullyTransactional}
+     *
+     * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
+     * @param causeForBeingMarkedAsDeadLetter the optional reason for the message being marked as a Dead Letter Message
      */
     public MarkAsDeadLetterMessage(QueueEntryId queueEntryId, Throwable causeForBeingMarkedAsDeadLetter) {
+        this(queueEntryId, causeForBeingMarkedAsDeadLetter != null ? Exceptions.getStackTrace(causeForBeingMarkedAsDeadLetter) : null);
+    }
+
+    /**
+     * Mark a Message as a Dead Letter Message (or Poison Message).  Dead Letter Messages won't be delivered to any {@link DurableQueueConsumer} (called by the {@link DurableQueueConsumer})<br>
+     * To deliver a Dead Letter Message you must first resurrect the message using {@link DurableQueues#resurrectDeadLetterMessage(QueueEntryId, Duration)}<br>
+     * Note this method MUST be called within an existing {@link UnitOfWork} IF
+     * using {@link TransactionalMode#FullyTransactional}
+     *
+     * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
+     * @param causeForBeingMarkedAsDeadLetter the optional reason for the message being marked as a Dead Letter Message
+     */
+    public MarkAsDeadLetterMessage(QueueEntryId queueEntryId, String causeForBeingMarkedAsDeadLetter) {
         this.queueEntryId = requireNonNull(queueEntryId, "No queueEntryId provided");
         this.causeForBeingMarkedAsDeadLetter = causeForBeingMarkedAsDeadLetter;
     }
 
     /**
-     *
      * @return the unique id of the message that must be marked as a Dead Letter Message
      */
     public QueueEntryId getQueueEntryId() {
@@ -68,18 +93,23 @@ public final class MarkAsDeadLetterMessage {
     }
 
     /**
-     *
      * @return the reason for the message being marked as a Dead Letter Message
      */
-    public Throwable getCauseForBeingMarkedAsDeadLetter() {
+    public String getCauseForBeingMarkedAsDeadLetter() {
         return causeForBeingMarkedAsDeadLetter;
     }
 
     /**
-     *
      * @param causeForBeingMarkedAsDeadLetter the reason for the message being marked as a Dead Letter Message
      */
     public void setCauseForBeingMarkedAsDeadLetter(Throwable causeForBeingMarkedAsDeadLetter) {
+        this.causeForBeingMarkedAsDeadLetter = causeForBeingMarkedAsDeadLetter != null ? Exceptions.getStackTrace(causeForBeingMarkedAsDeadLetter) : null;
+    }
+
+    /**
+     * @param causeForBeingMarkedAsDeadLetter the reason for the message being marked as a Dead Letter Message
+     */
+    public void setCauseForBeingMarkedAsDeadLetter(String causeForBeingMarkedAsDeadLetter) {
         this.causeForBeingMarkedAsDeadLetter = causeForBeingMarkedAsDeadLetter;
     }
 
@@ -93,6 +123,5 @@ public final class MarkAsDeadLetterMessage {
 
     public void validate() {
         requireNonNull(queueEntryId, "You must provide a queueEntryId");
-        requireNonNull(causeForBeingMarkedAsDeadLetter, "You must provide a causeForBeingMarkedAsDeadLetter");
     }
 }

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -784,6 +784,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
@@ -773,7 +773,7 @@ public final class PostgresqlEventStore<CONFIG extends AggregateEventStreamConfi
                                                                                         transientGapsToIncludeInQuery));
                 unitOfWork.commit();
                 unitOfWork = null;
-                if (persistedEvents.size() > 0) {
+                if (!persistedEvents.isEmpty()) {
                     consecutiveNoPersistedEventsReturned.set(0);
                     if (log.isTraceEnabled()) {
                         eventStoreStreamLog.debug("[{}] Polling worker - loadEventsByGlobalOrder using globalOrderRange {} and transientGapsToIncludeInQuery {} returned {} events: {}",
@@ -834,7 +834,6 @@ public final class PostgresqlEventStore<CONFIG extends AggregateEventStreamConfi
                                               aggregateType,
                                               nextFromInclusiveGlobalOrder.get()),
                                           e);
-                //sink.error(e);
                 return 0;
             }
         }

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_2_node_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_2_node_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWorkFactory;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
+import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+import dk.cloudcreate.essentials.components.foundation.types.*;
+import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
+import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.postgres.PostgresPlugin;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.*;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.stream.LongStream;
+
+import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class EventStoreSubscriptionManager_2_node_exclusivelySubscribeToAggregateEventsAsynchronously_IT {
+    public static final EventMetaData META_DATA = EventMetaData.of("Key1", "Value1", "Key2", "Value2");
+    public static final AggregateType ORDERS    = AggregateType.of("Orders");
+
+    @Container
+    private final PostgreSQLContainer<?>        postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+            .withDatabaseName("event-store")
+            .withUsername("test-user")
+            .withPassword("secret-password");
+    private       EventStoreSubscriptionManager eventStoreSubscriptionManagerNode1;
+    private       EventStoreSubscriptionManager eventStoreSubscriptionManagerNode2;
+
+
+    @BeforeEach
+    void setup() {
+        eventStoreSubscriptionManagerNode1 = createEventStoreSubscriptionManager("node1");
+        eventStoreSubscriptionManagerNode2 = createEventStoreSubscriptionManager("node2");
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (eventStoreSubscriptionManagerNode1 != null) {
+            eventStoreSubscriptionManagerNode1.getEventStore().getUnitOfWorkFactory().getCurrentUnitOfWork().ifPresent(UnitOfWork::rollback);
+            assertThat(eventStoreSubscriptionManagerNode1.getEventStore().getUnitOfWorkFactory().getCurrentUnitOfWork()).isEmpty();
+            eventStoreSubscriptionManagerNode1.stop();
+        }
+        if (eventStoreSubscriptionManagerNode2 != null) {
+            eventStoreSubscriptionManagerNode2.getEventStore().getUnitOfWorkFactory().getCurrentUnitOfWork().ifPresent(UnitOfWork::rollback);
+            assertThat(eventStoreSubscriptionManagerNode2.getEventStore().getUnitOfWorkFactory().getCurrentUnitOfWork()).isEmpty();
+            eventStoreSubscriptionManagerNode2.stop();
+        }
+    }
+
+    private EventStoreSubscriptionManager createEventStoreSubscriptionManager(String nodeName) {
+        var jdbi = Jdbi.create(postgreSQLContainer.getJdbcUrl() + "?connectTimeout=1&socketTimeout=1",
+                               postgreSQLContainer.getUsername(),
+                               postgreSQLContainer.getPassword());
+        jdbi.installPlugin(new PostgresPlugin());
+        jdbi.setSqlLogger(new SqlExecutionTimeLogger());
+
+        var unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
+        var eventMapper       = new TestPersistableEventMapper();
+        var jsonSerializer    = new JacksonJSONEventSerializer(createObjectMapper());
+        var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
+                                                                                       unitOfWorkFactory,
+                                                                                       eventMapper,
+                                                                                       SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(jsonSerializer,
+                                                                                                                                                                                      IdentifierColumnType.UUID,
+                                                                                                                                                                                      JSONColumnType.JSONB));
+        var eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
+                                                    persistenceStrategy);
+        eventStore.addAggregateEventStreamConfiguration(ORDERS,
+                                                        OrderId.class);
+
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var eventStoreSubscriptionManager = EventStoreSubscriptionManager.createFor(eventStore,
+                                                                                    20,
+                                                                                    Duration.ofMillis(100),
+                                                                                    new PostgresqlFencedLockManager(jdbi,
+                                                                                                                    unitOfWorkFactory,
+                                                                                                                    Optional.of(nodeName),
+                                                                                                                    Duration.ofSeconds(3),
+                                                                                                                    Duration.ofSeconds(1)),
+                                                                                    Duration.ofSeconds(1),
+                                                                                    durableSubscriptionRepository);
+        eventStoreSubscriptionManager.start();
+        return eventStoreSubscriptionManager;
+    }
+
+
+    private void disruptDatabaseConnection() {
+        System.out.println("***** Disrupting DB connection *****");
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.pauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    private void restoreDatabaseConnection() {
+        System.out.println("***** Restoring DB connection *****");
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.unpauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    @Test
+    void subscribe() throws InterruptedException {
+        var testEvents = createTestEvents();
+        var totalNumberOfOrderEvents = testEvents.values()
+                                                 .stream()
+                                                 .map(List::size)
+                                                 .reduce(Integer::sum)
+                                                 .get();
+        System.out.println("Total number of Order Events: " + totalNumberOfOrderEvents);
+
+        // Persist all test events using node2
+        testEvents.forEach((aggregateId, events) -> {
+            var eventStore = eventStoreSubscriptionManagerNode2.getEventStore();
+            eventStore.getUnitOfWorkFactory().usingUnitOfWork(() -> {
+                System.out.println(msg("Persisting {} {} events related to aggregate id {}",
+                                       events.size(),
+                                       ORDERS,
+                                       aggregateId));
+                var aggregateEventStream = eventStore.appendToStream(ORDERS,
+                                                                     aggregateId,
+                                                                     EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED,
+                                                                     events);
+                assertThat((CharSequence) aggregateEventStream.aggregateId()).isEqualTo(aggregateId);
+                assertThat(aggregateEventStream.isPartialEventStream()).isTrue();
+                assertThat(aggregateEventStream.eventList().size()).isEqualTo(events.size());
+            });
+        });
+
+        // Start with node1 as the active subscriber
+        var node1Subscription = createOrderSubscription(eventStoreSubscriptionManagerNode1);
+        var node2Subscription = createOrderSubscription(eventStoreSubscriptionManagerNode2);
+        Thread.sleep(500);
+        // Verify only one subscriber is active
+        boolean isNode1TheInitialActiveSubscriber;
+        if (node1Subscription.subscription.isActive()) {
+            assertThat(node2Subscription.subscription.isActive()).isFalse();
+        } else {
+            assertThat(node1Subscription.subscription.isActive()).isFalse();
+        }
+
+        Thread.sleep(500);
+        disruptDatabaseConnection();
+        System.out.println("Number of Order Events received: " + (node1Subscription.eventsReceived.size() + node2Subscription.eventsReceived.size()));
+        System.out.println("Number of Order Events received #1: " + node1Subscription.eventsReceived.size());
+        System.out.println("Number of Order Events received #2: " + node2Subscription.eventsReceived.size());
+        Thread.sleep(5000);
+        restoreDatabaseConnection();
+
+        // Verify that there's still only one subscriber active
+        if (node1Subscription.subscription.isActive()) {
+            assertThat(node2Subscription.subscription.isActive()).isFalse();
+        } else {
+            assertThat(node1Subscription.subscription.isActive()).isFalse();
+        }
+
+        // Verify we received all Order events
+        Awaitility.waitAtMost(Duration.ofSeconds(15)) // Longer wait time due to the smaller batch fetch size
+                  .untilAsserted(() -> {
+                      var allReceivedEventsDeduplicated = new HashSet<>(node1Subscription.eventsReceived);
+                      allReceivedEventsDeduplicated.addAll(node2Subscription.eventsReceived);
+                      assertThat(allReceivedEventsDeduplicated).hasSize(totalNumberOfOrderEvents);
+                  });
+        System.out.println("Number of Order Events received #1: " + node1Subscription.eventsReceived.size());
+        System.out.println("Number of Order Events received #2: " + node2Subscription.eventsReceived.size());
+
+        // During DB disconnects there can occur small gaps where two subscribers both believe they have the same fenced lock
+        var allReceivedEventsDeduplicated = new HashSet<>(node1Subscription.eventsReceived);
+        allReceivedEventsDeduplicated.addAll(node2Subscription.eventsReceived);
+        var allReceivedEvents = allReceivedEventsDeduplicated.stream().sorted(Comparator.comparing(PersistedEvent::globalEventOrder)).toList();
+        assertThat(allReceivedEvents.stream()
+                                    .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
+                                    .toList())
+                .isEqualTo(LongStream.rangeClosed(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER.longValue(),
+                                                  totalNumberOfOrderEvents)
+                                     .boxed()
+                                     .toList());
+
+        // Verify that there's still only one subscriber active
+        if (node1Subscription.subscription.isActive()) {
+            assertThat(node2Subscription.subscription.isActive()).isFalse();
+        } else {
+            assertThat(node1Subscription.subscription.isActive()).isFalse();
+        }
+
+        // Check subscription state after being stopped
+        if (node1Subscription.subscription.isActive()) {
+            System.out.println("******* Stopping node 2 subscription and then node 1 subscription *********");
+            node2Subscription.subscription.stop();
+            node1Subscription.subscription.stop();
+        } else {
+            System.out.println("******* Stopping node 1 subscription and then node 2 subscription *********");
+            node1Subscription.subscription.stop();
+            node2Subscription.subscription.stop();
+        }
+        Awaitility.waitAtMost(Duration.ofSeconds(5))
+                  .untilAsserted(() -> assertThat(node1Subscription.subscription.isActive()).isFalse());
+        Awaitility.waitAtMost(Duration.ofSeconds(5))
+                  .untilAsserted(() -> assertThat(node2Subscription.subscription.isActive()).isFalse());
+
+        // Check the ResumePoints are updated and saved across subscriptions that have been active
+        var lastEventOrder = allReceivedEvents.get(totalNumberOfOrderEvents - 1);
+        if (node1Subscription.subscription.currentResumePoint().isPresent()) {
+            assertThat(node1Subscription.subscription.currentResumePoint().get().getResumeFromAndIncluding()).isEqualTo(lastEventOrder.globalEventOrder().increment()); // When the subscriber is stopped we store the next global event order
+        }
+        if (node2Subscription.subscription.currentResumePoint().isPresent()) {
+            assertThat(node2Subscription.subscription.currentResumePoint().get().getResumeFromAndIncluding()).isEqualTo(lastEventOrder.globalEventOrder().increment()); // When the subscriber is stopped we store the next global event order
+        }
+    }
+
+    private EventSubscriber createOrderSubscription(EventStoreSubscriptionManager eventStoreSubscriptionManager) {
+        var orderEventsReceived = new ConcurrentLinkedDeque<PersistedEvent>();
+        var eventSubscription = eventStoreSubscriptionManager.exclusivelySubscribeToAggregateEventsAsynchronously(
+                SubscriberId.of("OrdersSubscriber"),
+                ORDERS,
+                GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER,
+                Optional.empty(),
+                new FencedLockAwareSubscriber() {
+                    @Override
+                    public void onLockAcquired(FencedLock fencedLock, SubscriptionResumePoint resumeFromAndIncluding) {
+                        System.out.println("Lock acquired: " + fencedLock);
+                    }
+
+                    @Override
+                    public void onLockReleased(FencedLock fencedLock) {
+                        System.out.println("Lock released: " + fencedLock);
+                    }
+                },
+                new PersistedEventHandler() {
+                    @Override
+                    public void onResetFrom(EventStoreSubscription eventStoreSubscription, GlobalEventOrder globalEventOrder) {
+                        throw new IllegalStateException("Method shouldn't be called");
+                    }
+
+                    @Override
+                    public void handle(PersistedEvent event) {
+                        System.out.println("Received Order event: " + event);
+                        orderEventsReceived.add(event);
+                    }
+                });
+        return new EventSubscriber(eventSubscription, orderEventsReceived);
+    }
+
+    private Map<OrderId, List<OrderEvent>> createTestEvents() {
+        // Orders
+        var aggregatesAndEvents = new HashMap<OrderId, List<OrderEvent>>();
+        for (int i = 0; i < 100; i++) {
+            var orderId = OrderId.random();
+            if (i % 2 == 0) {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i),
+                                                         new OrderEvent.ProductAddedToOrder(orderId, ProductId.random(), i)));
+            } else if (i % 3 == 0) {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i),
+                                                         new OrderEvent.ProductAddedToOrder(orderId, ProductId.random(), i),
+                                                         new OrderEvent.ProductOrderQuantityAdjusted(orderId, ProductId.random(), i - 1)));
+            } else if (i % 5 == 0) {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i),
+                                                         new OrderEvent.ProductAddedToOrder(orderId, ProductId.random(), i),
+                                                         new OrderEvent.ProductOrderQuantityAdjusted(orderId, ProductId.random(), i - 1),
+                                                         new OrderEvent.ProductRemovedFromOrder(orderId, ProductId.random()),
+                                                         new OrderEvent.OrderAccepted(orderId)));
+            } else {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i)));
+            }
+        }
+        return aggregatesAndEvents;
+    }
+
+    private ObjectMapper createObjectMapper() {
+        var objectMapper = JsonMapper.builder()
+                                     .disable(MapperFeature.AUTO_DETECT_GETTERS)
+                                     .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+                                     .disable(MapperFeature.AUTO_DETECT_SETTERS)
+                                     .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                                     .enable(MapperFeature.AUTO_DETECT_CREATORS)
+                                     .enable(MapperFeature.AUTO_DETECT_FIELDS)
+                                     .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
+                                     .addModule(new Jdk8Module())
+                                     .addModule(new JavaTimeModule())
+                                     .addModule(new EssentialTypesJacksonModule())
+                                     .addModule(new EssentialsImmutableJacksonModule())
+                                     .build();
+
+        objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
+                                               .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                               .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                               .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                                               .withCreatorVisibility(JsonAutoDetect.Visibility.ANY));
+        return objectMapper;
+    }
+
+    private static class TestPersistableEventMapper implements PersistableEventMapper {
+        private final CorrelationId correlationId   = CorrelationId.random();
+        private final EventId       causedByEventId = EventId.random();
+
+        @Override
+        public PersistableEvent map(Object aggregateId,
+                                    AggregateEventStreamConfiguration aggregateEventStreamConfiguration,
+                                    Object event,
+                                    EventOrder eventOrder) {
+            return PersistableEvent.from(EventId.random(),
+                                         aggregateEventStreamConfiguration.aggregateType,
+                                         aggregateId,
+                                         EventTypeOrName.with(event.getClass()),
+                                         event,
+                                         eventOrder,
+                                         EventRevision.of(1),
+                                         META_DATA,
+                                         OffsetDateTime.now(),
+                                         causedByEventId,
+                                         correlationId,
+                                         null);
+        }
+    }
+
+    private record EventSubscriber(EventStoreSubscription subscription,
+                                   ConcurrentLinkedDeque<PersistedEvent> eventsReceived) {
+
+    }
+}

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -33,6 +33,18 @@ class PostgresqlDistributedCompetingConsumersDurableQueuesIT extends Distributed
             .withPassword("secret-password");
 
     @Override
+    protected void disruptDatabaseConnection() {
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.pauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    @Override
+    protected void restoreDatabaseConnection() {
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.unpauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
         return PostgresqlDurableQueues.builder().setUnitOfWorkFactory(unitOfWorkFactory).build();
     }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -35,6 +35,18 @@ class SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQu
             .withPassword("secret-password");
 
     @Override
+    protected void disruptDatabaseConnection() {
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.pauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    @Override
+    protected void restoreDatabaseConnection() {
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.unpauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
         return PostgresqlDurableQueues.builder()
                                       .setUnitOfWorkFactory(unitOfWorkFactory)

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.*;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.test.context.*;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.*;
@@ -74,6 +73,19 @@ class MongoFencedLockManagerIT extends DBFencedLockManagerIT<MongoFencedLockMana
                                           Duration.ofSeconds(3),
                                           Duration.ofSeconds(1),
                                           Optional.empty());
+    }
+
+
+    @Override
+    protected void disruptDatabaseConnection() {
+        var dockerClient = mongoDBContainer.getDockerClient();
+        dockerClient.pauseContainerCmd(mongoDBContainer.getContainerId()).exec();
+    }
+
+    @Override
+    protected void restoreDatabaseConnection() {
+        var dockerClient = mongoDBContainer.getDockerClient();
+        dockerClient.unpauseContainerCmd(mongoDBContainer.getContainerId()).exec();
     }
 
     @Test

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -49,6 +49,19 @@ class MongoDistributedCompetingConsumersDurableQueuesIT extends DistributedCompe
     private MongoTransactionManager transactionManager;
 
     @Override
+    protected void disruptDatabaseConnection() {
+        var dockerClient = mongoDBContainer.getDockerClient();
+        dockerClient.pauseContainerCmd(mongoDBContainer.getContainerId()).exec();
+
+    }
+
+    @Override
+    protected void restoreDatabaseConnection() {
+        var dockerClient = mongoDBContainer.getDockerClient();
+        dockerClient.unpauseContainerCmd(mongoDBContainer.getContainerId()).exec();
+    }
+
+    @Override
     protected MongoDurableQueues createDurableQueues(SpringMongoTransactionAwareUnitOfWorkFactory unitOfWorkFactory) {
         return new MongoDurableQueues(mongoTemplate,
                                       unitOfWorkFactory);

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -44,6 +44,19 @@ class SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesI
     private MongoTemplate mongoTemplate;
 
     @Override
+    protected void disruptDatabaseConnection() {
+        var dockerClient = mongoDBContainer.getDockerClient();
+        dockerClient.pauseContainerCmd(mongoDBContainer.getContainerId()).exec();
+
+    }
+
+    @Override
+    protected void restoreDatabaseConnection() {
+        var dockerClient = mongoDBContainer.getDockerClient();
+        dockerClient.unpauseContainerCmd(mongoDBContainer.getContainerId()).exec();
+    }
+
+    @Override
     protected MongoDurableQueues createDurableQueues(SpringMongoTransactionAwareUnitOfWorkFactory unitOfWorkFactory) {
         return new MongoDurableQueues(mongoTemplate,
                                       Duration.ofSeconds(5));

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,27 +68,27 @@
         <objenesis.version>3.4</objenesis.version>
         <postgresql.version>42.7.4</postgresql.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <spring-boot.version>3.2.9</spring-boot.version>
+        <spring-boot.version>3.2.10</spring-boot.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <spring-data-mongodb.version>4.2.9</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.9</spring-data-jpa.version>
+        <spring-data-mongodb.version>4.2.10</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.2.10</spring-data-jpa.version>
         <assertj.version>3.26.3</assertj.version>
-        <mongodb-driver-sync.version>4.11.3</mongodb-driver-sync.version>
-        <log4j-to-slf4j.version>2.23.1</log4j-to-slf4j.version>
+        <mongodb-driver-sync.version>4.11.4</mongodb-driver-sync.version>
+        <log4j-to-slf4j.version>2.24.0</log4j-to-slf4j.version>
         <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
-        <micrometer.version>1.12.9</micrometer.version>
-        <micrometer-tracing.version>1.2.9</micrometer-tracing.version>
-        <netty-bom.version>4.1.112.Final</netty-bom.version>
-        <junit-bom.version>5.11.0</junit-bom.version>
+        <snakeyaml.version>2.3</snakeyaml.version>
+        <micrometer.version>1.12.10</micrometer.version>
+        <micrometer-tracing.version>1.2.10</micrometer-tracing.version>
+        <netty-bom.version>4.1.113.Final</netty-bom.version>
+        <junit-bom.version>5.11.1</junit-bom.version>
         <testcontainers-bom.version>1.20.1</testcontainers-bom.version>
         <jdbi3-bom.version>3.45.4</jdbi3-bom.version>
-        <jackson-bom.version>2.17.2</jackson-bom.version>
-        <reactor-bom.version>2023.0.9</reactor-bom.version>
-        <spring-framework-bom.version>6.1.12</spring-framework-bom.version>
-        <mockito-bom.version>5.13.0</mockito-bom.version>
-        <logback.version>1.5.7</logback.version>
+        <jackson-bom.version>2.18.0</jackson-bom.version>
+        <reactor-bom.version>2023.0.10</reactor-bom.version>
+        <spring-framework-bom.version>6.1.13</spring-framework-bom.version>
+        <mockito-bom.version>5.14.0</mockito-bom.version>
+        <logback.version>1.5.8</logback.version>
         <avro.version>1.12.0</avro.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
@@ -104,16 +104,16 @@
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
-        <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.0</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>10.0.3</dependency-check-maven.version>
+        <dependency-check-maven.version>10.0.4</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
-        <maven-gpg-plugin.version>3.2.5</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     </properties>
 
     <modules>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcControllerTest.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcControllerTest.java
@@ -27,7 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.result.*;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -184,6 +184,7 @@ public class WebMvcControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.put("/order")
                                               .contentType("application/json")
                                               .content(objectMapper.writeValueAsString(order)))
+               .andDo(MockMvcResultHandlers.print())
                .andExpect(MockMvcResultMatchers.status().isOk())
                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
                .andExpect(MockMvcResultMatchers.content().string(order.id.toString()));

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/AccountId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/AccountId.java
@@ -27,6 +27,10 @@ public class AccountId extends LongType<AccountId> implements Identifier {
         super(value);
     }
 
+    public AccountId(Number value) {
+        super(value.longValue());
+    }
+
     public static AccountId of(long value) {
         return new AccountId(value);
     }

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/CustomerId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/CustomerId.java
@@ -21,6 +21,11 @@ import dk.cloudcreate.essentials.types.*;
 import java.util.UUID;
 
 public class CustomerId extends CharSequenceType<CustomerId> implements Identifier {
+
+    public CustomerId(String value) {
+        super(value);
+    }
+
     public CustomerId(CharSequence value) {
         super(value);
     }

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/OrderId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/OrderId.java
@@ -23,6 +23,10 @@ import java.util.Random;
 public class OrderId extends LongType<OrderId> implements Identifier {
     private static Random RANDOM_ID_GENERATOR = new Random();
 
+    public OrderId(Number value) {
+        super(value.longValue());
+    }
+
     public OrderId(Long value) {
         super(value);
     }

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductId.java
@@ -25,6 +25,10 @@ public class ProductId extends CharSequenceType<ProductId> implements Identifier
         super(value);
     }
 
+    public ProductId(String value) {
+        super(value);
+    }
+
     public static ProductId of(CharSequence value) {
         return new ProductId(value);
     }

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Quantity.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Quantity.java
@@ -24,6 +24,10 @@ public class Quantity extends IntegerType<Quantity> {
         super(value);
     }
 
+    public Quantity(Number value) {
+        super(value.intValue());
+    }
+
     public static Quantity of(int value) {
         return new Quantity(value);
     }

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.15</version>
+    <version>0.40.16</version>
 </dependency>
 ```
 

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Amount.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Amount.java
@@ -33,6 +33,10 @@ public final class Amount extends BigDecimalType<Amount> {
         super(value);
     }
 
+    public Amount(double value) {
+        super(BigDecimal.valueOf(value));
+    }
+
     public Amount(long value) {
         super(BigDecimal.valueOf(value));
     }

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Percentage.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Percentage.java
@@ -30,6 +30,10 @@ public final class Percentage extends BigDecimalType<Percentage> {
         super(validate(value));
     }
 
+    public Percentage(Number value) {
+        super(validate(BigDecimal.valueOf(value.doubleValue())));
+    }
+
     private static BigDecimal validate(BigDecimal value) {
         requireNonNull(value, "value is null");
         return value.scale() < 2 ? value.setScale(2) : value;


### PR DESCRIPTION
- Ensured `Types` compatibility with Jackson 2.18.0 by adding explicit `String` (for subclasses of `CharSequenceType`)  or `Number` (for subclasses of `NumberType`) constructors to concrete semantic types
- Made providing an Exception optional when marking a `DurableQueue` message as a dead-letter message
- Added support for providing an optional String description/cause when marking a `DurableQueue` message as dead-letter message
- Added test to `DurableQueuesIT`, for a case where a Message handler during consumption manually marks the message as a dead-letter message, to confirm that the message is marked as a dead-letter message
- Changed `PostgresqlDurableQueues#acknowledgeMessageAsHandled(AcknowledgeMessageAsHandled)` to only delete a message if it's NOT marked as a dead-letter message
- Changed `MongoDurableQueues#markAsDeadLetterMessage(MarkAsDeadLetterMessage)` to not require that the message is marked is `isBeingDelivered`. The operation now also resets `nextDeliveryTimestamp` to null. This aligns with `PostgresqlDurableQueues` behaviour
- Changed `MongoDurableQueues#acknowledgeMessageAsHandled(AcknowledgeMessageAsHandled)` to only delete a message if it's NOT marked as a dead-letter message and not require that the message is marked is `isBeingDelivered`
- Since many operations are initiated by a new `UnitOfWork`, the `DBFencedLockManager`'s version of `withUnitOfWork` and `usingUnitOfWork` now requires an error handler to make error handling explicit
- The internal `DBFencedLockManager#confirmAllLocallyAcquiredLocks` no longer releases locks in case of an IO Exception during call to `lockStorage.confirmLockInDB`. If DB connectivity is broken it's better to retain the lock ownership as all nodes accessing the DB will likely experience the same behaviour
- Added tests to `DBFencedLockManagerIT`, thereby `PostgresqlFencedLockManagerIT` and `MongoFencedLockManagerIT`, that tests the behaviour in case database connectivity is interrupted
- Fixed potential `NoClassDefFoundException` in `IOExceptionUtil`
- Added tests to `DurableQueue` integration tests to verify the behaviour in case database connectivity is interrupted
- Improved `EventStoreSubscription` javadoc
- Introduced `PersistedEventSubscriber` in `EventStoreSubscriptionManager` to handle all `EventStore#pollEvent` related logic, event forwarding and error handling related to asynchronous subscriptions
- Added `EventStoreSubscriptionManager` tests the verify behaviour when the database connectivity is interrupted

Updated 3rd party dependencies:
- Spring-Boot 3.2.10
- Spring-Data-MongoDB 4.2.10
- Spring-Data-JPA 3.2.10
- MongoDB Driver Sync 4.11.4
- log4j 2.24.0
- snakeyaml 2.3
- micrometer 1.12.10
- micrometer-tracing 1.2.10
- netty 4.1.113.Final
- Junit 5.11.1
- Jackson 2.18.0
- Reactor 2023.0.10
- Spring 6.1.13
- Mockito 5.14.0
- Logback 1.5.8

Updated maven plugins:
- maven-failsafe-plugin / maven-surefire-plugin 3.5.0
- dependency-check-maven 10.0.4
- maven-gpg-plugin 3.2.7