### PR TITLE
issue 106 stop redelivery on exceptions root cause handling

### DIFF
--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
@@ -17,6 +17,7 @@
 package dk.cloudcreate.essentials.components.foundation.messaging;
 
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.shared.Exceptions;
 
 import java.util.List;
 
@@ -100,9 +101,10 @@ public interface MessageDeliveryErrorHandler {
 
         @Override
         public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
+            Class<? extends Throwable> rootCause = Exceptions.getRootCause(error).getClass();
             return exceptions.contains(error.getClass()) ||
                     exceptions.stream()
-                              .anyMatch(exception -> exception.isAssignableFrom(error.getClass()));
+                              .anyMatch(exception -> exception.isAssignableFrom(rootCause));
         }
 
         @Override

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
@@ -63,4 +63,24 @@ class MessageDeliveryErrorHandlerBuilderTest {
                                                  new ConnectException()))
                 .isFalse();
     }
+
+    @Test
+    void test_builder_with_stop_redelivery_on_stack_of_exceptions() {
+        var errorHandler = MessageDeliveryErrorHandler.builder()
+                                                      .stopRedeliveryOn(IllegalStateException.class, IllegalArgumentException.class)
+                                                      .build();
+
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new RuntimeException()))
+                .isFalse();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new RuntimeException(new IllegalStateException())))
+                .isTrue();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new Exception(new RuntimeException(new IllegalStateException()))))
+                .isTrue();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new Exception(new IllegalStateException(new RuntimeException()))))
+                .isFalse();
+    }
 }


### PR DESCRIPTION
https://github.com/cloudcreate-dk/essentials-project/issues/106

Added root cause retrieval from the exception to verify that with the registered ones. 

In case this is not the preferable approach please check other MR https://github.com/cloudcreate-dk/essentials-project/pull/108