### PR TITLE
Release 0.40.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -167,7 +167,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -183,7 +183,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -265,7 +265,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -339,7 +339,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -385,7 +385,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -432,7 +432,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -508,7 +508,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 
@@ -524,7 +524,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
@@ -239,7 +239,7 @@ public interface CommandHandler<COMMAND, EVENT, ERROR> {
 
             class DeciderUnitOfWorkLifecycleCallback implements UnitOfWorkLifecycleCallback<EventsToAppendToStream<ID, EVENT, STATE>> {
                 @Override
-                public void beforeCommit(UnitOfWork unitOfWork, List<EventsToAppendToStream<ID, EVENT, STATE>> associatedResources) {
+                public BeforeCommitProcessingStatus beforeCommit(UnitOfWork unitOfWork, List<EventsToAppendToStream<ID, EVENT, STATE>> associatedResources) {
                     log.trace("[{}] beforeCommit processing {} '{}' registered with the UnitOfWork being committed",
                               aggregateType,
                               associatedResources.size(),
@@ -265,12 +265,14 @@ public interface CommandHandler<COMMAND, EVENT, ERROR> {
                                       stateType.getName(),
                                       eventsToAppendToStream.aggregateId());
                         }
+                        // TODO: Expand support for marking EventsToAppendToStream as having been appended which will allow synchronous EventHandler to trigger additional changes within the same UnitOfWork
                         var persistedEvents = eventStore.appendToStream(aggregateType,
                                                                         eventsToAppendToStream.aggregateId(),
                                                                         eventsToAppendToStream.eventOrderOfLastRehydratedEvent(),
                                                                         eventsToAppendToStream.events());
                         optionalAggregateSnapshotRepository.ifPresent(repository -> repository.aggregateUpdated(eventsToAppendToStream.state(), persistedEvents));
                     });
+                    return BeforeCommitProcessingStatus.COMPLETED;
                 }
 
                 @Override

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository.java
@@ -518,7 +518,7 @@ public class PostgresqlAggregateSnapshotRepository implements AggregateSnapshotR
         public AggregateSnapshot map(ResultSet rs, StatementContext ctx) throws SQLException {
             var aggregateType     = AggregateType.of(rs.getString("aggregate_type"));
             var config            = eventStore.getAggregateEventStreamConfiguration(aggregateType);
-            var aggregateImplType = Classes.forName(rs.getString("aggregate_impl_type"));
+            var aggregateImplType = Classes.forName(rs.getString("aggregate_impl_type"), jsonSerializer.getClassLoader());
 
 
             var aggregateId     = config.aggregateIdSerializer.deserialize(rs.getString("aggregate_id"));

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventType.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventType.java
@@ -17,8 +17,7 @@
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types;
 
 import dk.cloudcreate.essentials.shared.reflection.Classes;
-import dk.cloudcreate.essentials.types.CharSequenceType;
-import dk.cloudcreate.essentials.types.Identifier;
+import dk.cloudcreate.essentials.types.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -63,6 +62,19 @@ public final class EventType extends CharSequenceType<EventType> implements Iden
     @SuppressWarnings("unchecked")
     public <T> Class<T> toJavaClass() {
         return (Class<T>) Classes.forName(getJavaTypeName());
+    }
+
+    /**
+     * Get a class instance corresponding to the Fully Qualified Class Name (FQCN) stored in this instance<br>
+     * To only get the Fully Qualified Class Name (FQCN) stored in this instance use {@link #getJavaTypeName()}
+     *
+     * @param <T> the java type
+     * @param classLoader The class loader used for Class lookup
+     * @return a class instance corresponding to the Fully Qualified Class Name (FQCN) stored in this instance
+     */
+    @SuppressWarnings("unchecked")
+    public <T> Class<T> toJavaClass(ClassLoader classLoader) {
+        return (Class<T>) Classes.forName(getJavaTypeName(), classLoader);
     }
 
     /**

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/Lifecycle.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/Lifecycle.java
@@ -17,27 +17,8 @@
 package dk.cloudcreate.essentials.components.foundation;
 
 /**
- * Common process life cycle interface
+ * Common process life cycle interface - backwards compatible variant of dk.cloudcreate.essentials.shared.Lifecycle
  */
-public interface Lifecycle {
-    /**
-     * Start the processing. This operation must be idempotent, such that duplicate calls
-     * to {@link #start()} for an already started process (where {@link #isStarted()} returns true)
-     * is ignored
-     */
-    void start();
+public interface Lifecycle extends dk.cloudcreate.essentials.shared.Lifecycle {
 
-    /**
-     * Stop the processing. This operation must be idempotent, such that duplicate calls
-     * to {@link #stop()} for an already stopped process (where {@link #isStarted()} returns false)
-     * is ignored
-     */
-    void stop();
-
-    /**
-     * Returns true if the process is started
-     *
-     * @return true if the process is started otherwise false
-     */
-    boolean isStarted();
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializer.java
@@ -83,4 +83,18 @@ public interface JSONSerializer {
      * @throws JSONDeserializationException in case the json couldn't be deserialized to the specified java type
      */
     <T> T deserialize(byte[] json, Class<T> javaType);
+
+    /**
+     * Get the {@link ClassLoader} used for serializing to JSON and deserializing from JSON<br>
+     * <b>Note: MUST not be null</b>
+     * @return the {@link ClassLoader} used for serializing to JSON and deserializing from JSON
+     */
+    ClassLoader getClassLoader();
+
+    /**
+     * Set the {@link ClassLoader} used for serializing to JSON and deserializing from JSON.
+     * This is e.g. required to support SpringBoot DevTools
+     * @param classLoader the {@link ClassLoader} used for serializing to JSON and deserializing from JSON
+     */
+    void setClassLoader(ClassLoader classLoader);
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManager.java
@@ -1,18 +1,13 @@
 package dk.cloudcreate.essentials.components.foundation.lifecycle;
 
+import dk.cloudcreate.essentials.shared.Lifecycle;
+import org.slf4j.*;
+import org.springframework.beans.BeansException;
+import org.springframework.context.*;
+import org.springframework.context.event.*;
+
 import java.util.Map;
 import java.util.function.Consumer;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ApplicationContextEvent;
-import org.springframework.context.event.ContextClosedEvent;
-import org.springframework.context.event.ContextRefreshedEvent;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -21,17 +16,16 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  * interface are started and stopped in response to {@link ContextRefreshedEvent} and {@link ContextClosedEvent}
  */
 public final class DefaultLifecycleManager implements LifecycleManager, ApplicationListener<ApplicationContextEvent>, ApplicationContextAware {
-    public static final Logger log = LoggerFactory.getLogger(DefaultLifecycleManager.class);
-    private ApplicationContext applicationContext;
-    private boolean hasStartedLifeCycleBeans;
-    private Map<String, Lifecycle> lifeCycleBeans;
-    private final Consumer<ApplicationContext> contextRefreshedEventConsumer;
-    private final boolean isStartLifecycles;
+    public static final Logger                       log = LoggerFactory.getLogger(DefaultLifecycleManager.class);
+    private             ApplicationContext           applicationContext;
+    private             boolean                      hasStartedLifeCycleBeans;
+    private             Map<String, Lifecycle>       lifeCycleBeans;
+    private final       Consumer<ApplicationContext> contextRefreshedEventConsumer;
+    private final       boolean                      isStartLifecycles;
 
     /**
-     *
      * @param contextRefreshedEventConsumer callback that will be called after all {@link Lifecycle} Beans {@link Lifecycle#start()} has been called
-     * @param isStartLifecycles determines if lifecycle beans should be started automatically
+     * @param isStartLifecycles             determines if lifecycle beans should be started automatically
      */
     public DefaultLifecycleManager(Consumer<ApplicationContext> contextRefreshedEventConsumer,
                                    boolean isStartLifecycles) {
@@ -41,11 +35,11 @@ public final class DefaultLifecycleManager implements LifecycleManager, Applicat
     }
 
     /**
-     *
      * @param isStartLifecycles determines if lifecycle beans should be started automatically
      */
     public DefaultLifecycleManager(boolean isStartLifecycles) {
-        this(event -> {}, isStartLifecycles);
+        this(event -> {
+        }, isStartLifecycles);
     }
 
     @Override

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
@@ -201,14 +201,13 @@ public final class MultiTableChangeListener<T extends TableChangeNotification> i
 
         if (listenForNotificationsRelatedToTables.isEmpty()) return;
 
-        PGConnection connection;
-        Handle handle = getHandle(handleCreated -> {
+        var handle = getHandle(handleCreated -> {
             for (String tableName : listenForNotificationsRelatedToTables.keySet()) {
                 listen(tableName);
             }
         });
         try {
-            connection = handle.getConnection().unwrap(PGConnection.class);
+            var connection = handle.getConnection().unwrap(PGConnection.class);
             var notifications = connection.getNotifications();
             if (notifications.length > 0) {
                 log.debug("Received {} Notification(s)", notifications.length);

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/SqlExecutionTimeLogger.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/SqlExecutionTimeLogger.java
@@ -48,6 +48,8 @@ public final class SqlExecutionTimeLogger implements org.jdbi.v3.core.statement.
 
     @Override
     public void logException(StatementContext context, SQLException ex) {
-        log.error(msg("Failed Execution time: {} ms - {}", Duration.between(context.getExecutionMoment(), context.getExceptionMoment()).toMillis(), context.getRenderedSql()), ex);
+        if (log.isDebugEnabled()) {
+            log.debug(msg("Failed Execution time: {} ms - {}", Duration.between(context.getExecutionMoment(), context.getExceptionMoment()).toMillis(), context.getRenderedSql()), ex);
+        }
     }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWork.java
@@ -50,6 +50,10 @@ public interface UnitOfWork {
 
     void markAsRollbackOnly(Exception cause);
 
+    default String info() {
+        return toString();
+    }
+
     /**
      * Roll back the {@link UnitOfWork} and any underlying transaction - see {@link UnitOfWorkStatus#RolledBack}
      */

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkFactory.java
@@ -90,24 +90,25 @@ public interface UnitOfWorkFactory<UOW extends UnitOfWork> {
 
         var existingUnitOfWork = getCurrentUnitOfWork();
         var unitOfWork = existingUnitOfWork.orElseGet(() -> {
-            unitOfWorkLog.debug("Creating a new UnitOfWork for this usingUnitOfWork(CheckedConsumer) method call as there wasn't an existing UnitOfWork");
-            return getOrCreateNewUnitOfWork();
+            var uow = getOrCreateNewUnitOfWork();
+            unitOfWorkLog.debug("Creating a new UnitOfWork for this usingUnitOfWork(CheckedConsumer) method call as there wasn't an existing UnitOfWork '{}'", uow.info());
+            return uow;
         });
-        existingUnitOfWork.ifPresent(uow -> unitOfWorkLog.debug("NestedUnitOfWork: Reusing existing UnitOfWork for this usingUnitOfWork(CheckedConsumer) method call"));
+        existingUnitOfWork.ifPresent(uow -> unitOfWorkLog.debug("NestedUnitOfWork: Reusing existing UnitOfWork for this usingUnitOfWork(CheckedConsumer) method call '{}'", uow.info()));
         try {
             unitOfWorkConsumer.accept(unitOfWork);
             if (existingUnitOfWork.isEmpty()) {
-                unitOfWorkLog.debug("Committing the UnitOfWork created by this usingUnitOfWork(CheckedConsumer) method call");
+                unitOfWorkLog.debug("Committing the UnitOfWork created by this usingUnitOfWork(CheckedConsumer) method call '{}'", unitOfWork.info());
                 unitOfWork.commit();
             } else {
-                unitOfWorkLog.debug("NestedUnitOfWork: Won't commit the UnitOfWork as it wasn't created by this usingUnitOfWork(CheckedConsumer) method call");
+                unitOfWorkLog.debug("NestedUnitOfWork: Won't commit the UnitOfWork as it wasn't created by this usingUnitOfWork(CheckedConsumer) method call '{}'", unitOfWork.info());
             }
         } catch (Exception e) {
             if (existingUnitOfWork.isEmpty()) {
-                unitOfWorkLog.debug("Rolling back the UnitOfWork created by this usingUnitOfWork(CheckedConsumer) method call");
+                unitOfWorkLog.debug("Rolling back the UnitOfWork created by this usingUnitOfWork(CheckedConsumer) method call '{}'", unitOfWork.info());
                 unitOfWork.rollback(e);
             } else {
-                unitOfWorkLog.debug("NestedUnitOfWork: Marking UnitOfWork as rollback only as it wasn't created by this usingUnitOfWork(CheckedConsumer) method call");
+                unitOfWorkLog.debug("NestedUnitOfWork: Marking UnitOfWork as rollback only as it wasn't created by this usingUnitOfWork(CheckedConsumer) method call '{}'", unitOfWork.info());
                 unitOfWork.markAsRollbackOnly(e);
             }
             throw new UnitOfWorkException(e);
@@ -134,26 +135,27 @@ public interface UnitOfWorkFactory<UOW extends UnitOfWork> {
         requireNonNull(unitOfWorkFunction, "No unitOfWorkFunction provided");
         var existingUnitOfWork = getCurrentUnitOfWork();
         var unitOfWork = existingUnitOfWork.orElseGet(() -> {
-            unitOfWorkLog.debug("Creating a new UnitOfWork for this withUnitOfWork(CheckedFunction) method call as there wasn't an existing UnitOfWork");
-            return getOrCreateNewUnitOfWork();
+            var uow = getOrCreateNewUnitOfWork();
+            unitOfWorkLog.debug("Creating a new UnitOfWork for this withUnitOfWork(CheckedFunction) method call as there wasn't an existing UnitOfWork '{}'", uow.info());
+            return uow;
         });
-        existingUnitOfWork.ifPresent(uow -> unitOfWorkLog.debug("NestedUnitOfWork: Reusing existing UnitOfWork for this withUnitOfWork(CheckedFunction) method call"));
+        existingUnitOfWork.ifPresent(uow -> unitOfWorkLog.debug("NestedUnitOfWork: Reusing existing UnitOfWork for this withUnitOfWork(CheckedFunction) method call '{}'", uow.info()));
         try {
             var result = unitOfWorkFunction.apply(unitOfWork);
             if (existingUnitOfWork.isEmpty()) {
-                unitOfWorkLog.debug("Committing the UnitOfWork created by this withUnitOfWork(CheckedFunction) method call");
+                unitOfWorkLog.debug("Committing the UnitOfWork created by this withUnitOfWork(CheckedFunction) method call '{}'", unitOfWork.info());
                 unitOfWork.commit();
             } else {
-                unitOfWorkLog.debug("NestedUnitOfWork: Won't commit the UnitOfWork as it wasn't created by this withUnitOfWork(CheckedFunction) method call");
+                unitOfWorkLog.debug("NestedUnitOfWork: Won't commit the UnitOfWork as it wasn't created by this withUnitOfWork(CheckedFunction) method call '{}'", unitOfWork.info());
             }
 
             return result;
         } catch (Exception e) {
             if (existingUnitOfWork.isEmpty()) {
-                unitOfWorkLog.debug("Rolling back the UnitOfWork created by this withUnitOfWork(CheckedFunction) method call");
+                unitOfWorkLog.debug("Rolling back the UnitOfWork created by this withUnitOfWork(CheckedFunction) method call '{}'", unitOfWork.info());
                 unitOfWork.rollback(e);
             } else {
-                unitOfWorkLog.debug("NestedUnitOfWork: Marking UnitOfWork as rollback only as it wasn't created by this withUnitOfWork(CheckedFunction) method call");
+                unitOfWorkLog.debug("NestedUnitOfWork: Marking UnitOfWork as rollback only as it wasn't created by this withUnitOfWork(CheckedFunction) method call '{}'", unitOfWork.info());
                 unitOfWork.markAsRollbackOnly(e);
             }
             throw new UnitOfWorkException(e);

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkLifecycleCallback.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkLifecycleCallback.java
@@ -25,7 +25,12 @@ import java.util.List;
  * the {@link UnitOfWork}
  */
 public interface UnitOfWorkLifecycleCallback<RESOURCE_TYPE> {
-    void beforeCommit(UnitOfWork unitOfWork, List<RESOURCE_TYPE> associatedResources);
+    enum BeforeCommitProcessingStatus {
+        REQUIRED,
+        COMPLETED
+    }
+
+    BeforeCommitProcessingStatus beforeCommit(UnitOfWork unitOfWork, List<RESOURCE_TYPE> associatedResources);
 
     void afterCommit(UnitOfWork unitOfWork, List<RESOURCE_TYPE> associatedResources);
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWork.java
@@ -149,6 +149,11 @@ public class SpringTransactionAwareUnitOfWork<TRX_MGR extends PlatformTransactio
     }
 
     @Override
+    public String info() {
+        return "TYPE:" + this.getClass().getSimpleName() + ":HASH:" + this.hashCode() + ":STATUS:" + this.status() ;
+    }
+
+    @Override
     public UnitOfWorkStatus status() {
         return status;
     }

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManagerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManagerTest.java
@@ -1,19 +1,14 @@
 package dk.cloudcreate.essentials.components.foundation.lifecycle;
 
+import dk.cloudcreate.essentials.shared.Lifecycle;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.*;
+
 import java.util.Map;
 import java.util.function.Consumer;
 
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import org.junit.jupiter.api.Test;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.ContextClosedEvent;
-import org.springframework.context.event.ContextRefreshedEvent;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class DefaultLifecycleManagerTest {
     private static final String BEAN_NAME = "beanName";

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/Query.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/Query.kt
@@ -815,6 +815,14 @@ internal class NoJSONSerializer : JSONSerializer {
     override fun <T : Any?> deserialize(json: ByteArray?, javaType: Class<T>?): T {
         throw NotImplementedError("Not supported")
     }
+
+    override fun getClassLoader(): ClassLoader {
+        throw NotImplementedError("Not supported")
+    }
+
+    override fun setClassLoader(classLoader: ClassLoader?) {
+        throw NotImplementedError("Not supported")
+    }
 }
 
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -784,6 +784,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -511,7 +511,7 @@ var eventStoreSubscriptionManager = EventStoreSubscriptionManager.builder()
                                                                  .setEventStorePollingInterval(Duration.ofMillis(100))
                                                                  .setFencedLockManager(fencedLockManager)
                                                                  .setSnapshotResumePointsEvery(Duration.ofSeconds(10))
-                                                                 .setDurableSubscriptionRepository(new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory()))
+                                                                 .setDurableSubscriptionRepository(new PostgresqlDurableSubscriptionRepository(jdbi, eventStore))
                                                                  .build();
 
 eventStoreSubscriptionManager.start();
@@ -717,7 +717,7 @@ var eventStoreSubscriptionManager = EventStoreSubscriptionManager.createFor(even
                                                                                                         .setLockConfirmationInterval(Duration.ofSeconds(1))
                                                                                                         .buildAndStart(),
                                                                              Duration.ofSeconds(1),
-                                                                             new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory()));
+                                                                             new PostgresqlDurableSubscriptionRepository(jdbi, eventStore));
 eventStoreSubscriptionManager.start();
 
 var productsSubscription = eventStoreSubscriptionManager.subscribeToAggregateEventsInTransaction(

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
@@ -784,7 +784,15 @@ public interface EventStore {
      * Find the highest {@link GlobalEventOrder} persisted in relation to the given aggregateType
      *
      * @param aggregateType the aggregate type that the underlying {@link AggregateEventStream} is associated with
-     * @return an {@link Optional} with the {@link GlobalEventOrder} persisted or {@link Optional#empty()} if no events have been persisted
+     * @return an {@link Optional} with the highest {@link GlobalEventOrder} persisted or {@link Optional#empty()} if no events have been persisted
      */
     Optional<GlobalEventOrder> findHighestGlobalEventOrderPersisted(AggregateType aggregateType);
+
+    /**
+     * Find the lowest {@link GlobalEventOrder} persisted in relation to the given aggregateType
+     *
+     * @param aggregateType the aggregate type that the underlying {@link AggregateEventStream} is associated with
+     * @return an {@link Optional} with the lowest {@link GlobalEventOrder} persisted or {@link Optional#empty()} if no events have been persisted
+     */
+    Optional<GlobalEventOrder> findLowestGlobalEventOrderPersisted(AggregateType aggregateType);
 }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
@@ -304,6 +304,12 @@ public final class PostgresqlEventStore<CONFIG extends AggregateEventStreamConfi
     }
 
     @Override
+    public Optional<GlobalEventOrder> findLowestGlobalEventOrderPersisted(AggregateType aggregateType) {
+        return persistenceStrategy.findLowestGlobalEventOrderPersisted(unitOfWorkFactory.getRequiredUnitOfWork(),
+                                                                        aggregateType);
+    }
+
+    @Override
     public <ID, AGGREGATE> Optional<AGGREGATE> inMemoryProjection(AggregateType aggregateType,
                                                                   ID aggregateId,
                                                                   Class<AGGREGATE> projectionType) {

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
@@ -455,8 +455,14 @@ public final class PostgresqlEventStore<CONFIG extends AggregateEventStreamConfi
             }
 
             try {
-                long batchSizeForThisQuery = resolveBatchSizeForThisQuery(aggregateType, eventStreamLogName, eventStoreStreamLog, lastBatchSizeForThisQuery.get(), batchFetchSize, consecutiveNoPersistedEventsReturned,
-                                                                          nextFromInclusiveGlobalOrder, unitOfWork);
+                long batchSizeForThisQuery = resolveBatchSizeForThisQuery(aggregateType,
+                                                                          eventStreamLogName,
+                                                                          eventStoreStreamLog,
+                                                                          lastBatchSizeForThisQuery.get(),
+                                                                          batchFetchSize,
+                                                                          consecutiveNoPersistedEventsReturned,
+                                                                          nextFromInclusiveGlobalOrder,
+                                                                          unitOfWork);
                 if (batchSizeForThisQuery == 0) {
                     consecutiveNoPersistedEventsReturned.set(0);
                     lastBatchSizeForThisQuery.set(batchFetchSize);

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
@@ -20,7 +20,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.e
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWork;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 
-import java.util.List;
+import java.util.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -35,7 +35,7 @@ public final class PersistedEvents {
     public PersistedEvents(CommitStage commitStage, EventStoreUnitOfWork unitOfWork, List<PersistedEvent> events) {
         this.commitStage = requireNonNull(commitStage, "No commitStage provided");
         this.unitOfWork = requireNonNull(unitOfWork, "No unitOfWork provided");
-        this.events = requireNonNull(events, "No events provided");
+        this.events = new ArrayList<>(requireNonNull(events, "No events provided"));
     }
 
     @Override

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEvent.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEvent.java
@@ -79,7 +79,7 @@ public interface PersistedEvent {
                                OffsetDateTime timestamp,
                                Optional<EventId> causedByEventId,
                                Optional<CorrelationId> correlationId,
-                               Optional<Tenant> tenant) {
+                               Optional<? extends Tenant> tenant) {
         return new PersistedEvent.DefaultPersistedEvent(eventId,
                                                         aggregateType,
                                                         aggregateId,
@@ -200,7 +200,7 @@ public interface PersistedEvent {
      * The tenant that the event belongs to<br>
      * Having a {@link Tenant} value associated with an Event is optional.
      */
-    Optional<Tenant> tenant();
+    Optional<? extends Tenant> tenant();
 
     /**
      * Compare each individual property in <code>this</code> {@link PersistedEvent} and compare them individually
@@ -223,7 +223,7 @@ public interface PersistedEvent {
         private final OffsetDateTime          timestamp;
         private final Optional<EventId>       causedByEventId;
         private final Optional<CorrelationId> correlationId;
-        private final Optional<Tenant>        tenant;
+        private final Optional<? extends Tenant>        tenant;
 
         public DefaultPersistedEvent(EventId eventId,
                                      AggregateType streamName,
@@ -236,7 +236,7 @@ public interface PersistedEvent {
                                      OffsetDateTime timestamp,
                                      Optional<EventId> causedByEventId,
                                      Optional<CorrelationId> correlationId,
-                                     Optional<Tenant> tenant) {
+                                     Optional<? extends Tenant> tenant) {
             this.eventId = requireNonNull(eventId, "You must supply a eventId");
             this.streamName = requireNonNull(streamName, "You must supply a streamName");
             this.aggregateId = requireNonNull(aggregateId, "You must supply a aggregateId");
@@ -302,7 +302,7 @@ public interface PersistedEvent {
         }
 
         @Override
-        public Optional<Tenant> tenant() {
+        public Optional<? extends Tenant> tenant() {
             return tenant;
         }
 
@@ -333,8 +333,7 @@ public interface PersistedEvent {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof PersistedEvent)) return false;
-            var that = (PersistedEvent) o;
+            if (!(o instanceof PersistedEvent that)) return false;
             return eventId.equals(that.eventId());
         }
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamPersistenceStrategy.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamPersistenceStrategy.java
@@ -214,6 +214,15 @@ public interface AggregateEventStreamPersistenceStrategy<CONFIG extends Aggregat
 
 
     /**
+     * Resolve the name of the {@link GlobalEventOrder} sequence for the table that stores events related to a given {@link AggregateType}
+     * @param unitOfWork The active {@link EventStoreUnitOfWork}
+     * @param aggregateType The aggregateType for which we want to resolve the {@link GlobalEventOrder} sequence name
+     * @return The database sequence name wrapped in an {@link Optional}. {@link Optional#empty()} if the sequence name couldn't be resolved
+     */
+    Optional<String> resolveGlobalEventOrderSequenceName(EventStoreUnitOfWork unitOfWork,
+                                               AggregateType aggregateType);
+
+    /**
      * Persist a List of persistable events
      *
      * @param unitOfWork                  the current unitOfWork
@@ -279,9 +288,18 @@ public interface AggregateEventStreamPersistenceStrategy<CONFIG extends Aggregat
      *
      * @param unitOfWork    the current unit of work
      * @param aggregateType the aggregate type that the underlying {@link AggregateEventStream} is associated with
-     * @return an {@link Optional} with the {@link GlobalEventOrder} persisted or {@link Optional#empty()} if no events have been persisted
+     * @return an {@link Optional} with the highest {@link GlobalEventOrder} persisted or {@link Optional#empty()} if no events have been persisted
      */
     Optional<GlobalEventOrder> findHighestGlobalEventOrderPersisted(EventStoreUnitOfWork unitOfWork, AggregateType aggregateType);
+
+    /**
+     * Find the lowest {@link GlobalEventOrder} persisted in relation to the given aggregateType
+     *
+     * @param unitOfWork    the current unit of work
+     * @param aggregateType the aggregate type that the underlying {@link AggregateEventStream} is associated with
+     * @return an {@link Optional} with the lowest {@link GlobalEventOrder} persisted or {@link Optional#empty()} if no events have been persisted
+     */
+    Optional<GlobalEventOrder> findLowestGlobalEventOrderPersisted(EventStoreUnitOfWork unitOfWork, AggregateType aggregateType);
 
     /**
      * Load all the <code>eventIds</code> related to the specified <code>aggregateType</code>

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AppendToStreamException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AppendToStreamException.java
@@ -22,4 +22,8 @@ public class AppendToStreamException extends EventStoreException {
     public AppendToStreamException(String msg, RuntimeException cause) {
         super(msg, cause);
     }
+
+    public AppendToStreamException(String msg) {
+        super(msg);
+    }
 }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/EventMetaData.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/EventMetaData.java
@@ -214,12 +214,13 @@ public final class EventMetaData implements Map<String, String>, Serializable {
 
     @Override
     public boolean equals(Object o) {
-        return metaData.equals(o);
+        if (!(o instanceof EventMetaData that)) return false;
+        return Objects.equals(metaData, that.metaData);
     }
 
     @Override
     public int hashCode() {
-        return metaData.hashCode();
+        return Objects.hashCode(metaData);
     }
 
     @Override

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/OptimisticAppendToStreamException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/OptimisticAppendToStreamException.java
@@ -20,4 +20,8 @@ public final class OptimisticAppendToStreamException extends AppendToStreamExcep
     public OptimisticAppendToStreamException(String msg, RuntimeException cause) {
         super(msg, cause);
     }
+
+    public OptimisticAppendToStreamException(String msg) {
+        super(msg);
+    }
 }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
@@ -460,7 +460,8 @@ public abstract class EventProcessor implements Lifecycle {
      * @param forwardToInbox the {@link Inbox} the event should be forwarded to
      */
     protected void forwardEventToInbox(PersistedEvent event, Inbox forwardToInbox) {
-        if (patternMatchingInboxMessageHandlerDelegate.handlesMessageWithPayload(event.event().getEventType().get().toJavaClass())) {
+        if (event.event().getEventType().isPresent() &&
+                patternMatchingInboxMessageHandlerDelegate.handlesMessageWithPayload(event.event().getEventTypeAsJavaClass().get())) {
             var aggregateType         = event.aggregateType();
             var aggregateIdSerializer = resolveAggregateIdSerializer(aggregateType);
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.EventJSON;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventType;
+import dk.cloudcreate.essentials.components.foundation.Lifecycle;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
+import dk.cloudcreate.essentials.components.foundation.json.JSONDeserializationException;
+import dk.cloudcreate.essentials.components.foundation.messaging.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
+import dk.cloudcreate.essentials.reactive.Handler;
+import dk.cloudcreate.essentials.reactive.command.*;
+import org.slf4j.*;
+
+import java.util.*;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * Event Modeling style Event Sourced Event Processor and Command Handler, which is capable of both containing {@link CmdHandler} as well as {@link MessageHandler}
+ * annotated event handling methods.<br>
+ * The {@link InTransactionEventProcessor} simplifies building event projections or process automations.<br>
+ * <br>
+ * An {@link InTransactionEventProcessor} can subscribe in transaction to multiple {@link EventStore} Event Streams (e.g. a stream of Order events or a stream of Product events).<br>
+ * If useExclusively flag is true only a single instance of a concrete {@link InTransactionEventProcessor} in a cluster can have an active Event Stream subscription at a time (using the {@link FencedLockManager}).
+ * <br>
+ * To enhance throughput, you can control the number of parallel threads utilized for handling messages. Consequently, events associated with different aggregate instances within an EventStream can be concurrently processed.
+ * <br>
+ * The {@link InTransactionEventProcessor} also ensures ordered handling of events, partitioned by aggregate id. I.e. events related to a specific aggregate id will always be processed in the exact order they were originally added to the {@link EventStore}.<br>
+ * This guarantees the preservation of the chronological sequence of events for each individual aggregate, maintaining data integrity and consistency, even during event redelivery/poison-message handling.<br>
+ * <br>
+ * Details:<br>
+ * Instead of manually subscribing to the underlying {@link EventStore} using the {@link EventStoreSubscriptionManager}, which requires you to provide your own error and retry handling,
+ * you can use the {@link InTransactionEventProcessor} to subscribe to one or more {@link EventStore} event streams, while providing you with error and retry handling using the common {@link RedeliveryPolicy} concept
+ * <p>
+ * You must override {@link #reactsToEventsRelatedToAggregateTypes()} to specify which EventSourced {@link AggregateType} event-streams the {@link EventProcessor} should subscribe to.<br>
+ * The {@link InTransactionEventProcessor} will set up an exclusive asynchronous {@link EventStoreSubscription} for each {@link AggregateType} and will forward any
+ * {@link PersistedEvent}'s as {@link OrderedMessage}'s IF and ONLY IF the concrete {@link EventProcessor} subclass contains a corresponding {@link MessageHandler}
+ * annotated method matching the {@link PersistedEvent#event()}'s {@link EventJSON#getEventType()}'s {@link EventType#toJavaClass()} matches that first argument type.
+ * In transaction subscriptions does not support replay.
+ * <p>
+ * Example:
+ * <pre>{@code
+ * @Service
+ * @Slf4j
+ * public class TransferMoneyProcessor extends InTransactionEventProcessor {
+ *     private final Accounts                accounts;
+ *     private final IntraBankMoneyTransfers intraBankMoneyTransfers;
+ *
+ *     public TransferMoneyProcessor(@NonNull Accounts accounts,
+ *                                   @NonNull IntraBankMoneyTransfers intraBankMoneyTransfers,
+ *                                   @NonNull EventProcessorDependencies eventProcessorDependencies) {
+ *         super(eventProcessorDependencies, true);
+ *         this.accounts = accounts;
+ *         this.intraBankMoneyTransfers = intraBankMoneyTransfers;
+ *     }
+ *
+ *     @Override
+ *     public String getProcessorName() {
+ *         return "TransferMoneyProcessor";
+ *     }
+ *
+ *     @Override
+ *     protected List<AggregateType> reactsToEventsRelatedToAggregateTypes() {
+ *         return List.of(Accounts.AGGREGATE_TYPE,
+ *                        IntraBankMoneyTransfers.AGGREGATE_TYPE);
+ *     }
+ *
+ *     @Handler
+ *     public void handle(@NonNull RequestIntraBankMoneyTransfer cmd) {
+ *         if (accounts.isAccountMissing(cmd.fromAccount)) {
+ *             throw new TransactionException(msg("Couldn't find fromAccount with id '{}'", cmd.fromAccount));
+ *         }
+ *         if (accounts.isAccountMissing(cmd.toAccount)) {
+ *             throw new TransactionException(msg("Couldn't find toAccount with id '{}'", cmd.toAccount));
+ *         }
+ *
+ *         var existingTransfer = intraBankMoneyTransfers.findTransfer(cmd.transactionId);
+ *         if (existingTransfer.isEmpty()) {
+ *             log.debug("===> Requesting New Transfer '{}'", cmd.transactionId);
+ *             intraBankMoneyTransfers.requestNewTransfer(new IntraBankMoneyTransfer(cmd));
+ *         }
+ *     }
+ *
+ *     @MessageHandler
+ *     void handle(IntraBankMoneyTransferRequested e, OrderedMessage eventMessage) {
+ *         var transfer = intraBankMoneyTransfers.getTransfer(e.transactionId);
+ *         accounts.getAccount(transfer.getFromAccount())
+ *                 .withdrawToday(transfer.getAmount(),
+ *                                transfer.aggregateId(),
+ *                                AllowOverdrawingBalance.NO);
+ *     }
+ *
+ *     @MessageHandler
+ *     void handle(IntraBankMoneyTransferStatusChanged e) {
+ *         var transfer = intraBankMoneyTransfers.getTransfer(e.transactionId);
+ *         if (transfer.getStatus() == TransferLifeCycleStatus.FROM_ACCOUNT_WITHDRAWN) {
+ *             accounts.getAccount(transfer.getToAccount())
+ *                     .depositToday(transfer.getAmount(),
+ *                                   transfer.aggregateId());
+ *         }
+ *     }
+ *
+ *     @MessageHandler
+ *     void handle(AccountWithdrawn e) {
+ *         var matchingTransfer = intraBankMoneyTransfers.findTransfer(e.transactionId);
+ *
+ *         matchingTransfer.ifPresent(transfer -> {
+ *             transfer.markFromAccountAsWithdrawn();
+ *         });
+ *     }
+ *
+ *     @MessageHandler
+ *     void handle(AccountDeposited e, OrderedMessage eventMessage) {
+ *         var matchingTransfer = intraBankMoneyTransfers.findTransfer(e.transactionId);
+ *         matchingTransfer.ifPresent(transfer -> {
+ *             transfer.markToAccountAsDeposited();
+ *         });
+ *     }
+ * }
+ * }</pre>
+ */
+public abstract class InTransactionEventProcessor implements Lifecycle {
+    protected final Logger log =                  LoggerFactory.getLogger(this.getClass());
+    private final   EventStoreSubscriptionManager eventStoreSubscriptionManager;
+    protected final DurableLocalCommandBus        commandBus;
+    private final   EventStore                    eventStore;
+
+    private boolean                               started;
+    private List<EventStoreSubscription>          eventStoreSubscriptions;
+    private AnnotatedCommandHandler               commandBusHandlerDelegate;
+    private PatternMatchingMessageHandler         patternMatchingHandlerDelegate;
+    private List<MessageHandlerInterceptor>       messageHandlerInterceptors;
+    private boolean                               useExclusively;
+
+    /**
+     * Create a new {@link InTransactionEventProcessor} instance
+     *
+     * @param eventProcessorDependencies The {@link EventProcessorDependencies} that encapsulates all
+     *                                   the dependencies required by an instance of an {@link EventProcessor}
+     * @param useExclusively             If true exclusive subscription (using the {@link FencedLockManager}).
+     * @see InTransactionEventProcessor#InTransactionEventProcessor(EventStoreSubscriptionManager, DurableLocalCommandBus, List, boolean)
+     */
+    protected InTransactionEventProcessor(EventProcessorDependencies eventProcessorDependencies,
+                                          boolean useExclusively) {
+        this(requireNonNull(eventProcessorDependencies, "No eventProcessorDependencies provided").eventStoreSubscriptionManager,
+                eventProcessorDependencies.commandBus,
+                eventProcessorDependencies.messageHandlerInterceptors,
+                useExclusively);
+    }
+
+    /**
+     * Create a new {@link InTransactionEventProcessor} instance
+     *
+     * @param eventProcessorDependencies The {@link EventProcessorDependencies} that encapsulates all
+     *                                   the dependencies required by an instance of an {@link EventProcessor}
+     * @see InTransactionEventProcessor#InTransactionEventProcessor(EventStoreSubscriptionManager, DurableLocalCommandBus, List, boolean)
+     */
+    protected InTransactionEventProcessor(EventProcessorDependencies eventProcessorDependencies) {
+        this(requireNonNull(eventProcessorDependencies, "No eventProcessorDependencies provided").eventStoreSubscriptionManager,
+                eventProcessorDependencies.commandBus,
+                eventProcessorDependencies.messageHandlerInterceptors,
+                false);
+    }
+
+    /**
+     * Create a new {@link InTransactionEventProcessor} instance
+     *
+     * @param eventStoreSubscriptionManager The {@link EventStoreSubscriptionManager} used for managing {@link EventStore} subscriptions<br>
+     *                                      The  {@link EventStore} instance associated with the {@link EventStoreSubscriptionManager} is used to only queue a reference to
+     *                                      the {@link PersistedEvent} and before the message is forwarded to the corresponding {@link MessageHandler} then we load the {@link PersistedEvent}'s
+     *                                      payload and forward it to the {@link MessageHandler} annotated method
+     * @param commandBus                    The {@link CommandBus} where any {@link Handler} or {@link CmdHandler} annotated methods in the subclass of the {@link EventProcessor} will be registered
+     * @param messageHandlerInterceptors    The {@link MessageHandlerInterceptor}'s that will intercept calls to the {@link MessageHandler} annotated methods.<br>
+     *                                      Unless you override {@link #getMessageHandlerInterceptors()} then these are the {@link MessageHandlerInterceptor}'s that will be used.
+     * @param useExclusively                If true exclusive subscription (using the {@link FencedLockManager}).
+     */
+    protected InTransactionEventProcessor(EventStoreSubscriptionManager eventStoreSubscriptionManager,
+                                          DurableLocalCommandBus commandBus,
+                                          List<MessageHandlerInterceptor> messageHandlerInterceptors,
+                                          boolean useExclusively) {
+        this.eventStoreSubscriptionManager = requireNonNull(eventStoreSubscriptionManager, "No eventStoreSubscriptionManager provided");
+        this.commandBus = requireNonNull(commandBus, "No commandBus provided");
+        this.eventStore = requireNonNull(eventStoreSubscriptionManager.getEventStore(), "No eventStore is associated with the eventStoreSubscriptionManager provided");
+        this.messageHandlerInterceptors = requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors list provided");
+        this.useExclusively = useExclusively;
+        setupCommandHandler();
+    }
+
+    private void setupCommandHandler() {
+        commandBusHandlerDelegate = new AnnotatedCommandHandler(this);
+        commandBus.addCommandHandler(commandBusHandlerDelegate);
+    }
+
+    private void setupMessageHandlerDelegate() {
+        if (patternMatchingHandlerDelegate != null) {
+            return;
+        }
+        patternMatchingHandlerDelegate = new PatternMatchingMessageHandler(this, getMessageHandlerInterceptors());
+        patternMatchingHandlerDelegate.allowUnmatchedMessages();
+    }
+
+    /**
+     * Default: The {@link MessageHandlerInterceptor}'s provided in the {@link InTransactionEventProcessor#InTransactionEventProcessor(EventStoreSubscriptionManager, DurableLocalCommandBus, List, boolean)} constructor<br>
+     * You can also override this method to provide your own {@link MessageHandlerInterceptor}'s that should be used when calling {@link MessageHandler} annotated methods<br>
+     * This method will be called during {@link InTransactionEventProcessor#start()} time
+     *
+     * @return the {@link MessageHandlerInterceptor}'s that should be used when calling {@link MessageHandler} annotated methods
+     */
+    protected List<MessageHandlerInterceptor> getMessageHandlerInterceptors() {
+        return messageHandlerInterceptors;
+    }
+
+    @Override
+    public void start() {
+        if(!started) {
+            started = true;
+            var processorName              = requireNonNull(getProcessorName(), "getProcessorName() returned null");
+            var subscribeToEventsRelatedTo = requireNonNull(reactsToEventsRelatedToAggregateTypes(), "reactsToEventsRelatedToAggregateTypes() returned null");
+            log.info("⚙️ [{}] Starting InTransactionEventProcessor - will subscribe '{}' to events related to these AggregatesType's: {}",
+                    processorName,
+                    useExclusively ? "exclusively" : "non-exclusively",
+                    subscribeToEventsRelatedTo);
+
+            setupMessageHandlerDelegate();
+            subscribeInTransaction(subscribeToEventsRelatedTo);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if(started) {
+            started = false;
+            log.info("⚙️ [{}] Stopping InTransactionEventProcessor",
+                    getProcessorName());
+
+            eventStoreSubscriptions.forEach(Lifecycle::stop);
+        }
+    }
+
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+
+    private void subscribeInTransaction(List<AggregateType> subscribeToEventsRelatedTo) {
+        eventStoreSubscriptions = subscribeToEventsRelatedTo.stream()
+                .map(this::createEventStoreSubscription).toList();
+    }
+
+    private EventStoreSubscription createEventStoreSubscription(AggregateType aggregateType) {
+        var subscriberId = SubscriberId.of(getProcessorName() + ":" + aggregateType + ":sync");
+
+        EventStoreSubscription subscription = createEventStoreSubscription(aggregateType, subscriberId);
+
+        log.info("⚙️ [{}] InTransactionEventProcessor created subscription '{}'",
+                getProcessorName(),
+                subscription);
+
+        return subscription;
+    }
+
+    private EventStoreSubscription createEventStoreSubscription(AggregateType aggregateType, SubscriberId subscriberId) {
+        if (useExclusively) {
+            return eventStoreSubscriptionManager.exclusivelySubscribeToAggregateEventsInTransaction(
+                    subscriberId,
+                    aggregateType,
+                    Optional.empty(),
+                    (event, unitOfWork) -> invokeHandler(event, unitOfWork, aggregateType, subscriberId));
+        } else {
+            return eventStoreSubscriptionManager.subscribeToAggregateEventsInTransaction(
+                    subscriberId,
+                    aggregateType,
+                    (event, unitOfWork) -> invokeHandler(event, unitOfWork, aggregateType, subscriberId));
+        }
+    }
+
+    private void invokeHandler(PersistedEvent event, UnitOfWork unitOfWork, AggregateType aggregateType, SubscriberId subscriberId) {
+        try {
+            log.info("[{}-{}] Processing event: {} using unit of work '{}'", subscriberId, aggregateType, event, unitOfWork.info());
+            patternMatchingHandlerDelegate.accept(OrderedMessage.of(event.event().deserialize(),
+                    resolveAggregateIdSerializer(event.aggregateType()).serialize(event.aggregateId()),
+                    event.eventOrder().value(),
+                    new MessageMetaData(event.metaData().deserialize()))
+            );
+        } catch (JSONDeserializationException e) {
+            log.error("Failed to deserialize PersistedEvent '{}'", event.event().getEventTypeOrNamePersistenceValue(), e);
+            throw e;
+        }
+    }
+
+
+    private AggregateIdSerializer resolveAggregateIdSerializer(AggregateType aggregateType) {
+        return ((ConfigurableEventStore<?>) eventStore).getAggregateEventStreamConfiguration(aggregateType).aggregateIdSerializer;
+    }
+
+    /**
+     * Get the name of the event processor.<br>
+     * This name is used as value for the underlying {@link EventStoreSubscription#subscriberId()}'s
+     *
+     * @return the name of the event processor
+     */
+    public abstract String getProcessorName();
+
+    /**
+     * Get the {@link AggregateType}'s who's events this {@link EventProcessor} is reacting to
+     *
+     * @return the {@link AggregateType}'s who's events this {@link EventProcessor} is reacting to
+     */
+    protected abstract List<AggregateType> reactsToEventsRelatedToAggregateTypes();
+
+
+    @Override
+    public String toString() {
+        return "⚙️ " + this.getClass().getSimpleName() + " { " +
+                "processorName='" + getProcessorName() + "'" +
+                ", reactsToEventsRelatedToAggregateTypes=" + reactsToEventsRelatedToAggregateTypes() +
+                ", started=" + started +
+                " }";
+    }
+
+    protected final EventStore getEventStore() {
+        return eventStore;
+    }
+
+    protected final DurableLocalCommandBus getCommandBus() {
+        return commandBus;
+    }
+
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/SubscriberGlobalOrderMicrometerMonitor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/monitoring/SubscriberGlobalOrderMicrometerMonitor.java
@@ -1,24 +1,18 @@
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWork;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWorkFactory;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
 import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
 import dk.cloudcreate.essentials.shared.functional.tuple.Pair;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.*;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.slf4j.*;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static dk.cloudcreate.essentials.components.foundation.messaging.queue.micrometer.DurableQueuesMicrometerInterceptor.MODULE_TAG_NAME;
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
@@ -59,9 +53,11 @@ public class SubscriberGlobalOrderMicrometerMonitor implements EventStoreSubscri
         var key = Pair.of(subscriberId, aggregateType);
         calculateSubscriberGlobalEventOrderDiff(subscriberId, aggregateType)
             .ifPresent(currentLag -> {
-                //if (currentLag > 0) {
-                    log.info("Subscriber lag found for subscriber {} on aggregateType {}. Lag is {}", subscriberId, aggregateType, currentLag);
-                //}
+                if (currentLag > 0) {
+                    log.info("Subscriber lag found for subscriber '{}' on aggregateType '{}'. Lag is {}", subscriberId, aggregateType, currentLag);
+                } else {
+                    log.debug("No Subscriber lag found for subscriber '{}' on aggregateType '{}'.", subscriberId, aggregateType);
+                }
                 subscriberGauges.computeIfAbsent(key, this::initializeEventOrderDiffCountGauge)
                     ._2.set(currentLag);
             });

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
@@ -116,7 +116,7 @@ class SingleTenantPostgresqlEventStoreIT {
 
     @Test
     void test_resolveGlobalEventOrderSequenceName() {
-        var unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
+        var unitOfWork   = unitOfWorkFactory.getOrCreateNewUnitOfWork();
         var sequenceName = eventStore.getPersistenceStrategy().resolveGlobalEventOrderSequenceName(unitOfWork, ORDERS);
         assertThat(sequenceName).isPresent();
         assertThat(sequenceName).hasValue("public.orders_events_global_order_seq");
@@ -730,7 +730,10 @@ class SingleTenantPostgresqlEventStoreIT {
         var customerId = CustomerId.of("Test-Customer-Id-3");
         var initialEvents = List.of(new OrderEvent.OrderAdded(orderId,
                                                               customerId,
-                                                              1234));
+                                                              1234),
+                                    new OrderEvent.ProductAddedToOrder(orderId,
+                                                                       ProductId.of("ProductId-0"),
+                                                                       1));
         var unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
 
         // When
@@ -743,16 +746,48 @@ class SingleTenantPostgresqlEventStoreIT {
         assertThat(persistedEventsStream).isNotNull();
         assertThat((CharSequence) persistedEventsStream.aggregateId()).isEqualTo(orderId);
         assertThat(persistedEventsStream.isPartialEventStream()).isTrue();
-        assertThat(persistedEventsStream.eventOrderRangeIncluded()).isEqualTo(LongRange.between(0, 0));
+        assertThat(persistedEventsStream.eventOrderRangeIncluded()).isEqualTo(LongRange.between(0, 1));
         var eventsPersisted = persistedEventsStream.eventList();
-        assertThat(eventsPersisted.size()).isEqualTo(1);
+        assertThat(eventsPersisted.size()).isEqualTo(2);
         assertThat((CharSequence) eventsPersisted.get(0).eventId()).isNotNull();
         assertThat((CharSequence) eventsPersisted.get(0).aggregateId()).isEqualTo(orderId);
         assertThat((CharSequence) eventsPersisted.get(0).aggregateType()).isEqualTo(aggregateType);
         assertThat(eventsPersisted.get(0).eventOrder()).isEqualTo(EventOrder.of(0));
         assertThat(eventsPersisted.get(0).globalEventOrder()).isEqualTo(GlobalEventOrder.of(1));
 
-        // Append to Stream with overlapping event order
+        assertThat((CharSequence) eventsPersisted.get(1).eventId()).isNotNull();
+        assertThat((CharSequence) eventsPersisted.get(1).aggregateId()).isEqualTo(orderId);
+        assertThat((CharSequence) eventsPersisted.get(1).aggregateType()).isEqualTo(aggregateType);
+        assertThat(eventsPersisted.get(1).eventOrder()).isEqualTo(EventOrder.of(1));
+        assertThat(eventsPersisted.get(1).globalEventOrder()).isEqualTo(GlobalEventOrder.of(2));
+
+        // Append Initial Event to Stream with overlapping event order
+        unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
+        var appendInitialEvent = List.of(new OrderEvent.ProductAddedToOrder(orderId,
+                                                                      ProductId.of("ProductId-1"),
+                                                                      2));
+        assertThatThrownBy(() -> eventStore.appendToStream(aggregateType,
+                                                           orderId,
+                                                           EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED, // -1
+                                                           appendInitialEvent))
+                .isExactlyInstanceOf(OptimisticAppendToStreamException.class)
+                .hasMessageContaining("Event-Order range [0]");
+        unitOfWork.rollback();
+
+        // Append Initial Event to Stream with overlapping event order
+        unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
+        var appendSecondEvent = List.of(new OrderEvent.ProductAddedToOrder(orderId,
+                                                                            ProductId.of("ProductId-1"),
+                                                                            2));
+        assertThatThrownBy(() -> eventStore.appendToStream(aggregateType,
+                                                           orderId,
+                                                           EventOrder.FIRST_EVENT_ORDER, // 0
+                                                           appendSecondEvent))
+                .isExactlyInstanceOf(OptimisticAppendToStreamException.class)
+                .hasMessageContaining("Event-Order range [1]");
+        unitOfWork.rollback();
+
+        // Append Events to Stream with overlapping event order
         unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
         var appendEvents = List.of(new OrderEvent.ProductAddedToOrder(orderId,
                                                                       ProductId.of("ProductId-1"),
@@ -763,7 +798,8 @@ class SingleTenantPostgresqlEventStoreIT {
                                                            orderId,
                                                            EventOrder.NO_EVENTS_PREVIOUSLY_PERSISTED, // -1
                                                            appendEvents))
-                .isExactlyInstanceOf(OptimisticAppendToStreamException.class);
+                .isExactlyInstanceOf(OptimisticAppendToStreamException.class)
+                .hasMessageContaining("Event-Order range [0..1]");
         unitOfWork.rollback();
 
         // And load events again and ensure that no events were persisted
@@ -775,8 +811,8 @@ class SingleTenantPostgresqlEventStoreIT {
         assertThat(loadedEventStream.isPartialEventStream()).isFalse();
         assertThat(loadedEventStream.eventOrderRangeIncluded()).isEqualTo(LongRange.from(0));
         assertThat((CharSequence) loadedEventStream.aggregateType()).isEqualTo(aggregateType);
-        var eventsLoaded = loadedEventStream.events().collect(Collectors.toList());
-        assertThat(eventsLoaded.size()).isEqualTo(1);
+        var eventsLoaded = loadedEventStream.events().toList();
+        assertThat(eventsLoaded.size()).isEqualTo(2);
         assertThat((CharSequence) eventsLoaded.get(0).eventId()).isNotNull();
         assertThat((CharSequence) eventsLoaded.get(0).aggregateId()).isEqualTo(orderId);
         assertThat((CharSequence) eventsLoaded.get(0).aggregateType()).isEqualTo(aggregateType);
@@ -795,6 +831,25 @@ class SingleTenantPostgresqlEventStoreIT {
         assertThat(eventsLoaded.get(0).metaData().getJsonDeserialized()).isEqualTo(Optional.of(META_DATA));
         assertThat(eventsLoaded.get(0).causedByEventId()).isEqualTo(Optional.of(eventMapper.causedByEventId));
         assertThat(eventsLoaded.get(0).correlationId()).isEqualTo(Optional.of(eventMapper.correlationId));
+
+        assertThat((CharSequence) eventsLoaded.get(1).eventId()).isNotNull();
+        assertThat((CharSequence) eventsLoaded.get(1).aggregateId()).isEqualTo(orderId);
+        assertThat((CharSequence) eventsLoaded.get(1).aggregateType()).isEqualTo(aggregateType);
+        assertThat(eventsLoaded.get(1).eventOrder()).isEqualTo(EventOrder.of(1));
+        assertThat(eventsLoaded.get(1).eventRevision()).isEqualTo(EventRevision.of(2));
+        assertThat(eventsLoaded.get(1).globalEventOrder()).isEqualTo(GlobalEventOrder.of(2));
+        assertThat(eventsLoaded.get(1).timestamp()).isBefore(OffsetDateTime.now());
+        assertThat(eventsLoaded.get(1).event().getEventName()).isEmpty();
+        assertThat(eventsLoaded.get(1).event().getEventType()).isEqualTo(Optional.of(EventType.of(OrderEvent.ProductAddedToOrder.class)));
+        assertThat(eventsLoaded.get(1).event().getEventTypeOrNamePersistenceValue()).isEqualTo(EventType.of(OrderEvent.ProductAddedToOrder.class).toString());
+        assertThat(eventsLoaded.get(1).event().getJsonDeserialized().get()).usingRecursiveComparison().isEqualTo(initialEvents.get(1));
+        assertThat(eventsLoaded.get(1).event().getJson()).isEqualTo("{\"orderId\": \"beed77fb-d911-480f-9c48-03ed5bfe1111\", \"quantity\": 1, \"productId\": \"ProductId-0\"}"); // Note formatting changed by postgresql
+        assertThat(eventsLoaded.get(1).metaData().getJson()).contains("\"Key1\": \"Value1\""); // Note formatting changed by postgresql
+        assertThat(eventsLoaded.get(1).metaData().getJson()).contains("\"Key2\": \"Value2\""); // Note formatting changed by postgresql
+        assertThat(eventsLoaded.get(1).metaData().getJavaType()).isEqualTo(Optional.of(EventMetaData.class.getName()));
+        assertThat(eventsLoaded.get(1).metaData().getJsonDeserialized()).isEqualTo(Optional.of(META_DATA));
+        assertThat(eventsLoaded.get(1).causedByEventId()).isEqualTo(Optional.of(eventMapper.causedByEventId));
+        assertThat(eventsLoaded.get(1).correlationId()).isEqualTo(Optional.of(eventMapper.correlationId));
     }
 
     @Test
@@ -1040,7 +1095,7 @@ class SingleTenantPostgresqlEventStoreIT {
         assertThat(allPersistedProductEvents).containsAll(allLoadedProductEvents);
         // Verify we can load all partial set of PRODUCT events persisted
         var partialListOfPersistedProductIds = allPersistedProductEvents.stream().map(PersistedEvent::eventId).limit(4).toList();
-        var partialLoadedProductEvents     = eventStore.loadEvents(PRODUCTS, partialListOfPersistedProductIds);
+        var partialLoadedProductEvents       = eventStore.loadEvents(PRODUCTS, partialListOfPersistedProductIds);
         assertThat(partialLoadedProductEvents).hasSize(4);
         assertThat(partialLoadedProductEvents.stream().map(PersistedEvent::eventId).toList()).containsAll(partialListOfPersistedProductIds);
         assertThat(allPersistedProductEvents).containsAll(partialLoadedProductEvents);
@@ -1054,7 +1109,7 @@ class SingleTenantPostgresqlEventStoreIT {
         assertThat(allPersistedOrderEvents).containsAll(allLoadedOrderEvents);
         // Verify we can load all partial set of ORDER events persisted
         var partialListOfPersistedOrderIds = allPersistedOrderEvents.stream().map(PersistedEvent::eventId).limit(10).toList();
-        var partialLoadedOrderEvents     = eventStore.loadEvents(ORDERS, partialListOfPersistedOrderIds);
+        var partialLoadedOrderEvents       = eventStore.loadEvents(ORDERS, partialListOfPersistedOrderIds);
         assertThat(partialLoadedOrderEvents).hasSize(10);
         assertThat(partialLoadedOrderEvents.stream().map(PersistedEvent::eventId).toList()).containsAll(partialListOfPersistedOrderIds);
         assertThat(allPersistedOrderEvents).containsAll(partialLoadedOrderEvents);
@@ -1547,7 +1602,7 @@ class SingleTenantPostgresqlEventStoreIT {
         private final List<PersistedEvent> beforeCommitPersistedEvents  = new ArrayList<>();
         private final List<PersistedEvent> afterCommitPersistedEvents   = new ArrayList<>();
         private final List<PersistedEvent> afterRollbackPersistedEvents = new ArrayList<>();
-        private final List<PersistedEvent> flushPersistedEvents = new ArrayList<>();
+        private final List<PersistedEvent> flushPersistedEvents         = new ArrayList<>();
 
         @Override
         public void handle(Object event) {

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEventTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEventTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.EventMetaData;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.foundation.types.*;
+import org.junit.jupiter.api.*;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.EventJSONTest.createSerializer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersistedEventTest {
+    public static final  String META_DATA_JSON = "{ \"metaData\": \"someValue\" }";
+    private static final String EVENT_JSON     = "{\"testField\": \"testFieldValue\"}";
+
+    private       JSONEventSerializer     jsonSerializer;
+    private final EventType               eventType          = new EventType(this.getClass().getName() + "$TestEvent");
+    private final EventName               eventName          = new EventName("ExampleEvent");
+    private final EventJSONTest.TestEvent deserializedObject = new EventJSONTest.TestEvent("testFieldValue");
+
+
+    @BeforeEach
+    void setUp() {
+        jsonSerializer = createSerializer();
+    }
+
+
+    @Test
+    void valueEquals_should_return_true_for_equal_properties() {
+        // Given
+        var eventId          = EventId.random();
+        var aggregateType    = AggregateType.of("TestAggregate");
+        var aggregateId      = "aggregate-id-123";
+        var event            = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder       = EventOrder.of(1);
+        var eventRevision    = EventRevision.of(1);
+        var globalEventOrder = GlobalEventOrder.of(1);
+        var metaData         = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp        = OffsetDateTime.now();
+        var causedByEventId  = Optional.of(EventId.random());
+        var correlationId    = Optional.of(CorrelationId.random());
+        var tenant           = Optional.of(TenantId.of("tenant-1"));
+
+        var event1 = PersistedEvent.from(eventId, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+        var event2 = PersistedEvent.from(eventId, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When & Then
+        assertThat(event1.valueEquals(event2)).isTrue();
+    }
+
+    @Test
+    void valueEquals_should_return_true_for_equal_properties_with_optional_empty() {
+        // Given
+        var eventId          = EventId.random();
+        var aggregateType    = AggregateType.of("TestAggregate");
+        var aggregateId      = "aggregate-id-123";
+        var event            = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder       = EventOrder.of(1);
+        var eventRevision    = EventRevision.of(1);
+        var globalEventOrder = GlobalEventOrder.of(1);
+        var metaData         = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp        = OffsetDateTime.now();
+        var causedByEventId  = Optional.<EventId>empty();
+        var correlationId    = Optional.<CorrelationId>empty();
+        var tenant           = Optional.<Tenant>empty();
+
+        var event1 = PersistedEvent.from(eventId, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+        var event2 = PersistedEvent.from(eventId, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When & Then
+        assertThat(event1.valueEquals(event2)).isTrue();
+    }
+
+    @Test
+    void valueEquals_should_return_false_for_different_properties() {
+        // Given
+        var eventId1         = EventId.random();
+        var eventId2         = EventId.random();
+        var aggregateType    = AggregateType.of("TestAggregate");
+        var aggregateId      = "aggregate-id-123";
+        var event            = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder       = EventOrder.of(1);
+        var eventRevision    = EventRevision.of(1);
+        var globalEventOrder = GlobalEventOrder.of(1);
+        var metaData         = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp        = OffsetDateTime.now();
+        var causedByEventId  = Optional.of(EventId.random());
+        var correlationId    = Optional.of(CorrelationId.random());
+        var tenant           = Optional.of(TenantId.of("tenant-1"));
+
+        var event1 = PersistedEvent.from(eventId1, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+        var event2 = PersistedEvent.from(eventId2, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When & Then
+        assertThat(event1.valueEquals(event2)).isFalse();
+    }
+
+    @Test
+    void equals_should_return_true_for_same_eventId_even_if_other_properties_are_different() {
+        // Given
+        var eventId         = EventId.random();
+        var aggregateType   = AggregateType.of("TestAggregate");
+        var event           = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder      = EventOrder.of(1);
+        var eventRevision   = EventRevision.of(1);
+        var metaData        = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp       = OffsetDateTime.now();
+        var causedByEventId = Optional.of(EventId.random());
+        var correlationId   = Optional.of(CorrelationId.random());
+        var tenant          = Optional.of(TenantId.of("tenant-1"));
+
+        var event1 = PersistedEvent.from(eventId, aggregateType, "aggregate-id-123", event, eventOrder,
+                                         eventRevision, GlobalEventOrder.of(1), metaData, timestamp, causedByEventId, correlationId, tenant);
+        var event2 = PersistedEvent.from(eventId, aggregateType, "aggregate-id-456", event, eventOrder,
+                                         eventRevision, GlobalEventOrder.of(2), metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When & Then
+        assertThat(event1).isEqualTo(event2);
+    }
+
+    @Test
+    void equals_should_return_false_for_different_eventId() {
+        // Given
+        var eventId1         = EventId.random();
+        var eventId2         = EventId.random();
+        var aggregateType    = AggregateType.of("TestAggregate");
+        var aggregateId      = "aggregate-id-123";
+        var event            = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder       = EventOrder.of(1);
+        var eventRevision    = EventRevision.of(1);
+        var globalEventOrder = GlobalEventOrder.of(1);
+        var metaData         = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp        = OffsetDateTime.now();
+        var causedByEventId  = Optional.of(EventId.random());
+        var correlationId    = Optional.of(CorrelationId.random());
+        var tenant           = Optional.of(TenantId.of("tenant-1"));
+
+        var event1 = PersistedEvent.from(eventId1, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+        var event2 = PersistedEvent.from(eventId2, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When & Then
+        assertThat(event1).isNotEqualTo(event2);
+    }
+
+    @Test
+    void should_return_correct_property_values() {
+        // Given
+        var eventId          = EventId.random();
+        var aggregateType    = AggregateType.of("TestAggregate");
+        var aggregateId      = "aggregate-id-123";
+        var eventJson        = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder       = EventOrder.of(1);
+        var eventRevision    = EventRevision.of(1);
+        var globalEventOrder = GlobalEventOrder.of(1);
+        var metaData         = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp        = OffsetDateTime.now();
+        var causedByEventId  = Optional.of(EventId.random());
+        var correlationId    = Optional.of(CorrelationId.random());
+        var tenant           = Optional.of(TenantId.of("tenant-1"));
+
+        var event = PersistedEvent.from(eventId, aggregateType, aggregateId, eventJson, eventOrder,
+                                        eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When & Then
+        assertThat((CharSequence) event.eventId()).isEqualTo(eventId);
+        assertThat((CharSequence) event.aggregateType()).isEqualTo(aggregateType);
+        assertThat(event.aggregateId()).isEqualTo(aggregateId);
+        assertThat(event.event()).isEqualTo(eventJson);
+        assertThat(event.eventOrder()).isEqualTo(eventOrder);
+        assertThat(event.eventRevision()).isEqualTo(eventRevision);
+        assertThat(event.globalEventOrder()).isEqualTo(globalEventOrder);
+        assertThat(event.metaData()).isEqualTo(metaData);
+        assertThat(event.timestamp()).isEqualTo(timestamp);
+        assertThat(event.causedByEventId()).isEqualTo(causedByEventId);
+        assertThat(event.correlationId()).isEqualTo(correlationId);
+        assertThat(event.tenant()).isEqualTo(tenant);
+    }
+
+    @Test
+    void hashCode_should_be_equal_for_same_eventId_even_if_other_properties_are_different() {
+        // Given
+        var eventId         = EventId.random();
+        var aggregateType   = AggregateType.of("TestAggregate");
+        var event           = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder      = EventOrder.of(1);
+        var eventRevision   = EventRevision.of(1);
+        var metaData        = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp       = OffsetDateTime.now();
+        var causedByEventId = Optional.of(EventId.random());
+        var correlationId   = Optional.of(CorrelationId.random());
+        var tenant          = Optional.of(TenantId.of("tenant-1"));
+
+        var event1 = PersistedEvent.from(eventId, aggregateType, "aggregate-id-123", event, eventOrder,
+                                         eventRevision, GlobalEventOrder.of(1), metaData, timestamp, causedByEventId, correlationId, tenant);
+        var event2 = PersistedEvent.from(eventId, aggregateType, "aggregate-id-456", event, eventOrder,
+                                         eventRevision, GlobalEventOrder.of(2), metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        assertThat(event1.hashCode()).isEqualTo(event2.hashCode());
+    }
+
+    @Test
+    void hashCode_should_return_false_for_different_eventId() {
+        // Given
+        var eventId1         = EventId.random();
+        var eventId2         = EventId.random();
+        var aggregateType    = AggregateType.of("TestAggregate");
+        var aggregateId      = "aggregate-id-123";
+        var event            = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder       = EventOrder.of(1);
+        var eventRevision    = EventRevision.of(1);
+        var globalEventOrder = GlobalEventOrder.of(1);
+        var metaData         = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp        = OffsetDateTime.now();
+        var causedByEventId  = Optional.of(EventId.random());
+        var correlationId    = Optional.of(CorrelationId.random());
+        var tenant           = Optional.of(TenantId.of("tenant-1"));
+
+        var event1 = PersistedEvent.from(eventId1, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+        var event2 = PersistedEvent.from(eventId2, aggregateType, aggregateId, event, eventOrder,
+                                         eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When & Then
+        assertThat(event1.hashCode()).isNotEqualTo(event2.hashCode());
+    }
+
+    @Test
+    void toString_should_return_string_without_event_json_payload() {
+        // Given
+        var eventId          = EventId.random();
+        var aggregateType    = AggregateType.of("TestAggregate");
+        var aggregateId      = "aggregate-id-123";
+        var eventJson        = new EventJSON(jsonSerializer, deserializedObject, eventType, EVENT_JSON);
+        var eventOrder       = EventOrder.of(1);
+        var eventRevision    = EventRevision.of(1);
+        var globalEventOrder = GlobalEventOrder.of(1);
+        var metaData         = new EventMetaDataJSON(jsonSerializer, EventMetaData.class.getName(), META_DATA_JSON);
+        var timestamp        = OffsetDateTime.now();
+        var causedByEventId  = Optional.of(EventId.random());
+        var correlationId    = Optional.of(CorrelationId.random());
+        var tenant           = Optional.of(TenantId.of("tenant-1"));
+
+        var event = PersistedEvent.from(eventId, aggregateType, aggregateId, eventJson, eventOrder,
+                                        eventRevision, globalEventOrder, metaData, timestamp, causedByEventId, correlationId, tenant);
+
+        // When
+        var toStringResult = event.toString();
+
+        // Then
+        assertThat(toStringResult).isNotEmpty();
+        assertThat(toStringResult).doesNotContain(EVENT_JSON);
+        assertThat(toStringResult).contains(META_DATA_JSON);
+    }
+}

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSONTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSONTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.foundation.json.JSONDeserializationException;
+import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
+import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
+import org.junit.jupiter.api.*;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class EventJSONTest {
+
+    private       JSONEventSerializer jsonSerializer;
+    private final String              jsonPayload        = "{\"testField\": \"testFieldValue\"}";
+    private final EventType           eventType          = new EventType(this.getClass().getName() + "$TestEvent");
+    private final EventName           eventName          = new EventName("ExampleEvent");
+    private final TestEvent           deserializedObject = new TestEvent("testFieldValue");
+
+    @BeforeEach
+    void setUp() {
+        jsonSerializer = createSerializer();
+    }
+
+    @Test
+    void testConstructorWithEventTypeAndJsonDeserialized() {
+        var eventJSON = new EventJSON(jsonSerializer, deserializedObject, eventType, jsonPayload);
+
+        assertThat(eventJSON.getEventType()).contains(eventType);
+        assertThat(eventJSON.getJsonDeserialized()).isPresent().contains(deserializedObject);
+        assertThat(eventJSON.getJson()).isEqualTo(jsonPayload);
+    }
+
+    @Test
+    void testConstructorWithEventType() {
+        var eventJSON = new EventJSON(jsonSerializer, eventType, jsonPayload);
+
+        assertThat(eventJSON.getEventType()).contains(eventType);
+        assertThat(eventJSON.getJson()).isEqualTo(jsonPayload);
+    }
+
+    @Test
+    void testConstructorWithEventNameAndJsonDeserialized() {
+        var eventJSON = new EventJSON(jsonSerializer, deserializedObject, eventName, jsonPayload);
+
+        assertThat(eventJSON.getEventName()).contains(eventName);
+        assertThat(eventJSON.getJsonDeserialized()).isPresent().contains(deserializedObject);
+        assertThat(eventJSON.getJson()).isEqualTo(jsonPayload);
+    }
+
+    @Test
+    void testConstructorWithEventName() {
+        var eventJSON = new EventJSON(jsonSerializer, eventName, jsonPayload);
+
+        assertThat(eventJSON).isNotNull();
+        assertThat(eventJSON.getEventName()).contains(eventName);
+        assertThat(eventJSON.getJson()).isEqualTo(jsonPayload);
+    }
+
+    @Test
+    void testGetJsonDeserialized_DeserializeOnDemand() {
+        var eventJSON = new EventJSON(jsonSerializer, eventType, jsonPayload);
+
+        Optional<TestEvent> deserialized = eventJSON.getJsonDeserialized();
+        assertThat(deserialized).isPresent();
+        assertThat(deserialized.get()).isEqualTo(deserializedObject);
+        assertThat(deserialized.get().getTestField()).isEqualTo("testFieldValue");
+    }
+
+    @Test
+    void testDeserialize_ThrowsExceptionWhenNoSerializerProvided() {
+        var eventJSON = new EventJSON(jsonSerializer, eventType, jsonPayload);
+        eventJSON = jsonSerializer.deserialize(jsonSerializer.serialize(eventJSON), EventJSON.class);
+        assertThatThrownBy(eventJSON::deserialize)
+                .isInstanceOf(JSONDeserializationException.class)
+                .hasMessageContaining("No JSONSerializer specified");
+    }
+
+    @Test
+    void testDeserialize_ThrowsExceptionWhenNoEventTypeProvided() {
+        var eventJSON = new EventJSON(jsonSerializer, eventName, jsonPayload);
+        assertThatThrownBy(eventJSON::deserialize)
+                .isInstanceOf(JSONDeserializationException.class)
+                .hasMessageContaining("No EventJavaType specified");
+    }
+
+    @Test
+    void testGetEventTypeOrNamePersistenceValue_WithEventType() {
+        var eventJSON = new EventJSON(jsonSerializer, eventType, jsonPayload);
+        assertThat(eventJSON.getEventTypeOrNamePersistenceValue()).isEqualTo(eventType.toString());
+    }
+
+    @Test
+    void testGetEventTypeOrNamePersistenceValue_WithEventName() {
+        var eventJSON = new EventJSON(jsonSerializer, eventName, jsonPayload);
+        assertThat(eventJSON.getEventTypeOrNamePersistenceValue()).isEqualTo(eventName.toString());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        var eventJSON1 = new EventJSON(jsonSerializer, eventType, jsonPayload);
+        var eventJSON2 = new EventJSON(jsonSerializer, eventType, jsonPayload);
+
+        assertThat(eventJSON1).isEqualTo(eventJSON2);
+        assertThat(eventJSON1.hashCode()).isEqualTo(eventJSON2.hashCode());
+    }
+
+    @Test
+    void testNotEquals() {
+        var eventJSON1 = new EventJSON(jsonSerializer, eventType, jsonPayload);
+        var eventJSON2 = new EventJSON(jsonSerializer, eventName, jsonPayload);
+
+        assertThat(eventJSON1).isNotEqualTo(eventJSON2);
+    }
+
+    @Test
+    void testToString() {
+        var    eventJSON = new EventJSON(jsonSerializer, eventType, jsonPayload);
+        String expected  = "EventJSON{eventTypeOrName=" + EventTypeOrName.with(eventType) + "}";
+        assertThat(eventJSON.toString()).isEqualTo(expected);
+    }
+
+    @Test
+    void testGetEventTypeAsJavaClass() {
+        var eventJSON = new EventJSON(jsonSerializer, eventType, jsonPayload);
+
+        assertThat(eventJSON.getEventTypeAsJavaClass()).isPresent();
+        assertThat(eventJSON.getEventTypeAsJavaClass().get()).isEqualTo(TestEvent.class);
+    }
+
+    public static class TestEvent {
+        private String testField;
+
+        public TestEvent(String testField) {
+            this.testField = testField;
+        }
+
+        public String getTestField() {
+            return testField;
+        }
+
+        public void setTestField(String testField) {
+            this.testField = testField;
+        }
+    }
+
+    public static JacksonJSONEventSerializer createSerializer() {
+        var objectMapper = JsonMapper.builder()
+                                     .disable(MapperFeature.AUTO_DETECT_GETTERS)
+                                     .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+                                     .disable(MapperFeature.AUTO_DETECT_SETTERS)
+                                     .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                                     .enable(MapperFeature.AUTO_DETECT_CREATORS)
+                                     .enable(MapperFeature.AUTO_DETECT_FIELDS)
+                                     .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
+                                     .addModule(new Jdk8Module())
+                                     .addModule(new JavaTimeModule())
+                                     .addModule(new EssentialTypesJacksonModule())
+                                     .addModule(new EssentialsImmutableJacksonModule())
+                                     .build();
+
+        objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
+                                               .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                               .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                                               .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                                               .withCreatorVisibility(JsonAutoDetect.Visibility.ANY));
+        return new JacksonJSONEventSerializer(objectMapper);
+    }
+}

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSONTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSONTest.java
@@ -27,7 +27,7 @@ import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonMod
 import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
 import org.junit.jupiter.api.*;
 
-import java.util.Optional;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -163,6 +163,24 @@ public class EventJSONTest {
 
         public void setTestField(String testField) {
             this.testField = testField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof TestEvent testEvent)) return false;
+            return Objects.equals(testField, testEvent.testField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(testField);
+        }
+
+        @Override
+        public String toString() {
+            return "TestEvent{" +
+                    "testField='" + testField + '\'' +
+                    '}';
         }
     }
 

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSONTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSONTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.EventMetaData;
+import dk.cloudcreate.essentials.components.foundation.json.JSONDeserializationException;
+import org.junit.jupiter.api.*;
+
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.EventJSONTest.createSerializer;
+import static org.assertj.core.api.Assertions.*;
+
+class EventMetaDataJSONTest {
+
+    private              JSONEventSerializer jsonEventSerializer;
+    private static final String              JAVA_TYPE = EventMetaData.class.getName();
+    private              String              json;
+    private              EventMetaData       jsonDeserialized;
+
+    @BeforeEach
+    void setUp() {
+        jsonEventSerializer = createSerializer();
+        jsonDeserialized = EventMetaData.of("key", "value");
+        json = jsonEventSerializer.serialize(jsonDeserialized);
+    }
+
+    @Test
+    void givenEventMetaDataJSON_whenCallingGetJsonDeserialized_thenReturnsCorrectObject() {
+        // Given
+        var eventMetaDataJSON = new EventMetaDataJSON(jsonEventSerializer, jsonDeserialized, JAVA_TYPE, json);
+
+        // When
+        var deserialized = eventMetaDataJSON.getJsonDeserialized();
+
+        // Then
+        assertThat(deserialized).isPresent().containsSame(jsonDeserialized);
+    }
+
+    @Test
+    void givenEventMetaDataJSONWithoutDeserializedObject_whenCallingGetJsonDeserialized_thenDeserializeObject() {
+        // Given
+        var eventMetaDataJSON = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+
+        // When
+        var deserialized = eventMetaDataJSON.getJsonDeserialized();
+
+        // Then
+        assertThat(deserialized).isPresent().contains(jsonDeserialized);
+    }
+
+    @Test
+    void givenEventMetaDataJSON_whenCallingDeserialize_thenReturnsCorrectObject() {
+        // Given
+        var eventMetaDataJSON = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+
+        // When
+        var deserialized = eventMetaDataJSON.deserialize();
+
+        // Then
+        assertThat(deserialized).isEqualTo(jsonDeserialized);
+    }
+
+    @Test
+    void givenEventMetaDataJSONWithoutSerializer_whenCallingDeserialize_thenThrowsException() {
+        // Given
+        var eventMetaDataJSON = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+
+        // When
+        eventMetaDataJSON = jsonEventSerializer.deserialize(jsonEventSerializer.serialize(eventMetaDataJSON), EventMetaDataJSON.class);
+
+        // When
+        assertThatThrownBy(eventMetaDataJSON::deserialize)
+                .isInstanceOf(JSONDeserializationException.class)
+                .hasMessageContaining("No JSONSerializer specified for deserialization");
+    }
+
+    @Test
+    void givenTwoEqualEventMetaDataJSONInstances_whenCallingEquals_thenTheyAreEqual() {
+        // Given
+        var eventMetaDataJSON1 = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+        var eventMetaDataJSON2 = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+
+        // When/Then
+        assertThat(eventMetaDataJSON1).isEqualTo(eventMetaDataJSON2);
+    }
+
+    @Test
+    void givenTwoDifferentEventMetaDataJSONInstances_whenCallingEquals_thenTheyAreNotEqual() {
+        // Given
+        var eventMetaDataJSON1 = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+        var eventMetaDataJSON2 = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, "{\"differentKey\": \"differentValue\"}");
+
+        // When/Then
+        assertThat(eventMetaDataJSON1).isNotEqualTo(eventMetaDataJSON2);
+    }
+
+    @Test
+    void givenEventMetaDataJSON_whenCallingHashCode_thenReturnsCorrectHashCode() {
+        // Given
+        var eventMetaDataJSON1 = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+        var eventMetaDataJSON2 = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+
+        // When/Then
+        assertThat(eventMetaDataJSON1.hashCode()).isEqualTo(eventMetaDataJSON2.hashCode());
+    }
+
+    @Test
+    void givenEventMetaDataJSON_whenCallingToString_thenReturnsExpectedString() {
+        // Given
+        var eventMetaDataJSON = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+
+        // When
+        var toStringResult = eventMetaDataJSON.toString();
+
+        // Then
+        assertThat(toStringResult).isEqualTo("EventMetaDataJSON{javaType='" + JAVA_TYPE + "', json='" + json + "'}");
+    }
+
+    @Test
+    void givenEventMetaDataJSONWithJavaType_whenCallingGetProperties_thenReturnsJavaTypeAndJson() {
+        // Given
+        var eventMetaDataJSON = new EventMetaDataJSON(jsonEventSerializer, JAVA_TYPE, json);
+
+        // When & Then
+        assertThat(eventMetaDataJSON.getJavaType()).isPresent().contains(JAVA_TYPE);
+        assertThat(eventMetaDataJSON.getJson()).isEqualTo(json);
+    }
+
+    @Test
+    void givenEventMetaDataJSONWithoutJavaType_whenCallingGetProperties_thenReturnsOnlyJson() {
+        // Given
+        var eventMetaDataJSON = new EventMetaDataJSON(jsonEventSerializer, null, json);
+
+        // When & Then
+        assertThat(eventMetaDataJSON.getJavaType()).isNotPresent();
+        assertThat(eventMetaDataJSON.getJson()).isEqualTo(json);
+    }
+}

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
@@ -115,7 +115,7 @@ class EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchr
 
     @Test
     void subscribe() {
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),
@@ -277,7 +277,7 @@ class EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchr
     void test_start_and_stop_subscription() {
         System.out.println("********** Start test_start_and_stop_subscription ***********");
 
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),
@@ -379,7 +379,7 @@ class EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchr
     @Test
     void test_with_resubscription() {
         System.out.println("********** Start test_with_resubscription ***********");
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
@@ -137,7 +137,7 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
 
 
     private void testSubscriptions(boolean simulateDbConnectivityIssues) throws InterruptedException {
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),
@@ -281,7 +281,7 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
     @Test
     void test_start_and_stop_subscription() {
         System.out.println("********** Start test_start_and_stop_subscription ***********");
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),
@@ -383,7 +383,7 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
     @Test
     void test_with_resubscription() {
         System.out.println("********** Start test_with_resubscription ***********");
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
@@ -167,8 +167,17 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
 
                     @Override
                     public void handle(PersistedEvent event) {
-                        System.out.println("Received Product event: " + event);
-                        productEventsReceived.add(event);
+                        var isDuplicateEvent = productEventsReceived.contains(event);
+                        if (isDuplicateEvent) {
+                            System.out.println("Received DUPLICATE Product event: " + event);
+                            // When db connectivity is interrupted we may briefly receive messages out of order or multiple times due to overlaps in lock ownership
+                            if (!simulateDbConnectivityIssues) {
+                                throw new IllegalStateException("Received unexpected DUPLICATE Product event: " + event);
+                            }
+                        } else {
+                            System.out.println("Received Product event: " + event);
+                            productEventsReceived.add(event);
+                        }
                     }
                 });
         System.out.println("productsSubscription: " + productsSubscription);
@@ -187,8 +196,17 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
 
                     @Override
                     public void handle(PersistedEvent event) {
-                        System.out.println("Received Order event: " + event);
-                        orderEventsReceived.add(event);
+                        var isDuplicateEvent = orderEventsReceived.contains(event);
+                        if (isDuplicateEvent) {
+                            System.out.println("Received DUPLICATE Order event: " + event);
+                            // When db connectivity is interrupted we may briefly receive messages out of order or multiple times due to overlaps in lock ownership
+                            if (!simulateDbConnectivityIssues) {
+                                throw new IllegalStateException("Received unexpected DUPLICATE Order event: " + event);
+                            }
+                        } else {
+                            System.out.println("Received Order event: " + event);
+                            orderEventsReceived.add(event);
+                        }
                     }
                 });
 
@@ -226,20 +244,6 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
                                                    .reduce(Integer::sum)
                                                    .get();
         System.out.println("Total number of Product Events: " + totalNumberOfProductEvents);
-        Awaitility.waitAtMost(Duration.ofSeconds(10))
-                  .untilAsserted(() -> assertThat(productEventsReceived.size()).isEqualTo(totalNumberOfProductEvents));
-        // Verify we only have Product related events
-        assertThat(productEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(PRODUCTS)).findAny()).isEmpty();
-        assertThat(productEventsReceived.stream()
-                                        .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
-                                        .sorted() // When db connectivity is interrupted we may briefly receive messages out of order due to overlaps in lock ownership
-                                        .collect(Collectors.toList()))
-                .isEqualTo(LongStream.rangeClosed(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER.longValue(),
-                                                  totalNumberOfProductEvents)
-                                     .boxed()
-                                     .collect(Collectors.toList()));
-
-        // Verify we received all Order events
         var totalNumberOfOrderEvents = testEvents.get(ORDERS)
                                                  .values()
                                                  .stream()
@@ -247,12 +251,41 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT 
                                                  .reduce(Integer::sum)
                                                  .get();
         System.out.println("Total number of Order Events: " + totalNumberOfOrderEvents);
+
+        // Verify we received all Product and Order events
+        Awaitility.waitAtMost(Duration.ofSeconds(10))
+                  .untilAsserted(() -> assertThat(productEventsReceived.size()).isEqualTo(totalNumberOfProductEvents));
+
         Awaitility.waitAtMost(Duration.ofSeconds(5))
                   .untilAsserted(() -> assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents));
+
+        // Sleep a little to verify that no additional events were delivered
+        Thread.sleep(5000);
+
+        // Verify we only have Product related events
+        assertThat(productEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(PRODUCTS)).findAny()).isEmpty();
+        var receivedProductEventGlobalOrders = productEventsReceived.stream()
+                                                                    .map(persistedEvent -> persistedEvent.globalEventOrder().longValue());
+        if (simulateDbConnectivityIssues) {
+            // When db connectivity is interrupted we may briefly receive messages out of order due to overlaps in lock ownership
+            receivedProductEventGlobalOrders = receivedProductEventGlobalOrders.sorted();
+        }
+        assertThat(receivedProductEventGlobalOrders
+                           .toList())
+                .isEqualTo(LongStream.rangeClosed(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER.longValue(),
+                                                  totalNumberOfProductEvents)
+                                     .boxed()
+                                     .collect(Collectors.toList()));
+
         assertThat(orderEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(ORDERS)).findAny()).isEmpty();
-        assertThat(orderEventsReceived.stream()
-                                      .map(persistedEvent -> persistedEvent.globalEventOrder().longValue())
-                                      .collect(Collectors.toList()))
+        var receivedOrderEventGlobalOrders = orderEventsReceived.stream()
+                                                                .map(persistedEvent -> persistedEvent.globalEventOrder().longValue());
+        if (simulateDbConnectivityIssues) {
+            // When db connectivity is interrupted we may briefly receive messages out of order due to overlaps in lock ownership
+            receivedOrderEventGlobalOrders = receivedOrderEventGlobalOrders.sorted();
+        }
+        assertThat(receivedOrderEventGlobalOrders
+                           .toList())
                 .isEqualTo(LongStream.rangeClosed(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER.longValue(),
                                                   totalNumberOfOrderEvents)
                                      .boxed()

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
@@ -118,7 +118,7 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT {
 
     @Test
     void subscribe() {
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_WithFlushAndPublish_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_WithFlushAndPublish_IT.java
@@ -121,7 +121,7 @@ class EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_With
     @Test
     void subscribe_using_FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream() {
         eventStore.addEventStoreInterceptor(new FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream());
-        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory());
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
         eventStoreSubscriptionManagerNode1 = EventStoreSubscriptionManager.createFor(eventStore,
                                                                                      50,
                                                                                      Duration.ofMillis(100),

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepositoryTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepositoryTest.java
@@ -16,8 +16,8 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription;
 
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
 import dk.cloudcreate.essentials.components.foundation.postgresql.InvalidTableOrColumnNameException;
-import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.HandleAwareUnitOfWorkFactory;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
 
@@ -30,21 +30,21 @@ class PostgresqlDurableSubscriptionRepositoryTest {
     void test_with_invalid_durableSubscriptionsTableName() {
         assertThatThrownBy(() -> {
             new PostgresqlDurableSubscriptionRepository(mock(Jdbi.class),
-                                                        mock(HandleAwareUnitOfWorkFactory.class),
+                                                        mock(EventStore.class),
                                                         "invalid name");
         }).isInstanceOf(InvalidTableOrColumnNameException.class)
           .hasMessageContaining("Invalid table or column name");
 
         assertThatThrownBy(() -> {
             new PostgresqlDurableSubscriptionRepository(mock(Jdbi.class),
-                                                        mock(HandleAwareUnitOfWorkFactory.class),
+                                                        mock(EventStore.class),
                                                         "name; DROP TABLE users;");
         }).isInstanceOf(InvalidTableOrColumnNameException.class)
           .hasMessageContaining("Invalid table or column name");
 
         assertThatThrownBy(() -> {
             new PostgresqlDurableSubscriptionRepository(mock(Jdbi.class),
-                                                        mock(HandleAwareUnitOfWorkFactory.class),
+                                                        mock(EventStore.class),
                                                         "drop");
         }).isInstanceOf(InvalidTableOrColumnNameException.class)
           .hasMessageContaining("is a reserved keyword");

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -34,7 +34,6 @@ import dk.cloudcreate.essentials.reactive.*;
 import dk.cloudcreate.essentials.shared.Exceptions;
 import dk.cloudcreate.essentials.shared.collections.Lists;
 import dk.cloudcreate.essentials.shared.interceptor.InterceptorChain;
-import dk.cloudcreate.essentials.shared.reflection.Classes;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -1230,7 +1229,7 @@ public final class PostgresqlDurableQueues implements DurableQueues {
         requireNonNull(messagePayload, "No messagePayload provided");
         requireNonNull(messagePayloadType, "No messagePayloadType provided");
         try {
-            return jsonSerializer.deserialize(messagePayload, Classes.forName(messagePayloadType));
+            return jsonSerializer.deserialize(messagePayload, messagePayloadType);
         } catch (Throwable e) {
             throw new DurableQueueException(msg("Failed to deserialize message payload of type {}", messagePayloadType), e, queueName);
         }

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -89,6 +89,13 @@ endangering the security and integrity of the database. It is highly recommended
     - **Failure to adequately sanitize and validate this value could expose the application to malicious input attacks, compromising the security and integrity of the database.**
 - `Inboxes`, `Outboxes` and `DurableLocalCommandBus` configured to use `MongoDurableQueues`
 - `LocalEventBus` with bus-name `default` and Bean name `eventBus`
+  - Supports additional configuration properties:
+  - ```
+    essentials.reactive.event-bus-backpressure-buffer-size=1024
+    essentials.reactive.overflow-max-retries=20
+    essentials.reactive.queued-task-cap-factor=1.5
+    #essentials.reactive.parallel-threads=4
+    ```
 - `ReactiveHandlersBeanPostProcessor` (for auto-registering `EventHandler` and `CommandHandler` Beans with the `EventBus`'s and `CommandBus` beans found in the `ApplicationContext`)
 - Automatically calling `Lifecycle.start()`/`Lifecycle.stop`, on any Beans implementing the `Lifecycle` interface, when the `ApplicationContext` is started/stopped through the `DefaultLifecycleManager`
   - You can disable starting `Lifecycle` Beans by using setting this property to false:

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mongodb.*;
@@ -471,7 +470,7 @@ public class EssentialsComponentsConfiguration {
                          event.getApplicationContext().getClassLoader(),
                          jacksonJSONSerializer.getObjectMapper().getTypeFactory().getClassLoader()
                         );
-                jacksonJSONSerializer.getObjectMapper().setTypeFactory(TypeFactory.defaultInstance().withClassLoader(event.getApplicationContext().getClassLoader()));
+                jacksonJSONSerializer.setClassLoader(event.getApplicationContext().getClassLoader());
             }
         }
     }

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -390,12 +390,20 @@ public class EssentialsComponentsConfiguration {
      * Configure the {@link EventBus} to use for all event handlers
      *
      * @param onErrorHandler the error handler which will be called if any asynchronous subscriber/consumer fails to handle an event
+     * @param properties The configuration properties
      * @return the {@link EventBus} to use for all event handlers
      */
     @Bean
     @ConditionalOnMissingBean
-    public EventBus eventBus(Optional<OnErrorHandler> onErrorHandler) {
-        return new LocalEventBus("default", onErrorHandler);
+    public EventBus eventBus(Optional<OnErrorHandler> onErrorHandler, EssentialsComponentsProperties properties) {
+        var localEventBusBuilder = LocalEventBus.builder()
+                                                .busName("default")
+                                                .overflowMaxRetries(properties.getReactive().getOverflowMaxRetries())
+                                                .parallelThreads(properties.getReactive().getParallelThreads())
+                                                .backpressureBufferSize(properties.getReactive().getEventBusBackpressureBufferSize())
+                                                .queuedTaskCapFactor(properties.getReactive().getQueuedTaskCapFactor());
+        onErrorHandler.ifPresent(localEventBusBuilder::onErrorHandler);
+        return localEventBusBuilder.build();
     }
 
     /**

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
@@ -24,8 +24,10 @@ import dk.cloudcreate.essentials.components.foundation.messaging.queue.operation
 import dk.cloudcreate.essentials.components.foundation.mongo.MongoUtil;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 import dk.cloudcreate.essentials.components.queue.springdata.mongodb.MongoDurableQueues;
+import dk.cloudcreate.essentials.reactive.LocalEventBus;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Sinks;
 
 import java.time.*;
 
@@ -78,7 +80,8 @@ public class EssentialsComponentsProperties {
     private final DurableQueues       durableQueues                 = new DurableQueues();
     private final LifeCycleProperties lifeCycles                    = new LifeCycleProperties();
     private final TracingProperties   tracingProperties             = new TracingProperties();
-    private       boolean             immutableJacksonModuleEnabled = true;
+    private       boolean            immutableJacksonModuleEnabled = true;
+    private final ReactiveProperties reactive                      = new ReactiveProperties();
 
     /**
      * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
@@ -114,6 +117,10 @@ public class EssentialsComponentsProperties {
 
     public TracingProperties getTracingProperties() {
         return this.tracingProperties;
+    }
+
+    public ReactiveProperties getReactive() {
+        return reactive;
     }
 
     public static class DurableQueues {
@@ -446,6 +453,86 @@ public class EssentialsComponentsProperties {
          */
         public void setModuleTag(String moduleTag) {
             this.moduleTag = moduleTag;
+        }
+    }
+
+    public static class ReactiveProperties {
+        private int    eventBusBackpressureBufferSize = LocalEventBus.DEFAULT_BACKPRESSURE_BUFFER_SIZE;
+        private int    parallelThreads                = Runtime.getRuntime().availableProcessors();
+        private int    overflowMaxRetries             = LocalEventBus.DEFAULT_OVERFLOW_MAX_RETRIES;
+        private double queuedTaskCapFactor            = LocalEventBus.QUEUED_TASK_CAP_FACTOR;
+
+        /**
+         * Get property to set as 'eventBusBackpressureBufferSize' value LocalEventBus back pressure size for {@link Sinks.Many}'s onBackpressureBuffer size. The default value set by reactor framework is {@value LocalEventBus#DEFAULT_BACKPRESSURE_BUFFER_SIZE}.
+         *
+         * @return property 'eventBusBackpressureBufferSize' used for value LocalEventBus Sinks.Many onBackpressureBuffer size.
+         */
+        public int getEventBusBackpressureBufferSize() {
+            return eventBusBackpressureBufferSize;
+        }
+
+        /**
+         * Set property 'eventBusBackpressureBufferSize'  value LocalEventBus back pressure size for {@link Sinks.Many}'s onBackpressureBuffer size. The default value set by reactor framework is {@value LocalEventBus#DEFAULT_BACKPRESSURE_BUFFER_SIZE}.
+         *
+         * @param eventBusBackpressureBufferSize property value 'eventBusBackpressureBufferSize' LocalEventBus Sinks.Many onBackpressureBuffer size.
+         */
+        public void setEventBusBackpressureBufferSize(int eventBusBackpressureBufferSize) {
+            this.eventBusBackpressureBufferSize = eventBusBackpressureBufferSize;
+        }
+
+        /**
+         * Get the number of parallel threads processing asynchronous events. Defaults to the number of available processors on the machine
+         *
+         * @return the number of parallel threads processing asynchronous events.
+         */
+        public int getParallelThreads() {
+            return parallelThreads;
+        }
+
+        /**
+         * Set the number of parallel threads processing asynchronous events. Defaults to the number of available processors on the machine
+         *
+         * @param parallelThreads the number of parallel threads processing asynchronous events.
+         */
+        public void setParallelThreads(int parallelThreads) {
+            this.parallelThreads = parallelThreads;
+        }
+
+        /**
+         * Set the maximum number of retries for events that overflow the Flux. Default is {@value LocalEventBus#DEFAULT_OVERFLOW_MAX_RETRIES}.
+         *
+         * @return the maximum number of retries for events that overflow the Flux
+         */
+        public int getOverflowMaxRetries() {
+            return overflowMaxRetries;
+        }
+
+        /**
+         * Get the maximum number of retries for events that overflow the Flux. Default is {@value LocalEventBus#DEFAULT_OVERFLOW_MAX_RETRIES}.
+         *
+         * @param overflowMaxRetries the maximum number of retries for events that overflow the Flux
+         */
+        public void setOverflowMaxRetries(int overflowMaxRetries) {
+            this.overflowMaxRetries = overflowMaxRetries;
+        }
+
+
+        /**
+         * Get the factor to calculate queued task capacity from the backpressureBufferSize. Default value is {@value LocalEventBus#QUEUED_TASK_CAP_FACTOR}.
+         *
+         * @return the factor to calculate queued task capacity from the backpressureBufferSize.
+         */
+        public double getQueuedTaskCapFactor() {
+            return queuedTaskCapFactor;
+        }
+
+        /**
+         * Set the factor to calculate queued task capacity from the backpressureBufferSize. Default value is {@value LocalEventBus#QUEUED_TASK_CAP_FACTOR}.
+         *
+         * @param queuedTaskCapFactor the factor to calculate queued task capacity from the backpressureBufferSize.
+         */
+        public void setQueuedTaskCapFactor(double queuedTaskCapFactor) {
+            this.queuedTaskCapFactor = queuedTaskCapFactor;
         }
     }
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -131,7 +131,14 @@ then you need to check the component document to learn about the Security implic
       - To mitigate the risk of SQL injection attacks, external or untrusted inputs should never directly provide the `essentials.durable-queues.shared-queue-table-name` value.
       - **Failure to adequately sanitize and validate this value could expose the application to SQL injection vulnerabilities, compromising the security and integrity of the database.**
 - `Inboxes`, `Outboxes` and `DurableLocalCommandBus` configured to use `PostgresqlDurableQueues`
-- `LocalEventBus` with bus-name `default` and Bean name `eventBus`
+- `EventStoreEventBus` with bus-name `EventStoreLocalBus` and Bean name `eventBus`
+  - Supports additional configuration properties:
+  - ```
+    essentials.reactive.event-bus-backpressure-buffer-size=1024
+    essentials.reactive.overflow-max-retries=20
+    essentials.reactive.queued-task-cap-factor=1.5
+    #essentials.reactive.parallel-threads=4
+    ```
 - `ReactiveHandlersBeanPostProcessor` (for auto-registering `EventHandler` and `CommandHandler` Beans with the `EventBus`'s and `CommandBus` beans found in the `ApplicationContext`)
 - `MultiTableChangeListener` which is used for optimizing `PostgresqlDurableQueues` message polling
 - Automatically calling `Lifecycle.start()`/`Lifecycle.stop`, on any Beans implementing the `Lifecycle` interface, when the `ApplicationContext` is started/stopped through the `DefaultLifecycleManager`

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
@@ -16,80 +16,50 @@
 
 package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.eventstore;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Optional;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.EssentialsComponentsConfiguration;
-import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.EssentialsComponentsProperties;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.ConfigurableEventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreSubscription;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.PostgresqlEventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.EventStoreEventBus;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.PersistedEvents;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.EventStreamTableColumnNames;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.NoEventStreamGapHandler;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler;
+import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor.EventStoreInterceptor;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor.micrometer.MicrometerTracingEventStoreInterceptor;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.AggregateEventStreamConfiguration;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.AggregateEventStreamPersistenceStrategy;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.PersistableEvent;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.PersistableEventMapper;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.PersistableEventEnricher;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypePersistenceStrategy;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.EventProcessor;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.EventProcessorDependencies;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JSONEventSerializer;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.spring.SpringTransactionAwareEventStoreUnitOfWorkFactory;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.PostgresqlDurableSubscriptionRepository;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.EventStoreSubscriptionMonitor;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.EventStoreSubscriptionMonitorManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.SubscriberGlobalOrderMicrometerMonitor;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWork;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreUnitOfWorkFactory;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventOrder;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventTypeOrName;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.monitoring.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
 import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
 import dk.cloudcreate.essentials.components.foundation.messaging.MessageHandler;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inbox;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inboxes;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.MessageHandlerInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
 import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
-import dk.cloudcreate.essentials.reactive.Handler;
-import dk.cloudcreate.essentials.reactive.OnErrorHandler;
-import dk.cloudcreate.essentials.reactive.command.CmdHandler;
-import dk.cloudcreate.essentials.reactive.command.CommandBus;
+import dk.cloudcreate.essentials.reactive.*;
+import dk.cloudcreate.essentials.reactive.command.*;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.tracing.Tracer;
 import io.micrometer.tracing.propagation.Propagator;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.*;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.Duration;
+import java.util.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireTrue;
 
@@ -179,7 +149,7 @@ public class EventStoreConfiguration {
         return EventStoreSubscriptionManager.builder()
                                             .setEventStore(eventStore)
                                             .setFencedLockManager(fencedLockManager)
-                                            .setDurableSubscriptionRepository(new PostgresqlDurableSubscriptionRepository(jdbi, eventStore.getUnitOfWorkFactory()))
+                                            .setDurableSubscriptionRepository(new PostgresqlDurableSubscriptionRepository(jdbi, eventStore))
                                             .setEventStorePollingBatchSize(eventStoreProperties.getSubscriptionManager().getEventStorePollingBatchSize())
                                             .setEventStorePollingInterval(eventStoreProperties.getSubscriptionManager().getEventStorePollingInterval())
                                             .setSnapshotResumePointsEvery(eventStoreProperties.getSubscriptionManager().getSnapshotResumePointsEvery())

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -89,6 +89,13 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
       - **Failure to adequately sanitize and validate this value could expose the application to SQL injection vulnerabilities, compromising the security and integrity of the database.**
 - `Inboxes`, `Outboxes` and `DurableLocalCommandBus` configured to use `PostgresqlDurableQueues`
 - `LocalEventBus` with bus-name `default` and Bean name `eventBus`
+  - Supports additional configuration properties:
+  - ```
+    essentials.reactive.event-bus-backpressure-buffer-size=1024
+    essentials.reactive.overflow-max-retries=20
+    essentials.reactive.queued-task-cap-factor=1.5
+    #essentials.reactive.parallel-threads=4
+    ```
 - `ReactiveHandlersBeanPostProcessor` (for auto-registering `EventHandler` and `CommandHandler` Beans with the `EventBus`'s and `CommandBus` beans found in the `ApplicationContext`)
 - `MultiTableChangeListener` which is used for optimizing `PostgresqlDurableQueues` message polling
 - Automatically calling `Lifecycle.start()`/`Lifecycle.stop`, on any Beans implementing the `Lifecycle` interface, when the `ApplicationContext` is started/stopped through the `DefaultLifecycleManager`

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -333,15 +333,23 @@ public class EssentialsComponentsConfiguration {
      * Configure the {@link EventBus} to use for all event handlers
      *
      * @param onErrorHandler the error handler which will be called if any asynchronous subscriber/consumer fails to handle an event
+     * @param properties The configuration properties
      * @return the {@link EventBus} to use for all event handlers
      */
     @Bean
     @ConditionalOnMissingClass("dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.EventStoreEventBus")
     @ConditionalOnMissingBean
-    public EventBus eventBus(Optional<OnErrorHandler> onErrorHandler) {
-        return new LocalEventBus("default", onErrorHandler);
+    public EventBus eventBus(Optional<OnErrorHandler> onErrorHandler, EssentialsComponentsProperties properties) {
+        var localEventBusBuilder = LocalEventBus.builder()
+                                                .busName("default")
+                                                .overflowMaxRetries(properties.getReactive().getOverflowMaxRetries())
+                                                .parallelThreads(properties.getReactive().getParallelThreads())
+                                                .backpressureBufferSize(properties.getReactive().getEventBusBackpressureBufferSize())
+                                                .queuedTaskCapFactor(properties.getReactive().getQueuedTaskCapFactor());
+        onErrorHandler.ifPresent(localEventBusBuilder::onErrorHandler);
+        return localEventBusBuilder.build();
     }
-
+    
     /**
      * {@link JSONSerializer} responsible for serializing/deserializing the raw Java events to and from JSON
      * (including handling {@link DurableQueues} message payload serialization and deserialization)

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.EssentialsComponentsProperties.*;
@@ -428,7 +427,7 @@ public class EssentialsComponentsConfiguration {
                          event.getApplicationContext().getClassLoader(),
                          jacksonJSONSerializer.getObjectMapper().getTypeFactory().getClassLoader()
                         );
-                jacksonJSONSerializer.getObjectMapper().setTypeFactory(TypeFactory.defaultInstance().withClassLoader(event.getApplicationContext().getClassLoader()));
+                jacksonJSONSerializer.setClassLoader(event.getApplicationContext().getClassLoader());
             }
         }
     }

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -24,8 +24,10 @@ import dk.cloudcreate.essentials.components.foundation.messaging.queue.operation
 import dk.cloudcreate.essentials.components.foundation.postgresql.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 import dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues;
+import dk.cloudcreate.essentials.reactive.LocalEventBus;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Sinks;
 
 import java.time.*;
 
@@ -69,6 +71,7 @@ import java.time.*;
  * To mitigate the risk of SQL injection attacks, external or untrusted inputs should never directly provide the {@code sharedQueueTableName} value.<br>
  * <b>Failure to adequately sanitize and validate this value could expose the application to SQL injection
  * vulnerabilities, compromising the security and integrity of the database.</b>
+ *
  * @see dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues
  * @see dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager
  * @see dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockStorage
@@ -82,14 +85,15 @@ public class EssentialsComponentsProperties {
 
     private final MultiTableChangeListenerProperties multiTableChangeListener = new MultiTableChangeListenerProperties();
 
-    private final LifeCycleProperties lifeCycles = new LifeCycleProperties();
-    private final TracingProperties tracingProperties = new TracingProperties();
-
-    private boolean             immutableJacksonModuleEnabled = true;
+    private final LifeCycleProperties lifeCycles                    = new LifeCycleProperties();
+    private final TracingProperties  tracingProperties             = new TracingProperties();
+    private final ReactiveProperties reactive                      = new ReactiveProperties();
+    private       boolean            immutableJacksonModuleEnabled = true;
 
     /**
      * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
      * Setting this value to false will not include the EssentialsImmutableJacksonModule, in the ObjectMapper configuration, even if Objenesis is on the classpath
+     *
      * @return Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration
      */
     public boolean isImmutableJacksonModuleEnabled() {
@@ -97,13 +101,18 @@ public class EssentialsComponentsProperties {
     }
 
     /**
-     /**
+     * /**
      * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
      * Setting this value to false will not include the EssentialsImmutableJacksonModule, in the ObjectMapper configuration, even if Objenesis is on the classpath
+     *
      * @param immutableJacksonModuleEnabled Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration
      */
     public void setImmutableJacksonModuleEnabled(boolean immutableJacksonModuleEnabled) {
         this.immutableJacksonModuleEnabled = immutableJacksonModuleEnabled;
+    }
+
+    public ReactiveProperties getReactive() {
+        return reactive;
     }
 
     public FencedLockManagerProperties getFencedLockManager() {
@@ -325,9 +334,9 @@ public class EssentialsComponentsProperties {
     }
 
     public static class FencedLockManagerProperties {
-        private Duration lockTimeOut              = Duration.ofSeconds(15);
-        private Duration lockConfirmationInterval = Duration.ofSeconds(4);
-        private String   fencedLocksTableName     = PostgresqlFencedLockStorage.DEFAULT_FENCED_LOCKS_TABLE_NAME;
+        private Duration lockTimeOut                                                    = Duration.ofSeconds(15);
+        private Duration lockConfirmationInterval                                       = Duration.ofSeconds(4);
+        private String   fencedLocksTableName                                           = PostgresqlFencedLockStorage.DEFAULT_FENCED_LOCKS_TABLE_NAME;
         private boolean  releaseAcquiredLocksInCaseOfIOExceptionsDuringLockConfirmation = false;
 
         /**
@@ -497,6 +506,7 @@ public class EssentialsComponentsProperties {
 
         /**
          * Get property to set as 'module' tag value for all micrometer metrics. This to differentiate metrics across different modules.
+         *
          * @return property to set as 'module' tag value for all micrometer metrics
          */
         public String getModuleTag() {
@@ -505,10 +515,88 @@ public class EssentialsComponentsProperties {
 
         /**
          * Set property to use as 'module' tag value for all micrometer metrics. This to differentiate metrics across different modules.
+         *
          * @param moduleTag property to set as 'module' tag value for all micrometer metrics
          */
         public void setModuleTag(String moduleTag) {
             this.moduleTag = moduleTag;
+        }
+    }
+
+    public static class ReactiveProperties {
+        private int    eventBusBackpressureBufferSize = LocalEventBus.DEFAULT_BACKPRESSURE_BUFFER_SIZE;
+        private int    parallelThreads                = Runtime.getRuntime().availableProcessors();
+        private int    overflowMaxRetries             = LocalEventBus.DEFAULT_OVERFLOW_MAX_RETRIES;
+        private double queuedTaskCapFactor            = LocalEventBus.QUEUED_TASK_CAP_FACTOR;
+
+        /**
+         * Get property to set as 'eventBusBackpressureBufferSize' value LocalEventBus back pressure size for {@link Sinks.Many}'s onBackpressureBuffer size. The default value set by reactor framework is {@value LocalEventBus#DEFAULT_BACKPRESSURE_BUFFER_SIZE}.
+         *
+         * @return property 'eventBusBackpressureBufferSize' used for value LocalEventBus Sinks.Many onBackpressureBuffer size.
+         */
+        public int getEventBusBackpressureBufferSize() {
+            return eventBusBackpressureBufferSize;
+        }
+
+        /**
+         * Set property 'eventBusBackpressureBufferSize'  value LocalEventBus back pressure size for {@link Sinks.Many}'s onBackpressureBuffer size. The default value set by reactor framework is {@value LocalEventBus#DEFAULT_BACKPRESSURE_BUFFER_SIZE}.
+         *
+         * @param eventBusBackpressureBufferSize property value 'eventBusBackpressureBufferSize' LocalEventBus Sinks.Many onBackpressureBuffer size.
+         */
+        public void setEventBusBackpressureBufferSize(int eventBusBackpressureBufferSize) {
+            this.eventBusBackpressureBufferSize = eventBusBackpressureBufferSize;
+        }
+
+        /**
+         * Get the number of parallel threads processing asynchronous events. Defaults to the number of available processors on the machine
+         *
+         * @return the number of parallel threads processing asynchronous events.
+         */
+        public int getParallelThreads() {
+            return parallelThreads;
+        }
+
+        /**
+         * Set the number of parallel threads processing asynchronous events. Defaults to the number of available processors on the machine
+         *
+         * @param parallelThreads the number of parallel threads processing asynchronous events.
+         */
+        public void setParallelThreads(int parallelThreads) {
+            this.parallelThreads = parallelThreads;
+        }
+
+        /**
+         * Set the maximum number of retries for events that overflow the Flux. Default is {@value LocalEventBus#DEFAULT_OVERFLOW_MAX_RETRIES}.
+         *
+         * @return the maximum number of retries for events that overflow the Flux
+         */
+        public int getOverflowMaxRetries() {
+            return overflowMaxRetries;
+        }
+
+        /**
+         * Get the maximum number of retries for events that overflow the Flux. Default is {@value LocalEventBus#DEFAULT_OVERFLOW_MAX_RETRIES}.
+         *
+         * @param overflowMaxRetries the maximum number of retries for events that overflow the Flux
+         */
+        public void setOverflowMaxRetries(int overflowMaxRetries) {
+            this.overflowMaxRetries = overflowMaxRetries;
+        }
+
+        /**
+         * Get the factor to calculate queued task capacity from the backpressureBufferSize. Default value is {@value LocalEventBus#QUEUED_TASK_CAP_FACTOR}.
+         * @return the factor to calculate queued task capacity from the backpressureBufferSize.
+         */
+        public double getQueuedTaskCapFactor() {
+            return queuedTaskCapFactor;
+        }
+
+        /**
+         * Set the factor to calculate queued task capacity from the backpressureBufferSize. Default value is {@value LocalEventBus#QUEUED_TASK_CAP_FACTOR}.
+         * @param queuedTaskCapFactor the factor to calculate queued task capacity from the backpressureBufferSize.
+         */
+        public void setQueuedTaskCapFactor(double queuedTaskCapFactor) {
+            this.queuedTaskCapFactor = queuedTaskCapFactor;
         }
     }
 }

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -101,7 +101,6 @@ public class EssentialsComponentsProperties {
     }
 
     /**
-     * /**
      * Should the EssentialsImmutableJacksonModule be included in the ObjectMapper configuration - default is true<br>
      * Setting this value to false will not include the EssentialsImmutableJacksonModule, in the ObjectMapper configuration, even if Objenesis is on the classpath
      *

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
@@ -22,7 +22,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
 @DirtiesContext
-class SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryTest extends OrderAggregateRootRepositoryTest {
+class SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryIT extends OrderAggregateRootRepositoryTest {
 
     @Override
     protected EventStoreUnitOfWorkFactory<? extends EventStoreUnitOfWork> createUnitOfWorkFactory() {

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
@@ -22,7 +22,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
 @DirtiesContext
-class SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryTest extends OrderAggregateRootRepositoryTest {
+class SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryIT extends OrderAggregateRootRepositoryTest {
 
     @Override
     protected EventStoreUnitOfWorkFactory<? extends EventStoreUnitOfWork> createUnitOfWorkFactory() {

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -36,7 +36,6 @@ import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonMod
 import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
 import dk.cloudcreate.essentials.shared.Exceptions;
 import dk.cloudcreate.essentials.shared.functional.TripleFunction;
-import dk.cloudcreate.essentials.shared.reflection.Classes;
 import org.slf4j.*;
 import org.springframework.data.annotation.*;
 import org.springframework.data.domain.Sort;
@@ -698,7 +697,7 @@ public final class MongoDurableQueues implements DurableQueues {
 
     private Object deserializeMessagePayload(QueueName queueName, byte[] messagePayload, String messagePayloadType) {
         try {
-            return jsonSerializer.deserialize(messagePayload, Classes.forName(messagePayloadType));
+            return jsonSerializer.deserialize(messagePayload, messagePayloadType);
         } catch (Throwable e) {
             throw new DurableQueueException(msg("Failed to deserialize message payload of type {}", messagePayloadType), e, queueName);
         }

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <kotlin.version>2.0.20</kotlin.version>
+        <kotlin.version>2.0.21</kotlin.version>
         <revision>DEV-SNAPSHOT</revision>
         <skipDependencyCheck>false</skipDependencyCheck>
 
@@ -70,25 +70,25 @@
         <slf4j.version>2.0.16</slf4j.version>
         <spring-boot.version>3.2.10</spring-boot.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <spring-data-mongodb.version>4.2.10</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.10</spring-data-jpa.version>
+        <spring-data-mongodb.version>4.2.11</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.2.11</spring-data-jpa.version>
         <assertj.version>3.26.3</assertj.version>
         <mongodb-driver-sync.version>4.11.4</mongodb-driver-sync.version>
-        <log4j-to-slf4j.version>2.24.0</log4j-to-slf4j.version>
+        <log4j-to-slf4j.version>2.24.1</log4j-to-slf4j.version>
         <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
         <snakeyaml.version>2.3</snakeyaml.version>
-        <micrometer.version>1.12.10</micrometer.version>
-        <micrometer-tracing.version>1.2.10</micrometer-tracing.version>
-        <netty-bom.version>4.1.113.Final</netty-bom.version>
-        <junit-bom.version>5.11.1</junit-bom.version>
+        <micrometer.version>1.12.11</micrometer.version>
+        <micrometer-tracing.version>1.2.11</micrometer-tracing.version>
+        <netty-bom.version>4.1.114.Final</netty-bom.version>
+        <junit-bom.version>5.11.2</junit-bom.version>
         <testcontainers-bom.version>1.20.2</testcontainers-bom.version>
-        <jdbi3-bom.version>3.45.4</jdbi3-bom.version>
+        <jdbi3-bom.version>3.46.0</jdbi3-bom.version>
         <jackson-bom.version>2.18.0</jackson-bom.version>
-        <reactor-bom.version>2023.0.10</reactor-bom.version>
-        <spring-framework-bom.version>6.1.13</spring-framework-bom.version>
-        <mockito-bom.version>5.14.1</mockito-bom.version>
-        <logback.version>1.5.8</logback.version>
+        <reactor-bom.version>2023.0.11</reactor-bom.version>
+        <spring-framework-bom.version>6.1.14</spring-framework-bom.version>
+        <mockito-bom.version>5.14.2</mockito-bom.version>
+        <logback.version>1.5.11</logback.version>
         <avro.version>1.12.0</avro.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
@@ -103,9 +103,9 @@
         <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.7.0</maven-javadoc-plugin.version>
-        <maven-failsafe-plugin.version>3.5.0</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
+        <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
+        <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,36 +65,36 @@
         <revision>DEV-SNAPSHOT</revision>
         <skipDependencyCheck>false</skipDependencyCheck>
 
+        <spring-boot.version>3.2.12</spring-boot.version>
+        <spring-framework-bom.version>6.1.15</spring-framework-bom.version>
+        <reactor-bom.version>2023.0.12</reactor-bom.version>
+        <spring-data-mongodb.version>4.2.12</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.2.12</spring-data-jpa.version>
         <objenesis.version>3.4</objenesis.version>
         <postgresql.version>42.7.4</postgresql.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <spring-boot.version>3.2.10</spring-boot.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <spring-data-mongodb.version>4.2.11</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.11</spring-data-jpa.version>
         <assertj.version>3.26.3</assertj.version>
-        <mongodb-driver-sync.version>4.11.4</mongodb-driver-sync.version>
-        <log4j-to-slf4j.version>2.24.1</log4j-to-slf4j.version>
+        <mongodb-driver-sync.version>4.11.5</mongodb-driver-sync.version>
+        <log4j-to-slf4j.version>2.24.2</log4j-to-slf4j.version>
         <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
         <snakeyaml.version>2.3</snakeyaml.version>
-        <micrometer.version>1.12.11</micrometer.version>
-        <micrometer-tracing.version>1.2.11</micrometer-tracing.version>
-        <netty-bom.version>4.1.114.Final</netty-bom.version>
-        <junit-bom.version>5.11.2</junit-bom.version>
-        <testcontainers-bom.version>1.20.2</testcontainers-bom.version>
-        <jdbi3-bom.version>3.46.0</jdbi3-bom.version>
-        <jackson-bom.version>2.18.0</jackson-bom.version>
-        <reactor-bom.version>2023.0.11</reactor-bom.version>
-        <spring-framework-bom.version>6.1.14</spring-framework-bom.version>
+        <micrometer.version>1.12.13</micrometer.version>
+        <micrometer-tracing.version>1.2.12</micrometer-tracing.version>
+        <netty-bom.version>4.1.115.Final</netty-bom.version>
+        <junit-bom.version>5.11.3</junit-bom.version>
+        <testcontainers-bom.version>1.20.4</testcontainers-bom.version>
+        <jdbi3-bom.version>3.47.0</jdbi3-bom.version>
+        <jackson-bom.version>2.18.1</jackson-bom.version>
         <mockito-bom.version>5.14.2</mockito-bom.version>
-        <logback.version>1.5.11</logback.version>
+        <logback.version>1.5.12</logback.version>
         <avro.version>1.12.0</avro.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
 
         <dokka.version>1.9.20</dokka.version>
-        <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <maven-project-info-reports-plugin.version>3.7.0</maven-project-info-reports-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
@@ -104,13 +104,13 @@
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
-        <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
+        <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>10.0.4</dependency-check-maven.version>
+        <dependency-check-maven.version>11.1.0</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventBus.java
@@ -16,6 +16,8 @@
 
 package dk.cloudcreate.essentials.reactive;
 
+import dk.cloudcreate.essentials.shared.Lifecycle;
+
 /**
  * Simple event bus concept that supports both synchronous and asynchronous subscribers that are registered and listening for events published<br>
  * <br>
@@ -56,7 +58,7 @@ package dk.cloudcreate.essentials.reactive;
  * @see LocalEventBus
  * @see AnnotatedEventHandler
  */
-public interface EventBus {
+public interface EventBus extends Lifecycle {
     /**
      * Publish the event to all subscribers/consumer<br>
      * First we call all asynchronous subscribers, after which we will call all synchronous subscribers on the calling thread (i.e. on the same thread that the publish method is called on)

--- a/reactive/src/test/resources/logback-test.xml
+++ b/reactive/src/test/resources/logback-test.xml
@@ -25,7 +25,13 @@
     </appender>
 
     <logger name="dk.cloudcreate.essentials" level="TRACE"/>
-    <logger name="LocalEventBus - Test" level="TRACE"/>
+    <logger name="LocalEventBus - AsyncMultiThreaded" level="TRACE"/>
+    <logger name="LocalEventBus - Test-MultiThread" level="TRACE"/>
+    <logger name="LocalEventBus - Test-Sync-Async" level="TRACE"/>
+    <logger name="LocalEventBus - InOrderAsyncSingleThreaded" level="TRACE"/>
+    <logger name="LocalEventBus - InOrderAsyncMultiThreaded" level="TRACE"/>
+    <logger name="LocalEventBus - Test-Async-Exception" level="TRACE"/>
+    <logger name="LocalEventBus - Test-Sync-Exception" level="TRACE"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/Lifecycle.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/Lifecycle.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.shared;
+
+/**
+ * Common process life cycle interface
+ */
+public interface Lifecycle {
+    /**
+     * Start the processing. This operation must be idempotent, such that duplicate calls
+     * to {@link #start()} for an already started process (where {@link #isStarted()} returns true)
+     * is ignored
+     */
+    void start();
+
+    /**
+     * Stop the processing. This operation must be idempotent, such that duplicate calls
+     * to {@link #stop()} for an already stopped process (where {@link #isStarted()} returns false)
+     * is ignored
+     */
+    void stop();
+
+    /**
+     * Returns true if the process is started
+     *
+     * @return true if the process is started otherwise false
+     */
+    boolean isStarted();
+}

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.17</version>
+    <version>0.40.18</version>
 </dependency>
 ```
 


### PR DESCRIPTION
- Clarified `Inbox`/`Outbox` `UnitOfWork`/transaction handling
- Improved lag logging in `SubscriberGlobalOrderMicrometerMonitor`
- All `Classes.forName` now use a classloader when converting Fully Qualified Java Class names to Class instances.
- Added `getClassLoader` and `setClassLoader` to `JSONSerializer` to encapsulate setting the class loader on the underlying JSON serializer implementation.
- Added new methods to `AggregateEventStreamPersistenceStrategy`
  - `resolveGlobalEventOrderSequenceName`
  - `findLowestGlobalEventOrderPersisted`
- Added `EventStore#findLowestGlobalEventOrderPersisted(AggregateType)`
- `PostgresqlDurableSubscriptionRepository`
  - Added `EventStore` a constructor argument
  - Removed `HandleAwareUnitOfWorkFactory<?> unitOfWorkFactory` argument from `PostgresqlDurableSubscriptionRepository`, which acquires the `HandleAwareUnitOfWorkFactory` from the `EventStore`
  - `createResumePoint` now uses `EventStore.findLowestGlobalEventOrderPersisted` to lookup the lowest `GlobalEventOrder` persisted and uses this value if it's greater than the provided `onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder` (which typically defaults to `GlobalEventOrder#FIRST_GLOBAL_EVENT_ORDER`)
    - This solves an issue where (Re)Subscriptions after the EventStream table(s) have been truncated, but the corresponding `GlobalEventOrder` sequence hasn't been reset, would result in a slow catchup towards the lowest persisted `GlobalEventOrder`, due to EventStream Gap detection being cautious with regards to how fast Subscriptions increase the global-event-order range that's included in EventStore polling requests.
- Switched to use log-level `DEBUG` for `SqlExecutionTimeLogger.logException`, instead of level `ERROR`
- Improved `PostgresqlEventStreamGapHandler` log output
- Improved the `OptimisticAppendToStreamException` detection in `SeparateTablePerAggregateTypePersistenceStrategy` and removed the cause exception from `OptimisticAppendToStreamException` and `AppendToStreamException`
- Improved `OptimisticAppendToStreamException` testing in `SingleTenantPostgresqlEventStoreIT`
- Improved EventJSON, EventMetaDataJSON, EventMetaData and PersistedEvent - added unit tests
- Improved `EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT` test
- Moved `Lifecycle` to the `Shared` module - kept `Lifecycle` in `Foundation` for backwards compatibility
- `EventBus` now extends `Lifecycle`
- Redesigned the `LocalEventBus`
  - Removed `Optional`'s from constructors and introduced a Builder
  - async publisher code, which now has improved Overflow handling. It supports controlling the Flux backpressure buffer size, queue task cap size, overflow max retries
  - Improved shutdown logic
- Improved `EventStoreEventBus`
  - Removed `Optional`'s from constructors
- Added equals/hashCode/toString to `EventJSONTest`
- Added `BeforeCommitProcessingStatus` return value to `UnitOfWorkLifecycleCallback#beforeCommit` to allow `GenericHandleAwareUnitOfWorkFactory` and `SpringTransactionAwareEventStoreUnitOfWorkFactory` to rerun the beforeCommit phase to capture aggregate changes resulting from in-transaction event handling (e.g. from code listening to the `EventBus`)
- Changed the `UnitOfWorkLifecycleCallback` in `FlexAggregateRepository` and `StatefulAggregateRepository` to return `BeforeCommitProcessingStatus.REQUIRED` as long as each beforeCommit run returns changes to aggregates.
- Added `info` method to `UnitOfWork`
- Added debug logging of `UnitOfWork#info` in `UnitOfWorkFactory`
- Added copying `PersistedEvent`'s list in `PersistedEvents` since the associated lists are reset in `EventStoreManagedUnitOfWork` across beforeCommit runs
- Adjusted before/after commit callback logic in `SpringTransactionAwareEventStoreUnitOfWorkFactory`
- Renamed Spring EventStore integration test classes from being called "Test" to "IT"
- Added `ReactiveProperties` to `EssentialsComponentsConfiguration` to allow controlling the `LocalEventBus`/`EventStoreEventBus` properties
- Updated README.md
- Added support for `exclusivelySubscribeToAggregateEventsInTransaction` in `EventStoreSubscriptionManager` (work in progress)
- Added `InTransactionEventProcessor` (work in progress)

Updated to Kotlin 2.0.21
Updated 3rd party dependencies
- Spring Boot 3.2.12
- Spring Framework 6.1.15
- Reactor 2023.0.12
- Spring Data MongoDB 4.2.12
- Spring Data JPA 3.2.12
- mongodb-driver-sync 4.11.5
- log4j-to-slf4j 2.24.2
- micrometer 1.12.13
- micrometer-tracing 1.2.12
- netty 4.1.115.Final
- JUnit 5.11.3
- TestContainers 1.20.4
- JDBI 3.47.0
- Jackson 2.18.1
- LogBack 1.5.12

Updated Maven plugins
- maven-javadoc-plugin 3.10.1
- maven-dependency-plugin 3.8.1
- maven-failsafe-plugin / maven-surefire-plugin 3.5.2
- versions-maven-plugin 2.18.0
- dependency-check-maven 11.1.0