### PR TITLE
Release 0.40.20

### DIFF
--- a/components/eventsourced-aggregates/pom.xml
+++ b/components/eventsourced-aggregates/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/Aggregate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/Aggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/AggregateException.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/AggregateException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventHandler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventsToPersist.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/EventsToPersist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OptimisticAggregateLoadException.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OptimisticAggregateLoadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/AggregateIdResolver.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/AggregateIdResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/CommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Decider.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Decider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Handler.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/HandlerResult.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/HandlerResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/InitialStateProvider.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/InitialStateProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/IsStateFinalResolver.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/IsStateFinalResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/StateEvolver.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/StateEvolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/View.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/View.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategy.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategy.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/BrokenSnapshot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/BrokenSnapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/DelayedAddAndDeleteAggregateSnapshotDelegate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/DelayedAddAndDeleteAggregateSnapshotDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregate.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInMemoryProjector.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInMemoryProjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInstanceFactory.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateInstanceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepository.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/AggregateRoot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/AggregateRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/Event.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/InitialEventIsMissingAggregateIdException.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/InitialEventIsMissingAggregateIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateRootWithState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateRootWithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/classic/state/AggregateState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateRoot.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/AggregateState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/WithState.java
+++ b/components/eventsourced-aggregates/src/main/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/modern/WithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/CustomerId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OrderId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductIdKeyDeserializer.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderAggregateRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderEvents.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/OrderEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/NoDefaultConstructorOrderEvents.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/NoDefaultConstructorOrderEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/OrderAggregateRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootWithStateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/objenesis/state/OrderWithStateAggregateRootWithStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootWithStateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/classic/state/OrderWithStateAggregateRootWithStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderBasedCommandHandlerIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderBasedCommandHandlerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/decider/DeciderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/FlexAggregateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/flex/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/AggregateRootTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/AggregateRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderAggregateRootRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderEvent.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/BiTemporalProductPriceIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/BiTemporalProductPriceIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/InitialPriceSet.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/InitialPriceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceAdjusted.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceAdjusted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceValidityAdjusted.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/PriceValidityAdjusted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductId.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPrice.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPrice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPriceEvent.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/bitemporal/ProductPriceEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/AggregateRootWithStateTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/AggregateRootWithStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/Order.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderAggregateRootWithStateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderAggregateRootWithStateRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderState.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/modern/with_state/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategyTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AddNewAggregateSnapshotStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategyTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/AggregateSnapshotDeletionStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepositoryTest.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_deleteAllHistoricSnapshotsIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_deleteAllHistoricSnapshotsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_keepALimitedNumberOfHistoricSnapshotsIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/snapshot/PostgresqlAggregateSnapshotRepository_keepALimitedNumberOfHistoricSnapshotsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryCombinedWithInTransactionEventProcessorIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryCombinedWithInTransactionEventProcessorIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryIT.java
+++ b/components/eventsourced-aggregates/src/test/java/dk/cloudcreate/essentials/components/eventsourced/aggregates/stateful/StatefulAggregateRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/eventsourced-aggregates/src/test/resources/logback-test.xml
+++ b/components/eventsourced-aggregates/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/foundation-test/pom.xml
+++ b/components/foundation-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManagerIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManager_MultiNode_ReleaseLockIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/fencedlock/DBFencedLockManager_MultiNode_ReleaseLockIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesLoadIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesLoadIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalCompetingConsumersDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/AccountId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/CustomerId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderEvent.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductEvent.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductId.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/reactive/command/AbstractDurableLocalCommandBusIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/reactive/command/AbstractDurableLocalCommandBusIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/pom.xml
+++ b/components/foundation-types/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateType.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventName.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventOrder.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types;
 
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
 import dk.cloudcreate.essentials.types.LongType;
 
 /**

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventRevision.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventRevision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventType.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeOrName.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeOrName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types;
 
-import dk.cloudcreate.essentials.shared.functional.tuple.Either;
-import dk.cloudcreate.essentials.shared.functional.tuple.Tuple;
+import dk.cloudcreate.essentials.shared.functional.tuple.*;
 
 import java.util.Optional;
 import java.util.function.Consumer;

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/GlobalEventOrder.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/GlobalEventOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,11 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
-import dk.cloudcreate.essentials.types.LongRange;
-import dk.cloudcreate.essentials.types.LongType;
+import dk.cloudcreate.essentials.types.*;
+
+import java.util.List;
+import java.util.stream.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/Revision.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/Revision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/CorrelationId.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/CorrelationId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/EventId.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/EventId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/MessageId.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/MessageId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/RandomIdGenerator.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/RandomIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/SubscriberId.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/SubscriberId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/Tenant.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/Tenant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/TenantId.java
+++ b/components/foundation-types/src/main/java/dk/cloudcreate/essentials/components/foundation/types/TenantId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/pom.xml
+++ b/components/foundation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
@@ -19,11 +19,8 @@ package dk.cloudcreate.essentials.components.foundation;
 import com.mongodb.MongoSocketException;
 import dk.cloudcreate.essentials.shared.Exceptions;
 import org.jdbi.v3.core.ConnectionException;
-import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
-import java.io.*;
-import java.net.ConnectException;
-import java.sql.SQLException;
+import java.io.IOException;
 import java.util.concurrent.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
@@ -42,28 +39,35 @@ public final class IOExceptionUtil {
      */
     public static boolean isIOException(Throwable e) {
         requireNonNull(e, "No exception provided");
-        var rootCause = Exceptions.getRootCause(e);
-        var rootCauseMessage  = rootCause != null && rootCause.getMessage() != null ? rootCause.getMessage() : "";
-        var message   = e.getMessage() != null ? e.getMessage() : "";
-        return (
-                (message.contains("An I/O error occurred while sending to the backend") && rootCause instanceof EOFException) ||
-                        (message.contains("Could not open JDBC Connection for transaction") && rootCause instanceof EOFException) ||
-                        (message.contains("Could not open JDBC Connection for transaction") && rootCause instanceof ConnectException) ||
-                        (message.contains("Could not open JDBC Connection for transaction") && rootCause instanceof SQLException && rootCauseMessage.contains("has been closed")) ||
-                        message.contains("Connection is closed") ||
-                        message.contains("Unable to acquire JDBC Connection") ||
-                        message.contains("Could not open JPA EntityManager for transaction") ||
-                        (rootCause != null && rootCause.getClass().getSimpleName().equals("ConnectionException")) ||
-                        (rootCause != null && rootCause.getClass().getSimpleName().equals("MongoSocketReadException")) ||
-                        (isClassAvailable("com.mongodb.MongoSocketException") && rootCause instanceof MongoSocketException) ||
-                        (isClassAvailable("org.jdbi.v3.core.statement.UnableToExecuteStatementException") && rootCause instanceof UnableToExecuteStatementException) ||
-                        rootCause instanceof IOException ||
-                        rootCause instanceof ConnectionException ||
-                        message.contains("has been closed")
-        );
+        var message = e.getMessage() != null ? e.getMessage() : "";
+
+        return e instanceof IOException ||
+                Exceptions.getRootCause(e) instanceof IOException ||
+                containsKnownErrorMessage(message) ||
+                isJdbiRelatedException(e) ||
+                isMongoRelatedException(e);
     }
 
-    private static boolean isClassAvailable(String className) {
+    private static boolean containsKnownErrorMessage(String message) {
+        return message.contains("An I/O error occurred while sending to the backend") ||
+                message.contains("Could not open JDBC Connection for transaction") ||
+                message.contains("Connection is closed") ||
+                message.contains("Unable to acquire JDBC Connection") ||
+                message.contains("Could not open JPA EntityManager for transaction");
+    }
+
+    private static boolean isMongoRelatedException(Throwable e) {
+        return (isClassAvailable("com.mongodb.MongoSocketException") &&
+                Exceptions.doesStackTraceContainExceptionOfType(e, MongoSocketException.class));
+    }
+
+    private static boolean isJdbiRelatedException(Throwable e) {
+        return e.getClass().getName().equals("org.jdbi.v3.core.ConnectionException") ||
+                (isClassAvailable("org.jdbi.v3.core.ConnectionException") && Exceptions.doesStackTraceContainExceptionOfType(e, ConnectionException.class));
+    }
+
+
+    static boolean isClassAvailable(String className) {
         return classCache.computeIfAbsent(className, key -> {
             try {
                 Class.forName(key);

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/Lifecycle.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/Lifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLock.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLockManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLock.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockEvents.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockStorage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/FencedLockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallback.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallbackBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockCallbackBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/LockName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONDeserializationException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONDeserializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializationException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JSONSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/json/JacksonJSONSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/ExponentialBackoffBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/ExponentialBackoffBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/FixedBackoffBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/FixedBackoffBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/LinearBackoffBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/LinearBackoffBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilder.java
@@ -17,6 +17,7 @@
 package dk.cloudcreate.essentials.components.foundation.messaging;
 
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuedMessage;
+import dk.cloudcreate.essentials.shared.Exceptions;
 
 import java.util.List;
 
@@ -110,7 +111,7 @@ public final class MessageDeliveryErrorHandlerBuilder {
             private boolean shouldAlwaysRetryOn(Throwable error) {
                 return alwaysRetryOnExceptions.contains(error.getClass()) ||
                         alwaysRetryOnExceptions.stream()
-                                               .anyMatch(exception -> exception.isAssignableFrom(error.getClass()));
+                                               .anyMatch(alwaysRetryOnException -> Exceptions.doesStackTraceContainExceptionOfType(error, alwaysRetryOnException));
             }
 
             @Override

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
@@ -176,6 +176,14 @@ public final class RedeliveryPolicy {
                         .build();
     }
 
+    /**
+     * If an exception occurs during message handling, the {@link #isPermanentError(QueuedMessage, Throwable)} will be called with
+     * only the top-level exception - the associated {@link MessageDeliveryErrorHandler#isPermanentError(QueuedMessage, Throwable)} must itself check the error exceptions causal chain
+     * to determine if it represents a permanent error.
+     * @param queuedMessage The message being processed by the message handler
+     * @param error the exception that occurred
+     * @return true if the error represents a permanent error, otherwise false
+     */
     public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
         return deliveryErrorHandler.isPermanentError(queuedMessage, error);
     }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicyBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inbox.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfig.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfigBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/InboxName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inboxes.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inboxes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inboxes.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Inboxes.java
@@ -20,6 +20,7 @@ import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.*;
 import dk.cloudcreate.essentials.reactive.command.CommandBus;
+import org.slf4j.*;
 
 import java.time.Duration;
 import java.util.*;
@@ -145,7 +146,7 @@ public interface Inboxes {
         }
 
         public class DurableQueueBasedInbox implements Inbox {
-
+            private static final Logger log = LoggerFactory.getLogger(DurableQueueBasedInbox.class);
             private      Consumer<Message>    messageConsumer;
             public final QueueName            inboxQueueName;
             public final InboxConfig          config;
@@ -183,16 +184,33 @@ public interface Inboxes {
                 if (this.messageConsumer == null) {
                     throw new IllegalStateException("No message consumer specified. Please call #setMessageConsumer");
                 }
+                log.info("Starting Consuming from Inbox '{}'", config.inboxName);
                 switch (config.messageConsumptionMode) {
                     case SingleGlobalConsumer:
-                        fencedLockManager.acquireLockAsync(config.inboxName.asLockName(),
+                        var lockName = config.inboxName.asLockName();
+                        log.info("Creating FencedLock '{}' for Consumer for Inbox '{}'", lockName, config.inboxName);
+                        fencedLockManager.acquireLockAsync(lockName,
                                                            LockCallback.builder()
-                                                                       .onLockAcquired(lock -> durableQueueConsumer = consumeFromDurableQueue(lock))
-                                                                       .onLockReleased(lock -> durableQueueConsumer.cancel())
+                                                                       .onLockAcquired(lock -> {
+                                                                           log.info("FencedLock '{}' for Inbox '{}' was ACQUIRED - will start Exclusive DurableQueueConsumer", lockName, config.inboxName);
+                                                                           durableQueueConsumer = consumeFromDurableQueue(lock);
+                                                                           log.info("Exclusive DurableQueueConsumer for Inbox '{}': {}", config.inboxName, durableQueueConsumer);
+                                                                       })
+                                                                       .onLockReleased(lock -> {
+                                                                           if (durableQueueConsumer != null) {
+                                                                               log.info("FencedLock '{}' for Inbox '{}' was RELEASED - will stop Exclusive DurableQueueConsumer: {}", lockName, config.inboxName, durableQueueConsumer);
+                                                                               durableQueueConsumer.cancel();
+                                                                               log.info("Stopped Exclusive DurableQueueConsumer for Inbox '{}': {}", config.inboxName, durableQueueConsumer);
+                                                                           } else {
+                                                                               log.warn("FencedLock '{}' for Inbox '{}' was RELEASED - didn't find an Exclusive DurableQueueConsumer!", lockName, config.inboxName);
+                                                                           }
+                                                                       })
                                                                        .build());
                         break;
                     case GlobalCompetingConsumers:
+                        log.info("Starting Non-Exclusive DurableQueueConsumer for Inbox '{}'", config.inboxName);
                         durableQueueConsumer = consumeFromDurableQueue(null);
+                        log.info("Non-Exclusive DurableQueueConsumer for Inbox '{}': {}", config.inboxName, durableQueueConsumer);
                         break;
                     default:
                         throw new IllegalStateException("Unexpected messageConsumptionMode: " + config.messageConsumptionMode);
@@ -213,13 +231,16 @@ public interface Inboxes {
             @Override
             public Inbox stopConsuming() {
                 if (messageConsumer != null) {
-
+                    log.info("Stop Consuming from Inbox '{}'", config.inboxName);
                     switch (config.messageConsumptionMode) {
                         case SingleGlobalConsumer:
-                            fencedLockManager.cancelAsyncLockAcquiring(config.inboxName.asLockName());
+                            var lockName = config.inboxName.asLockName();
+                            log.info("CancelAsyncLockAcquiring FencedLock '{}' for Inbox '{}'", lockName, config.inboxName);
+                            fencedLockManager.cancelAsyncLockAcquiring(lockName);
                             break;
                         case GlobalCompetingConsumers:
                             if (durableQueueConsumer != null) {
+                                log.info("Stopping Non-Exclusive DurableQueueConsumer for Inbox '{}': {}", config.inboxName, durableQueueConsumer);
                                 durableQueueConsumer.cancel();
                                 durableQueueConsumer = null;
                             }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageConsumptionMode.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageConsumptionMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageHandlerInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/MessageHandlerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outbox.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfig.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfigBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/OutboxName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/Outboxes.java
@@ -20,6 +20,7 @@ import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.*;
 import dk.cloudcreate.essentials.reactive.EventHandler;
+import org.slf4j.*;
 
 import java.time.Duration;
 import java.util.*;
@@ -144,7 +145,8 @@ public interface Outboxes {
         }
 
         public class DurableQueueBasedOutbox implements Outbox {
-            private      Consumer<Message>    messageConsumer;
+            private static final Logger            log = LoggerFactory.getLogger(DurableQueueBasedOutbox.class);
+            private              Consumer<Message> messageConsumer;
             public final QueueName            outboxQueueName;
             public final OutboxConfig         config;
             private      DurableQueueConsumer durableQueueConsumer;
@@ -192,16 +194,34 @@ public interface Outboxes {
                 if (this.messageConsumer == null) {
                     throw new IllegalStateException("No message consumer specified. Please call #setMessageConsumer");
                 }
+                log.info("Starting Consuming from Outbox '{}'", config.outboxName);
                 switch (config.messageConsumptionMode) {
                     case SingleGlobalConsumer:
+                        var lockName = config.outboxName.asLockName();
+                        log.info("Creating FencedLock '{}' for Consumer for Outbox '{}'", lockName, config.outboxName);
+
                         fencedLockManager.acquireLockAsync(config.outboxName.asLockName(),
                                                            LockCallback.builder()
-                                                                       .onLockAcquired(lock -> durableQueueConsumer = consumeFromDurableQueue(lock))
-                                                                       .onLockReleased(lock -> durableQueueConsumer.cancel())
+                                                                       .onLockAcquired(lock -> {
+                                                                           log.info("FencedLock '{}' for Outbox '{}' was ACQUIRED - will start Exclusive DurableQueueConsumer", lockName, config.outboxName);
+                                                                           durableQueueConsumer = consumeFromDurableQueue(lock);
+                                                                           log.info("Exclusive DurableQueueConsumer for Outbox '{}': {}", config.outboxName, durableQueueConsumer);
+                                                                       })
+                                                                       .onLockReleased(lock -> {
+                                                                           if (durableQueueConsumer != null) {
+                                                                               log.info("FencedLock '{}' for Outbox '{}' was RELEASED - will stop Exclusive DurableQueueConsumer: {}", lockName, config.outboxName, durableQueueConsumer);
+                                                                               durableQueueConsumer.cancel();
+                                                                               log.info("Stopped Exclusive DurableQueueConsumer for Outbox '{}': {}", config.outboxName, durableQueueConsumer);
+                                                                           } else {
+                                                                               log.warn("FencedLock '{}' for Outbox '{}' was RELEASED - didn't find an Exclusive DurableQueueConsumer!", lockName, config.outboxName);
+                                                                           }
+                                                                       })
                                                                        .build());
                         break;
                     case GlobalCompetingConsumers:
+                        log.info("Starting Non-Exclusive DurableQueueConsumer for Outbox '{}'", config.outboxName);
                         durableQueueConsumer = consumeFromDurableQueue(null);
+                        log.info("Non-Exclusive DurableQueueConsumer for Outbox '{}': {}", config.outboxName, durableQueueConsumer);
                         break;
                     default:
                         throw new IllegalStateException("Unexpected messageConsumptionMode: " + config.messageConsumptionMode);
@@ -212,13 +232,16 @@ public interface Outboxes {
             @Override
             public Outbox stopConsuming() {
                 if (messageConsumer != null) {
-
+                    log.info("Stop Consuming from Outbox '{}'", config.outboxName);
                     switch (config.messageConsumptionMode) {
                         case SingleGlobalConsumer:
-                            fencedLockManager.cancelAsyncLockAcquiring(config.outboxName.asLockName());
+                            var lockName = config.outboxName.asLockName();
+                            log.info("CancelAsyncLockAcquiring FencedLock '{}' for Outbox '{}'", lockName, config.outboxName);
+                            fencedLockManager.cancelAsyncLockAcquiring(lockName);
                             break;
                         case GlobalCompetingConsumers:
                             if (durableQueueConsumer != null) {
+                                log.info("Stopping Non-Exclusive DurableQueueConsumer for Outbox '{}': {}", config.outboxName, durableQueueConsumer);
                                 durableQueueConsumer.cancel();
                                 durableQueueConsumer = null;
                             }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandler.java
@@ -24,7 +24,8 @@ import dk.cloudcreate.essentials.shared.reflection.ReflectionException;
 import dk.cloudcreate.essentials.shared.reflection.invocation.*;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
 import static dk.cloudcreate.essentials.shared.FailFast.*;
@@ -80,7 +81,7 @@ public class PatternMatchingMessageHandler implements Consumer<Message> {
      */
     public PatternMatchingMessageHandler(Object invokeMessageHandlerMethodsOn, List<MessageHandlerInterceptor> interceptors) {
         this.invokeMessageHandlerMethodsOn = requireNonNull(invokeMessageHandlerMethodsOn, "No invokeMessageHandlerMethodsOn provided");
-        this.interceptors = new ArrayList<>(requireNonNull(interceptors, "No interceptors provided"));
+        this.interceptors = new CopyOnWriteArrayList<>(requireNonNull(interceptors, "No interceptors provided"));
         invoker = createMethodInvoker();
     }
 
@@ -98,7 +99,7 @@ public class PatternMatchingMessageHandler implements Consumer<Message> {
      */
     public PatternMatchingMessageHandler(List<MessageHandlerInterceptor> interceptors) {
         this.invokeMessageHandlerMethodsOn = this;
-        this.interceptors = new ArrayList<>(requireNonNull(interceptors, "No interceptors provided"));
+        this.interceptors = new CopyOnWriteArrayList<>(requireNonNull(interceptors, "No interceptors provided"));
         invoker = createMethodInvoker();
     }
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/operation/InvokeMessageHandlerMethod.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/operation/InvokeMessageHandlerMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultQueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultQueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultQueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultQueuedMessage.java
@@ -16,7 +16,7 @@
 
 package dk.cloudcreate.essentials.components.foundation.messaging.queue;
 
-import java.time.OffsetDateTime;
+import java.time.*;
 import java.util.Objects;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
@@ -39,6 +39,8 @@ public final class DefaultQueuedMessage implements QueuedMessage {
     public final int            redeliveryAttempts;
     public final boolean        isDeadLetterMessage;
     public final boolean        isBeingDelivered;
+
+    private Duration manuallyRequestedRedeliveryDelay;
 
     public DefaultQueuedMessage(QueueEntryId id,
                                 QueueName queueName,
@@ -105,6 +107,21 @@ public final class DefaultQueuedMessage implements QueuedMessage {
     }
 
     @Override
+    public void markForRedeliveryIn(Duration deliveryDelay) {
+        this.manuallyRequestedRedeliveryDelay = deliveryDelay;
+    }
+
+    @Override
+    public boolean isManuallyMarkedForRedelivery() {
+        return manuallyRequestedRedeliveryDelay != null;
+    }
+
+    @Override
+    public Duration getRedeliveryDelay() {
+        return manuallyRequestedRedeliveryDelay;
+    }
+
+    @Override
     public String getLastDeliveryError() {
         return lastDeliveryError;
     }
@@ -151,6 +168,7 @@ public final class DefaultQueuedMessage implements QueuedMessage {
                 ", redeliveryAttempts=" + redeliveryAttempts +
                 ", isDeadLetterMessage=" + isDeadLetterMessage +
                 ", isBeingDelivered=" + isBeingDelivered +
+                ", manuallyRequestedRedeliveryDelay=" + manuallyRequestedRedeliveryDelay +
                 '}';
     }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumer.java
@@ -28,5 +28,7 @@ import dk.cloudcreate.essentials.components.foundation.Lifecycle;
 public interface DurableQueueConsumer extends Lifecycle {
     QueueName queueName();
 
+    String consumerName();
+
     void cancel();
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumerNotifications.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueConsumerNotifications.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -435,7 +435,7 @@ public interface DurableQueues extends Lifecycle {
      * using {@link TransactionalMode#FullyTransactional}
      *
      * @param queueEntryId  the unique id of the message that must we will retry the delivery of
-     * @param causeForRetry the reason why the message delivery has to be retried
+     * @param causeForRetry the reason why the message delivery has to be retried (optional)
      * @param deliveryDelay how long will the queue wait until it delivers the message to the {@link DurableQueueConsumer}
      * @return the {@link QueuedMessage} message wrapped in an {@link Optional} if the operation was successful, otherwise it returns an {@link Optional#empty()}
      */

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueuesInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueuesInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/Message.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageMetaData.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/NextQueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/NextQueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/OrderedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/OrderedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueEntryId.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueEntryId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueName.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueueName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuePollingOptimizer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuePollingOptimizer.java
@@ -54,6 +54,11 @@ public interface QueuePollingOptimizer extends DurableQueueConsumerNotifications
             @Override
             public void messageAdded(QueuedMessage queuedMessage) {
             }
+
+            @Override
+            public String toString() {
+                return "NoQueuePollingOptimizer";
+            }
         };
     }
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuePollingOptimizer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuePollingOptimizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessage.java
@@ -16,9 +16,10 @@
 
 package dk.cloudcreate.essentials.components.foundation.messaging.queue;
 
+import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.*;
 
-import java.time.OffsetDateTime;
+import java.time.*;
 
 /**
  * Represents a {@link Message} that has been queued using {@link QueueMessage}/{@link QueueMessages}/{@link QueueMessageAsDeadLetterMessage}
@@ -128,4 +129,28 @@ public interface QueuedMessage {
      * @return the timestamp for when the message delivery started
      */
     OffsetDateTime getDeliveryTimestamp();
+
+    /**
+     * Mark the message for redelivery with the specified deliveryDelay - this manually requested redelivery counts towards the specified {@link RedeliveryPolicy#maximumNumberOfRedeliveries}<br>
+     * A {@link QueuedMessageHandler} can choose to call this method directly to have the message be redelivered.<br>
+     * <b>Note:</b> A {@link QueuedMessageHandler} should never directly call {@link DurableQueues#retryMessage(RetryMessage)} as this doesn't set the {@link #isManuallyMarkedForRedelivery()} flag
+     * which the {@link DefaultDurableQueueConsumer} relies upon for manually requested message redeliveries
+     *
+     * @param deliveryDelay how long will the queue wait until it delivers the message to the {@link DurableQueueConsumer}
+     */
+    void markForRedeliveryIn(Duration deliveryDelay);
+
+    /**
+     * Is the message marked for redelivery - i.e. {@link #markForRedeliveryIn(Duration)} has been called on the message
+     *
+     * @return Is the message marked for redelivery
+     */
+    boolean isManuallyMarkedForRedelivery();
+
+    /**
+     * In case {@link #isManuallyMarkedForRedelivery()} returns true, then this method will return the requested redelivery delay
+     *
+     * @return how long will the queue wait until it delivers the message to the {@link DurableQueueConsumer}
+     */
+    Duration getRedeliveryDelay();
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageCounts.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageHandler.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/QueuedMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/TransactionalMode.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/TransactionalMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerTracingInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/micrometer/DurableQueuesMicrometerTracingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandled.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandledBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/AcknowledgeMessageAsHandledBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueue.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueueBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ConsumeFromQueueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/DeleteMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessages.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessagesBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetDeadLetterMessagesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDelivery.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDelivery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDeliveryBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetNextMessageReadyForDeliveryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsFor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsForBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessageCountsForBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessages.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessagesBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetQueuedMessagesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedFor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedForBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalDeadLetterMessagesQueuedForBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedFor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedFor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedForBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/GetTotalMessagesQueuedForBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/MarkAsDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueue.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueueBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/PurgeQueueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageAsDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessages.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessagesBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/QueueMessagesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/ResurrectDeadLetterMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessage.java
@@ -31,6 +31,7 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  * Operation also matches {@link DurableQueuesInterceptor#intercept(RetryMessage, InterceptorChain)}
  */
 public final class RetryMessage {
+    public static final String MANUALLY_REQUESTED_REDELIVERY = "Manually requested redelivery";
     public final QueueEntryId queueEntryId;
     private      Throwable    causeForRetry;
     private      Duration     deliveryDelay;
@@ -50,7 +51,7 @@ public final class RetryMessage {
      * using {@link TransactionalMode#FullyTransactional}
      *
      * @param queueEntryId  the unique id of the message that must we will retry the delivery of
-     * @param causeForRetry the reason why the message delivery has to be retried
+     * @param causeForRetry the reason why the message delivery has to be retried (optional) - if left out {@link QueuedMessage#getLastDeliveryError()} will use value {@value #MANUALLY_REQUESTED_REDELIVERY}
      * @param deliveryDelay how long will the queue wait until it delivers the message to the {@link DurableQueueConsumer}
      */
     public RetryMessage(QueueEntryId queueEntryId, Throwable causeForRetry, Duration deliveryDelay) {
@@ -69,7 +70,7 @@ public final class RetryMessage {
 
     /**
      *
-     * @return the reason why the message delivery has to be retried
+     * @return the reason why the message delivery has to be retried (optional)
      */
     public Throwable getCauseForRetry() {
         return causeForRetry;
@@ -110,7 +111,6 @@ public final class RetryMessage {
 
     public void validate() {
         requireNonNull(queueEntryId, "You must provide a queueEntryId");
-        requireNonNull(causeForRetry, "You must provide a causeForRetry");
         requireNonNull(deliveryDelay, "You must provide a deliveryDelay");
     }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessageBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/RetryMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueue.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueueBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/operations/StopConsumingFromQueueBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/mongo/InvalidCollectionNameException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/mongo/InvalidCollectionNameException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/mongo/MongoUtil.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/mongo/MongoUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/InvalidTableOrColumnNameException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/InvalidTableOrColumnNameException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
@@ -16,6 +16,7 @@
 
 package dk.cloudcreate.essentials.components.foundation.postgresql;
 
+import dk.cloudcreate.essentials.components.foundation.IOExceptionUtil;
 import org.jdbi.v3.core.*;
 import org.postgresql.*;
 import org.slf4j.*;
@@ -388,15 +389,30 @@ public final class ListenNotify {
                                return Flux.empty();
                            }
                        } catch (ConnectionException | SQLException e) {
-                           log.error(msg("Failed to listen for notification for table '{}'", tableName),
-                                     e);
+                           if (IOExceptionUtil.isIOException(e)) {
+                               log.debug(msg("Failed to listen for notification for table '{}'", tableName),
+                                         e);
+                           } else {
+                               log.error(msg("Failed to listen for notification for table '{}'", tableName),
+                                         e);
+                           }
+
                            // This may be due to Connection issue, so let's close the handle and reset the reference
                            try {
-                               handle.close();
+                               if (handle != null) {
+                                   handle.close();
+                               }
                            } catch (Exception ex) {
-                               log.error(msg("Failed to close the listener Handle for table '{}'", tableName),
-                                         e);
-                               return Flux.error(ex);
+                               if (IOExceptionUtil.isIOException(ex)) {
+                                   log.debug(msg("Failed to close the listener Handle for table '{}'", tableName),
+                                             e);
+                                   return Flux.empty();
+                               } else {
+                                   log.error(msg("Failed to close the listener Handle for table '{}'", tableName),
+                                             e);
+
+                                   return Flux.error(ex);
+                               }
                            }
                            handleReference.set(null);
                            return Flux.empty();

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/NotificationDuplicationFilter.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/NotificationDuplicationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/NotificationFilterChain.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/NotificationFilterChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/PostgresqlUtil.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/PostgresqlUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/SqlExecutionTimeLogger.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/SqlExecutionTimeLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/TableChangeNotification.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/TableChangeNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBus.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBusBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBusBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/UnitOfWorkControllingCommandBusInterceptor.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/UnitOfWorkControllingCommandBusInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/NoActiveUnitOfWorkException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/NoActiveUnitOfWorkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkException.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkLifecycleCallback.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkLifecycleCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkStatus.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/UnitOfWorkStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/GenericHandleAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/GenericHandleAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/HandleAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/JdbiUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/jdbi/JdbiUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/mongo/ClientSessionAwareUnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/mongo/ClientSessionAwareUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWork.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/SpringTransactionAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/jdbi/SpringTransactionAwareJdbiUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/jdbi/SpringTransactionAwareJdbiUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/mongo/SpringMongoTransactionAwareUnitOfWorkFactory.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/transaction/spring/mongo/SpringMongoTransactionAwareUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation;
+
+import com.mongodb.*;
+import org.jdbi.v3.core.ConnectionException;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ConnectException;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IOExceptionUtilTest {
+
+    @Test
+    void shouldIdentifyIOException_whenRootCauseIsIOException() {
+        var ioException = new IOException("Root IO Exception");
+        assertThat(IOExceptionUtil.isIOException(ioException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMessageMatchesKnownErrors() {
+        assertThat(IOExceptionUtil.isIOException(new Exception("An I/O error occurred while sending to the backend"))).isTrue();
+        assertThat(IOExceptionUtil.isIOException(new Exception("Could not open JDBC Connection for transaction"))).isTrue();
+        assertThat(IOExceptionUtil.isIOException(new Exception("Connection is closed"))).isTrue();
+        assertThat(IOExceptionUtil.isIOException(new Exception("Unable to acquire JDBC Connection"))).isTrue();
+        assertThat(IOExceptionUtil.isIOException(new Exception("Could not open JPA EntityManager for transaction"))).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenSQLExceptionWithConnectException() {
+        var connectException = new ConnectException("Connection refused");
+        var sqlException     = new SQLException("Unable to acquire JDBC Connection", connectException);
+        assertThat(IOExceptionUtil.isIOException(sqlException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenSQLExceptionWithEOFException() {
+        var eofException = new EOFException("Simulated EOF");
+        var sqlException = new SQLException("Could not open JDBC Connection for transaction", eofException);
+        assertThat(IOExceptionUtil.isIOException(sqlException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenJPAHasIssuesOpeningATransaction() {
+        var rootCause       = new InterruptedException();
+        var hikariException = new SQLException("Hikari - Interrupted during connection acquisition", rootCause);
+        var transactionException = new org.springframework.transaction.CannotCreateTransactionException(
+                "Could not open JPA EntityManager for transaction", hikariException);
+
+        assertThat(IOExceptionUtil.isIOException(transactionException)).isTrue();
+    }
+
+    @Test
+    void shouldNotIdentifyIOException_forUnrelatedExceptions() {
+        var nullPointerException = new NullPointerException("This is not an IO exception");
+        assertThat(IOExceptionUtil.isIOException(nullPointerException)).isFalse();
+
+        var runtimeException = new RuntimeException("Generic runtime exception");
+        assertThat(IOExceptionUtil.isIOException(runtimeException)).isFalse();
+    }
+
+    // ---------------------- MongoDB ----------------------
+
+    @Test
+    void shouldIdentifyIOException_whenActualMongoSocketException() {
+        var mongoSocketException = new MongoSocketException("Simulated MongoSocketException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadException() {
+        var mongoSocketReadException = new MongoSocketReadException("Simulated MongoSocketReadException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketReadException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketClosedException() {
+        var mongoSocketClosedException = new MongoSocketClosedException("Simulated MongoSocketClosedException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketClosedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketOpenException() {
+        var mongoSocketOpenException = new MongoSocketOpenException("Simulated MongoSocketOpenException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketOpenException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketWriteException() {
+        var mongoSocketWriteException = new MongoSocketWriteException("Simulated MongoSocketWriteException", new ServerAddress(), new RuntimeException("Simulated RuntimeException"));
+        assertThat(IOExceptionUtil.isIOException(mongoSocketWriteException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadTimeoutException() {
+        var mongoSocketReadTimeoutException = new MongoSocketReadTimeoutException("Simulated MongoSocketReadTimeoutException", new ServerAddress(), new RuntimeException("Simulated RuntimeException"));
+        assertThat(IOExceptionUtil.isIOException(mongoSocketReadTimeoutException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenActualMongoSocketExceptionWrapped() {
+        var mongoSocketException = new MongoSocketException("Simulated MongoSocketException", new ServerAddress());
+        var wrappedException     = new RuntimeException("Wrapper exception", mongoSocketException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadExceptionWrapped() {
+        var mongoSocketReadException = new MongoSocketReadException("Simulated MongoSocketReadException", new ServerAddress());
+        var wrappedException         = new RuntimeException("Wrapper exception", mongoSocketReadException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketClosedExceptionWrapped() {
+        var mongoSocketClosedException = new MongoSocketClosedException("Simulated MongoSocketClosedException", new ServerAddress());
+        var wrappedException           = new RuntimeException("Wrapper exception", mongoSocketClosedException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketOpenExceptionWrapped() {
+        var mongoSocketOpenException = new MongoSocketOpenException("Simulated MongoSocketOpenException", new ServerAddress());
+        var wrappedException         = new RuntimeException("Wrapper exception", mongoSocketOpenException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketWriteExceptionWrapped() {
+        var mongoSocketWriteException = new MongoSocketWriteException(
+                "Simulated MongoSocketWriteException",
+                new ServerAddress(),
+                new RuntimeException("Simulated RuntimeException"));
+        var wrappedException = new RuntimeException("Wrapper exception", mongoSocketWriteException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadTimeoutExceptionWrapped() {
+        var mongoSocketReadTimeoutException = new MongoSocketReadTimeoutException(
+                "Simulated MongoSocketReadTimeoutException",
+                new ServerAddress(),
+                new RuntimeException("Simulated RuntimeException"));
+        var wrappedException = new RuntimeException("Wrapper exception", mongoSocketReadTimeoutException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    // ---------------------- JDBI ----------------------
+    @Test
+    void shouldIdentifyIOException_whenJdbiConnectionException() {
+        var jdbiException = new ConnectionException(new RuntimeException("Simulated RuntimeException"));
+        assertThat(IOExceptionUtil.isIOException(jdbiException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenActualConnectionException() {
+        var connectionException = new ConnectionException(new InterruptedException("Simulated exception"));
+        assertThat(IOExceptionUtil.isIOException(connectionException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenConnectionExceptionAsRootCause() {
+        // Test with ConnectionException as the root cause
+        var connectionException = new ConnectionException(new RuntimeException("Simulated RuntimeException"));
+        var wrappedException    = new RuntimeException("Wrapper exception", connectionException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+}

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManagerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/lifecycle/DefaultLifecycleManagerTest.java
@@ -3,7 +3,6 @@ package dk.cloudcreate.essentials.components.foundation.lifecycle;
 import dk.cloudcreate.essentials.shared.Lifecycle;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.*;
 
 import java.util.Map;
 import java.util.function.Consumer;
@@ -23,13 +22,11 @@ class DefaultLifecycleManagerTest {
         var manager = new DefaultLifecycleManager(true);
         manager.setApplicationContext(applicationContext);
 
-        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
-        verify(lifeCycleBean).start();
+        manager.start();
         verify(lifeCycleBean, times(0)).stop();
 
         when(lifeCycleBean.isStarted()).thenReturn(true);
-        manager.onApplicationEvent(mock(ContextClosedEvent.class));
-        verify(lifeCycleBean).stop();
+        manager.stop();
     }
 
     @Test
@@ -42,12 +39,12 @@ class DefaultLifecycleManagerTest {
         var manager = new DefaultLifecycleManager(true);
         manager.setApplicationContext(applicationContext);
 
-        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
+        manager.start();
         verify(lifecycleBean, times(0)).start();
     }
 
     @Test
-    void onContextRefreshedEventCustomConsumerTest() {
+    void onStartCustomConsumerTest() {
         var applicationContext = mock(ApplicationContext.class);
         when(applicationContext.getBeansOfType(Lifecycle.class)).thenReturn(Map.of());
 
@@ -55,7 +52,7 @@ class DefaultLifecycleManagerTest {
         var manager = new DefaultLifecycleManager(consumer, true);
         manager.setApplicationContext(applicationContext);
 
-        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
+        manager.start();
         verify(consumer).accept(applicationContext);
     }
 
@@ -64,11 +61,11 @@ class DefaultLifecycleManagerTest {
         var applicationContext = mock(ApplicationContext.class);
         var manager = new DefaultLifecycleManager(false);
         manager.setApplicationContext(applicationContext);
-        manager.onApplicationEvent(mock(ContextRefreshedEvent.class));
+        manager.start();
 
         verifyNoInteractions(applicationContext);
 
-        manager.onApplicationEvent(mock(ContextClosedEvent.class));
+        manager.stop();
 
         verifyNoInteractions(applicationContext);
     }

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
@@ -17,6 +17,7 @@
 package dk.cloudcreate.essentials.components.foundation.messaging;
 
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuedMessage;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -38,6 +39,18 @@ class MessageDeliveryErrorHandlerBuilderTest {
                                                  new IllegalStateException()))
                 .isTrue();
         assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException()))
+                .isFalse();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new RuntimeException())))
+                .isFalse();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new IllegalStateException())))
+                .isTrue();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new IllegalStateException(new RuntimeException()))))
+                .isTrue();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
                                                  new IllegalArgumentException()))
                 .isTrue();
     }
@@ -55,12 +68,36 @@ class MessageDeliveryErrorHandlerBuilderTest {
         assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
                                                  new IllegalStateException()))
                 .isTrue();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException()))
+                .isFalse();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new RuntimeException())))
+                .isFalse();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new IllegalStateException())))
+                .isTrue();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new IllegalStateException(new RuntimeException()))))
+                .isTrue();
+
         // Assert that alwaysRetryOn has higher priority than stopRedeliveryOn
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new ConnectException()))
+                .isFalse();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new ConnectException())))
+                .isFalse();
+
         assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
                                                  new IllegalArgumentException()))
                 .isFalse();
         assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
-                                                 new ConnectException()))
+                                                 new UnitOfWorkException(new IllegalArgumentException())))
                 .isFalse();
+        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+                                                 new UnitOfWorkException(new IllegalStateException(new IllegalArgumentException()))))
+                .isFalse();
+
     }
 }

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueInboxesTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueInboxesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueOutboxesTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/DurableQueueOutboxesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerWithInterceptorTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/eip/store_and_forward/PatternMatchingMessageHandlerWithInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandlerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/PatternMatchingQueuedMessageHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeOtherCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeOtherCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeThirdCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeThirdCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeUnmatchedCommand.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/test_data/SomeUnmatchedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/mongo/MongoUtilTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/mongo/MongoUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyIT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyPostgresql12IT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyPostgresql12IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerIT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerPostgresql12IT.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerPostgresql12IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/PostgresqlUtilTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/postgresql/PostgresqlUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/foundation/src/test/resources/logback-test.xml
+++ b/components/foundation/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/pom.xml
+++ b/components/kotlin-eventsourcing/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/AggregateTypeConfiguration.kt
+++ b/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/AggregateTypeConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/Decider.kt
+++ b/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/Decider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/EventOutOfOrderException.kt
+++ b/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/EventOutOfOrderException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/Evolver.kt
+++ b/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/Evolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/adapters/DeciderAndAggregateTypeConfigurator.kt
+++ b/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/adapters/DeciderAndAggregateTypeConfigurator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/adapters/DeciderCommandHandlerAdapter.kt
+++ b/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/adapters/DeciderCommandHandlerAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/test/GivenWhenThenScenario.kt
+++ b/components/kotlin-eventsourcing/src/main/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/test/GivenWhenThenScenario.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/kotlin-eventsourcing/src/test/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/test/GivenWhenThenScenarioTest.kt
+++ b/components/kotlin-eventsourcing/src/test/kotlin/dk/cloudcreate/essentials/components/kotlin/eventsourcing/test/GivenWhenThenScenarioTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/pom.xml
+++ b/components/postgresql-distributed-fenced-lock/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManager.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerBuilder.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockStorage.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameArgumentFactory.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameColumnMapper.java
+++ b/components/postgresql-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/jdbi/LockNameColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerIT.java
+++ b/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManager_MultiNode_ReleaseLockIT.java
+++ b/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockManager_MultiNode_ReleaseLockIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockStorageTest.java
+++ b/components/postgresql-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/postgresql/PostgresqlFencedLockStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-distributed-fenced-lock/src/test/resources/logback-test.xml
+++ b/components/postgresql-distributed-fenced-lock/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/pom.xml
+++ b/components/postgresql-document-db/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/DocumentDbRepository.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/DocumentDbRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/Version.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/VersionedEntity.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/VersionedEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/annotations/DocumentDBAnnotations.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/annotations/DocumentDBAnnotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/EntityConfiguration.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/EntityConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/PostgresqlDocumentDbRepository.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/PostgresqlDocumentDbRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/Query.kt
+++ b/components/postgresql-document-db/src/main/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/Query.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/CompositeDocumentDbRepositoryIT.kt
+++ b/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/CompositeDocumentDbRepositoryIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/Entities.kt
+++ b/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/Entities.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/EntityConfigurationTest.kt
+++ b/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/EntityConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
-import java.util.*
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 

--- a/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/PostgresqlDocumentDbRepositoryIT.kt
+++ b/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/PostgresqlDocumentDbRepositoryIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/QueryIT.kt
+++ b/components/postgresql-document-db/src/test/kotlin/dk/cloudcreate/essentials/components/document_db/postgresql/QueryIT.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-document-db/src/test/resources/logback-test.xml
+++ b/components/postgresql-document-db/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/pom.xml
+++ b/components/postgresql-event-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/AggregateNotFoundException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/AggregateNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/ConfigurableEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/ConfigurableEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreSubscription.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStoreSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/InMemoryProjector.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/InMemoryProjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStore.java
@@ -113,7 +113,7 @@ public final class PostgresqlEventStore<CONFIG extends AggregateEventStreamConfi
         this.eventStoreEventBus = eventStoreLocalEventBusOption.orElseGet(() -> new EventStoreEventBus(unitOfWorkFactory));
         this.eventStreamGapHandler = eventStreamGapHandlerFactory.apply(this);
 
-        eventStoreInterceptors = new ArrayList<>();
+        eventStoreInterceptors = new CopyOnWriteArrayList<>();
         inMemoryProjectors = new HashSet<>();
         inMemoryProjectorPerProjectionType = new ConcurrentHashMap<>();
     }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/CommitStage.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/CommitStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/EventStoreEventBus.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/EventStoreEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/bus/PersistedEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateEventStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/AggregateEventStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNames.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/IdentifierColumnType.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/IdentifierColumnType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/JSONColumnType.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/JSONColumnType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEvent.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/EventStreamGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/EventStreamGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/NoEventStreamGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/NoEventStreamGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/SubscriptionGapHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/SubscriptionGapHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptorChain.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/EventStoreInterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/micrometer/MicrometerTracingEventStoreInterceptor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/micrometer/MicrometerTracingEventStoreInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStreamBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/AppendToStreamBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStream.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStreamBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/FetchStreamBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEvent.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEvents.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrderBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadEventsByGlobalOrderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedTo.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedToBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/operations/LoadLastPersistedEventRelatedToBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfiguration.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfigurationFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamPersistenceStrategy.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AggregateEventStreamPersistenceStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AppendToStreamException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/AppendToStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/EventMetaData.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/EventMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/OptimisticAppendToStreamException.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/OptimisticAppendToStreamException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEvent.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/CorrelationIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventOrderColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/EventRevisionColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/jdbi/GlobalEventOrderColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistableEventEnricher.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistableEventEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistedEventRowMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PersistedEventRowMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PostgresqlEventStreamListener.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/PostgresqlEventStreamListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfiguration.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypeEventStreamConfigurationFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypeEventStreamConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategy.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
@@ -38,6 +38,7 @@ import org.slf4j.*;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -213,7 +214,7 @@ public abstract class EventProcessor implements Lifecycle {
         this.inboxes = requireNonNull(inboxes, "No inboxes instance provided");
         this.commandBus = requireNonNull(commandBus, "No commandBus provided");
         this.eventStore = requireNonNull(eventStoreSubscriptionManager.getEventStore(), "No eventStore is associated with the eventStoreSubscriptionManager provided");
-        this.messageHandlerInterceptors = requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors list provided");
+        this.messageHandlerInterceptors = new CopyOnWriteArrayList<>(requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors list provided"));
         setupCommandHandler();
     }
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependencies.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependenciesBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/EventProcessorDependenciesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
@@ -37,6 +37,7 @@ import dk.cloudcreate.essentials.reactive.command.*;
 import org.slf4j.*;
 
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -211,7 +212,7 @@ public abstract class InTransactionEventProcessor implements Lifecycle {
         this.eventStoreSubscriptionManager = requireNonNull(eventStoreSubscriptionManager, "No eventStoreSubscriptionManager provided");
         this.commandBus = requireNonNull(commandBus, "No commandBus provided");
         this.eventStore = requireNonNull(eventStoreSubscriptionManager.getEventStore(), "No eventStore is associated with the eventStoreSubscriptionManager provided");
-        this.messageHandlerInterceptors = requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors list provided");
+        this.messageHandlerInterceptors = new CopyOnWriteArrayList<>(requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors list provided"));
         this.useExclusively = useExclusively;
         setupCommandHandler();
     }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/AggregateIdSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/AggregateIdSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/TenantSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/TenantSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSON.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSON.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JSONEventSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JSONEventSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JacksonJSONEventSerializer.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/JacksonJSONEventSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/DurableSubscriptionRepository.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/DurableSubscriptionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManagerBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/FencedLockAwareSubscriber.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/FencedLockAwareSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
@@ -20,6 +20,7 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.E
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.AggregateType;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.jdbi.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
+import dk.cloudcreate.essentials.components.foundation.IOExceptionUtil;
 import dk.cloudcreate.essentials.components.foundation.postgresql.PostgresqlUtil;
 import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.HandleAwareUnitOfWorkFactory;
 import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
@@ -125,7 +126,7 @@ public final class PostgresqlDurableSubscriptionRepository implements DurableSub
                                          "resume_from_and_including_global_eventorder bigint,\n" +
                                          "last_updated TIMESTAMP WITH TIME ZONE,\n" +
                                          "PRIMARY KEY (subscriber_id, aggregate_type))");
-            log.info("Ensured '{}' table exists", durableSubscriptionsTableName);
+            log.info("Ensured '{}' table exists", this.durableSubscriptionsTableName);
         });
     }
 
@@ -223,47 +224,55 @@ public final class PostgresqlDurableSubscriptionRepository implements DurableSub
             log.trace("Received {} ResumePoints to save: {}", resumePoints.size(), resumePoints);
         }
 
-        unitOfWorkFactory.usingUnitOfWork(uow -> {
-            var now = OffsetDateTime.now(Clock.systemUTC());
-            var preparedBatch = uow.handle().prepareBatch("UPDATE " + this.durableSubscriptionsTableName +
-                                                                  " SET resume_from_and_including_global_eventorder = :resume_from_and_including_global_eventorder, last_updated = :last_updated " +
-                                                                  " WHERE aggregate_type = :aggregate_type AND subscriber_id = :subscriber_id");
+        try {
+            unitOfWorkFactory.usingUnitOfWork(uow -> {
+                var now = OffsetDateTime.now(Clock.systemUTC());
+                var preparedBatch = uow.handle().prepareBatch("UPDATE " + this.durableSubscriptionsTableName +
+                                                                      " SET resume_from_and_including_global_eventorder = :resume_from_and_including_global_eventorder, last_updated = :last_updated " +
+                                                                      " WHERE aggregate_type = :aggregate_type AND subscriber_id = :subscriber_id");
 
-            // TODO: Optimize filtering to happen outside db trx
-            resumePoints.forEach(subscriptionResumePoint -> {
-                if (!subscriptionResumePoint.isChanged()) {
-                    log.debug("Wont save Unchanged {}", subscriptionResumePoint);
-                    return;
-                }
-                log.debug("Saving {}", subscriptionResumePoint);
-                preparedBatch
-                        .bind("aggregate_type", subscriptionResumePoint.getAggregateType())
-                        .bind("subscriber_id", subscriptionResumePoint.getSubscriberId())
-                        .bind("resume_from_and_including_global_eventorder", subscriptionResumePoint.getResumeFromAndIncluding())
-                        .bind("last_updated", now)
-                        .add();
-            });
+                // TODO: Optimize filtering to happen outside db trx
+                resumePoints.forEach(subscriptionResumePoint -> {
+                    if (!subscriptionResumePoint.isChanged()) {
+                        log.debug("Wont save Unchanged {}", subscriptionResumePoint);
+                        return;
+                    }
+                    log.debug("Saving {}", subscriptionResumePoint);
+                    preparedBatch
+                            .bind("aggregate_type", subscriptionResumePoint.getAggregateType())
+                            .bind("subscriber_id", subscriptionResumePoint.getSubscriberId())
+                            .bind("resume_from_and_including_global_eventorder", subscriptionResumePoint.getResumeFromAndIncluding())
+                            .bind("last_updated", now)
+                            .add();
+                });
 
-            var batchSize = preparedBatch.size();
-            var rowsUpdated = Arrays.stream(preparedBatch.execute())
-                                    .reduce(Integer::sum).orElse(0);
-            resumePoints.forEach(subscriptionResumePoint -> {
-                if (subscriptionResumePoint.isChanged()) {
-                    subscriptionResumePoint.setLastUpdated(now);
+                var batchSize = preparedBatch.size();
+                var rowsUpdated = Arrays.stream(preparedBatch.execute())
+                                        .reduce(Integer::sum).orElse(0);
+                resumePoints.forEach(subscriptionResumePoint -> {
+                    if (subscriptionResumePoint.isChanged()) {
+                        subscriptionResumePoint.setLastUpdated(now);
+                    }
+                });
+                if (log.isTraceEnabled()) {
+                    log.trace("Saved {} resumePoints out of {} resulting in {} updated rows: {}",
+                              batchSize,
+                              resumePoints.size(),
+                              rowsUpdated,
+                              resumePoints);
+                } else {
+                    log.debug("Saved {} resumePoints out of {} resulting in {} updated rows",
+                              batchSize,
+                              resumePoints.size(),
+                              rowsUpdated);
                 }
             });
-            if (log.isTraceEnabled()) {
-                log.trace("Saved {} resumePoints out of {} resulting in {} updated rows: {}",
-                          batchSize,
-                          resumePoints.size(),
-                          rowsUpdated,
-                          resumePoints);
+        } catch (Exception e) {
+            if (IOExceptionUtil.isIOException(e)) {
+                log.trace("Failed to save the {} ResumePoints", resumePoints.size(), e);
             } else {
-                log.debug("Saved {} resumePoints out of {} resulting in {} updated rows",
-                          batchSize,
-                          resumePoints.size(),
-                          rowsUpdated);
+                log.error("Failed to save the {} ResumePoints", resumePoints.size(), e);
             }
-        });
+        }
     }
 }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionResumePoint.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/SubscriptionResumePoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/TransactionalPersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/TransactionalPersistedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/AggregateTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdArgumentFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdColumnMapper.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/jdbi/SubscriberIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWorkFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreManagedUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWork.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,8 @@ import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.E
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.bus.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.interceptor.FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStream;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager.DefaultEventStoreSubscriptionManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.TransactionalPersistedEventHandler;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
 import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.HandleAwareUnitOfWork;
 import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWorkFactory.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/EventStoreUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/PersistedEventsCommitLifecycleCallback.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/transaction/PersistedEventsCommitLifecycleCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/main/kotlin/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/StringValueTypeAggregateIdSerializer.kt
+++ b/components/postgresql-event-store/src/main/kotlin/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/StringValueTypeAggregateIdSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/MultiTenantPostgresqlEventStoreIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/MultiTenantPostgresqlEventStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStoreBenchmark.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/PostgresqlEventStoreBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/SingleTenantPostgresqlEventStoreIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesBuilderTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/EventStreamTableColumnNamesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEventTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/eventstream/PersistedEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandlerIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/gap/PostgresqlEventStreamGapHandlerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStreamIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/interceptor/FlushAndPublishPersistedEventsToEventBusRightAfterAppendToStreamIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/PersistableEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfigurationTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateEventStreamConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategyTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/persistence/table_per_aggregate_type/SeparateTablePerAggregateTypePersistenceStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSONTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventJSONTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSONTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/serializer/json/EventMetaDataJSONTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_2_node_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_2_node_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_with_large_initial_globaleventorder_gap_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_exclusivelySubscribeToAggregateEventsAsynchronously_with_large_initial_globaleventorder_gap_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsAsynchronously_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_WithFlushAndPublish_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager_subscribeToAggregateEventsInTransaction_WithFlushAndPublish_IT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandlerTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingPersistedEventHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandlerTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PatternMatchingTransactionalPersistedEventHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepositoryTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/CustomerId.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderEvent.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderId.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductEvent.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductId.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeTest.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/types/EventTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-event-store/src/test/resources/logback-test.xml
+++ b/components/postgresql-event-store/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/pom.xml
+++ b/components/postgresql-queue/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueueConsumer.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -89,7 +89,7 @@ public final class PostgresqlDurableQueues implements DurableQueues {
     private final String                                                        sharedQueueTableName;
     private final ConcurrentMap<QueueName, PostgresqlDurableQueueConsumer>      durableQueueConsumers                 = new ConcurrentHashMap<>();
     private final QueuedMessageRowMapper                                        queuedMessageMapper;
-    private final List<DurableQueuesInterceptor>                                interceptors                          = new ArrayList<>();
+    private final List<DurableQueuesInterceptor>                                interceptors                          = new CopyOnWriteArrayList<>();
     private final Optional<MultiTableChangeListener<TableChangeNotification>>   multiTableChangeListener;
     private final Function<ConsumeFromQueue, QueuePollingOptimizer>             queuePollingOptimizerFactory;
     private final TransactionalMode                                             transactionalMode;
@@ -480,6 +480,12 @@ public final class PostgresqlDurableQueues implements DurableQueues {
             if (started) {
                 consumer.start();
             }
+            log.info("[{}] {} - {} {}",
+                     operation.queueName,
+                     operation.consumerName,
+                     started ? "Started" : "Created",
+                     consumer.getClass().getSimpleName()
+                     );
             return consumer;
         });
     }

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesBuilder.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/QueueNameDuplicationFilter.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/QueueNameDuplicationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdArgumentFactory.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdColumnMapper.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueEntryIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameArgumentFactory.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameColumnMapper.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/jdbi/QueueNameColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation;
+
+import org.jdbi.v3.core.ConnectionException;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ConnectException;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Related to IOExceptionUtilTest in Foundation, with the goal of verifying
+ * that any lack of MongoDB dependencies will not result in {@link NoClassDefFoundError}'s
+ */
+public class IOExceptionUtilTest {
+
+    @Test
+    void shouldIdentifyIOException_whenRootCauseIsIOException() {
+        var ioException = new IOException("Root IO Exception");
+        assertThat(IOExceptionUtil.isIOException(ioException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenSQLExceptionWithConnectException() {
+        var connectException = new ConnectException("Connection refused");
+        var sqlException     = new SQLException("Unable to acquire JDBC Connection", connectException);
+        assertThat(IOExceptionUtil.isIOException(sqlException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenSQLExceptionWithEOFException() {
+        var eofException = new EOFException("Simulated EOF");
+        var sqlException = new SQLException("Could not open JDBC Connection for transaction", eofException);
+        assertThat(IOExceptionUtil.isIOException(sqlException)).isTrue();
+    }
+
+    @Test
+    void shouldNotIdentifyIOException_forUnrelatedExceptions() {
+        var nullPointerException = new NullPointerException("This is not an IO exception");
+        assertThat(IOExceptionUtil.isIOException(nullPointerException)).isFalse();
+
+        var runtimeException = new RuntimeException("Generic runtime exception");
+        assertThat(IOExceptionUtil.isIOException(runtimeException)).isFalse();
+    }
+
+    // ---------------------- JDBI ----------------------
+    @Test
+    void shouldIdentifyIOException_whenJdbiConnectionException() {
+        var jdbiException = new ConnectionException(new RuntimeException("Simulated RuntimeException"));
+        assertThat(IOExceptionUtil.isIOException(jdbiException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenActualConnectionException() {
+        var connectionException = new ConnectionException(new InterruptedException("Simulated exception"));
+        assertThat(IOExceptionUtil.isIOException(connectionException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenConnectionExceptionAsRootCause() {
+        // Test with ConnectionException as the root cause
+        var connectionException = new ConnectionException(new RuntimeException("Simulated RuntimeException"));
+        var wrappedException    = new RuntimeException("Wrapper exception", connectionException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+}

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBusIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBusIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBus_withSingleOperationTransactionIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBus_withSingleOperationTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesLoadIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesLoadIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesTest.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/CustomerId.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderEvent.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderId.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductEvent.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductId.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/postgresql-queue/src/test/resources/logback-test.xml
+++ b/components/postgresql-queue/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/pom.xml
+++ b/components/spring-boot-starter-mongodb/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalCharSequenceTypesSupported.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalCharSequenceTypesSupported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalConverters.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/AdditionalConverters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-mongodb/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/mongodb/EssentialsComponentsProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql-event-store/pom.xml
+++ b/components/spring-boot-starter-postgresql-event-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EssentialsEventStoreProperties.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EssentialsEventStoreProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,16 @@
 
 package dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.eventstore;
 
-import java.time.Duration;
-
 import dk.cloudcreate.essentials.components.boot.autoconfigure.postgresql.EssentialsComponentsConfiguration;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.PostgresqlEventStore;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.EventStreamTableColumnNames;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.IdentifierColumnType;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.JSONColumnType;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.NoEventStreamGapHandler;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypePersistenceStrategy;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.PostgresqlDurableSubscriptionRepository;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.SubscriptionResumePoint;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
 
 /**
  * Properties for the Postgresql EventStore<br>

--- a/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
+++ b/components/spring-boot-starter-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/eventstore/EventStoreConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/pom.xml
+++ b/components/spring-boot-starter-postgresql/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/JdbiConfigurationCallback.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/JdbiConfigurationCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/pom.xml
+++ b/components/spring-postgresql-event-store/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory.java
+++ b/components/spring-postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/ApplicationTests.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/ApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/OrderAggregateRootRepositoryTest.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/OrderAggregateRootRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringManagedUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/SpringTransactionAwareEventStoreUnitOfWorkFactory_OrderAggregateRootRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/CustomerId.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/Order.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderEvent.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderId.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderState.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/OrderState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/ProductId.java
+++ b/components/spring-postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/spring/test_data/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/spring-postgresql-event-store/src/test/resources/logback-test.xml
+++ b/components/spring-postgresql-event-store/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/pom.xml
+++ b/components/springdata-mongo-distributed-fenced-lock/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManager.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerBuilder.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockStorage.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/main/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/ApplicationTests.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/ApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManagerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManager_MultiNode_ReleaseLockIT.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockManager_MultiNode_ReleaseLockIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockStorageTest.java
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/java/dk/cloudcreate/essentials/components/distributed/fencedlock/springdata/mongo/MongoFencedLockStorageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-distributed-fenced-lock/src/test/resources/logback-test.xml
+++ b/components/springdata-mongo-distributed-fenced-lock/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/pom.xml
+++ b/components/springdata-mongo-queue/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueueConsumer.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueueConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -100,7 +100,7 @@ public final class MongoDurableQueues implements DurableQueues {
     protected final String                                              sharedQueueCollectionName;
     private final   ConcurrentMap<QueueName, MongoDurableQueueConsumer> durableQueueConsumers = new ConcurrentHashMap<>();
     private final   ConcurrentMap<QueueName, ReentrantLock>             localQueuePollLock    = new ConcurrentHashMap<>();
-    private final   List<DurableQueuesInterceptor>                      interceptors          = new ArrayList<>();
+    private final   List<DurableQueuesInterceptor>                      interceptors          = new CopyOnWriteArrayList<>();
     private final   MessageListenerContainer                            messageListenerContainer;
 
 
@@ -1385,6 +1385,12 @@ public final class MongoDurableQueues implements DurableQueues {
             if (started) {
                 consumer.start();
             }
+            log.info("[{}] {} - {} {}",
+                     operation.queueName,
+                     operation.consumerName,
+                     started ? "Started" : "Created",
+                     consumer.getClass().getSimpleName()
+                    );
             return consumer;
         });
     }

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.foundation;
+
+import com.mongodb.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ConnectException;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Related to IOExceptionUtilTest in Foundation, with the goal of verifying
+ * that any lack of Jdbi dependencies will not result in {@link NoClassDefFoundError}'s
+ */
+public class IOExceptionUtilTest {
+
+    @Test
+    void shouldIdentifyIOException_whenRootCauseIsIOException() {
+        var ioException = new IOException("Root IO Exception");
+        assertThat(IOExceptionUtil.isIOException(ioException)).isTrue();
+    }
+
+
+    @Test
+    void shouldIdentifyIOException_whenSQLExceptionWithConnectException() {
+        var connectException = new ConnectException("Connection refused");
+        var sqlException     = new SQLException("Unable to acquire JDBC Connection", connectException);
+        assertThat(IOExceptionUtil.isIOException(sqlException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenSQLExceptionWithEOFException() {
+        var eofException = new EOFException("Simulated EOF");
+        var sqlException = new SQLException("Could not open JDBC Connection for transaction", eofException);
+        assertThat(IOExceptionUtil.isIOException(sqlException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenJPAHasIssuesOpeningATransaction() {
+        var rootCause       = new InterruptedException();
+        var hikariException = new SQLException("Hikari - Interrupted during connection acquisition", rootCause);
+        var transactionException = new org.springframework.transaction.CannotCreateTransactionException(
+                "Could not open JPA EntityManager for transaction", hikariException);
+
+        assertThat(IOExceptionUtil.isIOException(transactionException)).isTrue();
+    }
+
+    @Test
+    void shouldNotIdentifyIOException_forUnrelatedExceptions() {
+        var nullPointerException = new NullPointerException("This is not an IO exception");
+        assertThat(IOExceptionUtil.isIOException(nullPointerException)).isFalse();
+
+        var runtimeException = new RuntimeException("Generic runtime exception");
+        assertThat(IOExceptionUtil.isIOException(runtimeException)).isFalse();
+    }
+
+    // ---------------------- MongoDB ----------------------
+
+    @Test
+    void shouldIdentifyIOException_whenActualMongoSocketException() {
+        var mongoSocketException = new MongoSocketException("Simulated MongoSocketException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadException() {
+        var mongoSocketReadException = new MongoSocketReadException("Simulated MongoSocketReadException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketReadException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketClosedException() {
+        var mongoSocketClosedException = new MongoSocketClosedException("Simulated MongoSocketClosedException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketClosedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketOpenException() {
+        var mongoSocketOpenException = new MongoSocketOpenException("Simulated MongoSocketOpenException", new ServerAddress());
+        assertThat(IOExceptionUtil.isIOException(mongoSocketOpenException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketWriteException() {
+        var mongoSocketWriteException = new MongoSocketWriteException("Simulated MongoSocketWriteException", new ServerAddress(), new RuntimeException("Simulated RuntimeException"));
+        assertThat(IOExceptionUtil.isIOException(mongoSocketWriteException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadTimeoutException() {
+        var mongoSocketReadTimeoutException = new MongoSocketReadTimeoutException("Simulated MongoSocketReadTimeoutException", new ServerAddress(), new RuntimeException("Simulated RuntimeException"));
+        assertThat(IOExceptionUtil.isIOException(mongoSocketReadTimeoutException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenActualMongoSocketExceptionWrapped() {
+        var mongoSocketException = new MongoSocketException("Simulated MongoSocketException", new ServerAddress());
+        var wrappedException     = new RuntimeException("Wrapper exception", mongoSocketException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadExceptionWrapped() {
+        var mongoSocketReadException = new MongoSocketReadException("Simulated MongoSocketReadException", new ServerAddress());
+        var wrappedException         = new RuntimeException("Wrapper exception", mongoSocketReadException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketClosedExceptionWrapped() {
+        var mongoSocketClosedException = new MongoSocketClosedException("Simulated MongoSocketClosedException", new ServerAddress());
+        var wrappedException           = new RuntimeException("Wrapper exception", mongoSocketClosedException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketOpenExceptionWrapped() {
+        var mongoSocketOpenException = new MongoSocketOpenException("Simulated MongoSocketOpenException", new ServerAddress());
+        var wrappedException         = new RuntimeException("Wrapper exception", mongoSocketOpenException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketWriteExceptionWrapped() {
+        var mongoSocketWriteException = new MongoSocketWriteException(
+                "Simulated MongoSocketWriteException",
+                new ServerAddress(),
+                new RuntimeException("Simulated RuntimeException"));
+        var wrappedException = new RuntimeException("Wrapper exception", mongoSocketWriteException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenMongoSocketReadTimeoutExceptionWrapped() {
+        var mongoSocketReadTimeoutException = new MongoSocketReadTimeoutException(
+                "Simulated MongoSocketReadTimeoutException",
+                new ServerAddress(),
+                new RuntimeException("Simulated RuntimeException"));
+        var wrappedException = new RuntimeException("Wrapper exception", mongoSocketReadTimeoutException);
+        assertThat(IOExceptionUtil.isIOException(wrappedException)).isTrue();
+    }
+}

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ApplicationTests.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/ApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBusIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBusIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBus_withSingleOperationTransactionIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/DurableLocalCommandBus_withSingleOperationTransactionIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIndexIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesIndexIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesTest.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDistributedCompetingConsumersDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDurableQueuesIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoDurableQueuesIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoLocalCompetingConsumersDurableQueueIT.java
+++ b/components/springdata-mongo-queue/src/test/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/SingleOperationTransactionMongoLocalCompetingConsumersDurableQueueIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/components/springdata-mongo-queue/src/test/resources/logback-test.xml
+++ b/components/springdata-mongo-queue/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/immutable-jackson/pom.xml
+++ b/immutable-jackson/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModule.java
+++ b/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/ImmutableObjectsValueInstantiator.java
+++ b/immutable-jackson/src/main/java/dk/cloudcreate/essentials/jackson/immutable/ImmutableObjectsValueInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModuleTest.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/EssentialsImmutableJacksonModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/AccountId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/CustomerId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableOrder.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableSerializationTestSubject.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ImmutableSerializationTestSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/OrderId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductId.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductIdKeyDeserializer.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/Quantity.java
+++ b/immutable-jackson/src/test/java/dk/cloudcreate/essentials/jackson/immutable/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/pom.xml
+++ b/immutable/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/immutable/src/main/java/dk/cloudcreate/essentials/immutable/Immutable.java
+++ b/immutable/src/main/java/dk/cloudcreate/essentials/immutable/Immutable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/main/java/dk/cloudcreate/essentials/immutable/ImmutableValueObject.java
+++ b/immutable/src/main/java/dk/cloudcreate/essentials/immutable/ImmutableValueObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/main/java/dk/cloudcreate/essentials/immutable/annotations/Exclude.java
+++ b/immutable/src/main/java/dk/cloudcreate/essentials/immutable/annotations/Exclude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/ImmutableValueObjectTest.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/ImmutableValueObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/AccountId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/CustomerId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ImmutableOrder.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ImmutableOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/OrderId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ProductId.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/Quantity.java
+++ b/immutable/src/test/java/dk/cloudcreate/essentials/immutable/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,14 @@
 
         <spring-boot.version>3.2.12</spring-boot.version>
         <spring-framework-bom.version>6.1.16</spring-framework-bom.version>
-        <reactor-bom.version>2023.0.13</reactor-bom.version>
+        <reactor-bom.version>2023.0.14</reactor-bom.version>
         <spring-data-mongodb.version>4.2.12</spring-data-mongodb.version>
         <spring-data-jpa.version>3.2.12</spring-data-jpa.version>
         <objenesis.version>3.4</objenesis.version>
-        <postgresql.version>42.7.4</postgresql.version>
+        <postgresql.version>42.7.5</postgresql.version>
         <slf4j.version>2.0.16</slf4j.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <assertj.version>3.27.2</assertj.version>
+        <assertj.version>3.27.3</assertj.version>
         <mongodb-driver-sync.version>4.11.5</mongodb-driver-sync.version>
         <log4j-to-slf4j.version>2.24.3</log4j-to-slf4j.version>
         <json-smart.version>2.5.1</json-smart.version>
@@ -82,7 +82,7 @@
         <snakeyaml.version>2.3</snakeyaml.version>
         <micrometer.version>1.12.13</micrometer.version>
         <micrometer-tracing.version>1.2.12</micrometer-tracing.version>
-        <netty-bom.version>4.1.116.Final</netty-bom.version>
+        <netty-bom.version>4.1.117.Final</netty-bom.version>
         <junit-bom.version>5.11.4</junit-bom.version>
         <testcontainers-bom.version>1.20.4</testcontainers-bom.version>
         <jdbi3-bom.version>3.47.0</jdbi3-bom.version>
@@ -110,7 +110,7 @@
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>12.0.0</dependency-check-maven.version>
+        <dependency-check-maven.version>12.0.1</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,51 +66,51 @@
         <skipDependencyCheck>false</skipDependencyCheck>
 
         <spring-boot.version>3.2.12</spring-boot.version>
-        <spring-framework-bom.version>6.1.15</spring-framework-bom.version>
-        <reactor-bom.version>2023.0.12</reactor-bom.version>
+        <spring-framework-bom.version>6.1.16</spring-framework-bom.version>
+        <reactor-bom.version>2023.0.13</reactor-bom.version>
         <spring-data-mongodb.version>4.2.12</spring-data-mongodb.version>
         <spring-data-jpa.version>3.2.12</spring-data-jpa.version>
         <objenesis.version>3.4</objenesis.version>
         <postgresql.version>42.7.4</postgresql.version>
         <slf4j.version>2.0.16</slf4j.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <assertj.version>3.26.3</assertj.version>
+        <assertj.version>3.27.2</assertj.version>
         <mongodb-driver-sync.version>4.11.5</mongodb-driver-sync.version>
-        <log4j-to-slf4j.version>2.24.2</log4j-to-slf4j.version>
+        <log4j-to-slf4j.version>2.24.3</log4j-to-slf4j.version>
         <json-smart.version>2.5.1</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
         <snakeyaml.version>2.3</snakeyaml.version>
         <micrometer.version>1.12.13</micrometer.version>
         <micrometer-tracing.version>1.2.12</micrometer-tracing.version>
-        <netty-bom.version>4.1.115.Final</netty-bom.version>
-        <junit-bom.version>5.11.3</junit-bom.version>
+        <netty-bom.version>4.1.116.Final</netty-bom.version>
+        <junit-bom.version>5.11.4</junit-bom.version>
         <testcontainers-bom.version>1.20.4</testcontainers-bom.version>
         <jdbi3-bom.version>3.47.0</jdbi3-bom.version>
-        <jackson-bom.version>2.18.1</jackson-bom.version>
-        <mockito-bom.version>5.14.2</mockito-bom.version>
-        <logback.version>1.5.12</logback.version>
+        <jackson-bom.version>2.18.2</jackson-bom.version>
+        <mockito-bom.version>5.15.2</mockito-bom.version>
+        <logback.version>1.5.16</logback.version>
         <avro.version>1.12.0</avro.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
 
-        <dokka.version>1.9.20</dokka.version>
+        <dokka.version>2.0.0</dokka.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
-        <maven-project-info-reports-plugin.version>3.7.0</maven-project-info-reports-plugin.version>
+        <maven-project-info-reports-plugin.version>3.8.0</maven-project-info-reports-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
         <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
-        <maven-site-plugin.version>3.20.0</maven-site-plugin.version>
+        <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>11.1.0</dependency-check-maven.version>
+        <dependency-check-maven.version>12.0.0</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactive/pom.xml
+++ b/reactive/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/Handler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/LocalEventBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/LocalEventBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/OnErrorHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/OnErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AbstractCommandBus.java
@@ -37,7 +37,7 @@ import static dk.cloudcreate.essentials.shared.interceptor.DefaultInterceptorCha
 public abstract class AbstractCommandBus implements CommandBus {
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
-    protected final List<CommandBusInterceptor> interceptors    = new ArrayList<>();
+    protected final List<CommandBusInterceptor> interceptors    = new CopyOnWriteArrayList<>();
     protected final Set<CommandHandler>         commandHandlers = new HashSet<>();
     protected final SendAndDontWaitErrorHandler sendAndDontWaitErrorHandler;
 

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CmdHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CmdHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/CommandHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBus.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/MultipleCommandHandlersFoundException.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/MultipleCommandHandlersFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/NoCommandHandlerFoundException.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/NoCommandHandlerFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendAndDontWaitErrorHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendAndDontWaitErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendCommandException.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendCommandException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptor.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptorChain.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/interceptor/CommandBusInterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/AsyncEventHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/AsyncEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessor.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandlerTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/AnnotatedEventHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/LocalEventBusTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/LocalEventBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandlerTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/AnnotatedCommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBusTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/LocalCommandBusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/interceptor/DefaultCommandBusInterceptorChainTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/command/interceptor/DefaultCommandBusInterceptorChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessorTest.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersBeanPostProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersConfiguration.java
+++ b/reactive/src/test/java/dk/cloudcreate/essentials/reactive/spring/ReactiveHandlersConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/reactive/src/test/resources/logback-test.xml
+++ b/reactive/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/Exceptions.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/Exceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/FailFast.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/FailFast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/Lifecycle.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/Lifecycle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/MessageFormatter.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/MessageFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Lists.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Lists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Streams.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Streams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/concurrent/ThreadFactoryBuilder.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/concurrent/ThreadFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumer.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedExceptionRethrownException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedExceptionRethrownException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnable.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplier.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/TripleFunction.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/TripleFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Either.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Either.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Empty.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Empty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Pair.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Single.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Single.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Triple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Triple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Tuple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableEmpty.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableEmpty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparablePair.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparablePair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableSingle.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableSingle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTriple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTriple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTuple.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChain.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/Interceptor.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/Interceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorChain.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/interceptor/InterceptorOrder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/ElseIfExpression.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/ElseIfExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfExpression.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfPredicate.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfThenElseLogic.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/logic/IfThenElseLogic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/AbstractMessageTemplate.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/AbstractMessageTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/Message.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate0.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate1.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate2.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate3.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate4.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplate4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplates.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/messages/MessageTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/network/Network.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/network/Network.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Accessibles.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Accessibles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/BoxedTypes.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/BoxedTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Classes.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Classes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Constructors.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Constructors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Fields.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Fields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/GetFieldException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/GetFieldException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Interfaces.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Interfaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/LoadingClassFailedException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/LoadingClassFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/MethodInvocationFailedException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/MethodInvocationFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Methods.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Methods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoFieldFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoFieldFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoMatchingMethodFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/NoMatchingMethodFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Parameters.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/ReflectionException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/ReflectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Reflector.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/Reflector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/SetFieldException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/SetFieldException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingFieldsFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingFieldsFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingMethodsFoundException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/TooManyMatchingMethodsFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationException.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationStrategy.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/InvocationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/MethodPatternMatcher.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/MethodPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/NoMatchingMethodsHandler.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/NoMatchingMethodsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/SingleArgumentAnnotatedMethodPatternMatcher.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/reflection/invocation/SingleArgumentAnnotatedMethodPatternMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/time/StopWatch.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/time/StopWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/time/Timing.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/time/Timing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/time/TimingWithResult.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/time/TimingWithResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/types/GenericType.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/types/GenericType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/ExceptionsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/ExceptionsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.shared;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ExceptionsTest {
+
+    @Test
+    void shouldReturnTrue_whenExceptionMatchesType() {
+        var exception = new RuntimeException("Test exception");
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, RuntimeException.class)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrue_whenCauseMatchesType() {
+        var cause = new IllegalArgumentException("Cause exception");
+        var exception = new RuntimeException("Wrapper exception", cause);
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, IllegalArgumentException.class)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrue_whenRootCauseMatchesType() {
+        var rootCause = new IllegalStateException("Nested cause");
+        var nestedCause = new RuntimeException("Cause exception", rootCause);
+        var exception = new RuntimeException("Wrapper exception", nestedCause);
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, IllegalStateException.class)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrue_whenNestedCauseMatchesType() {
+        var rootCause = new RuntimeException("Cause exception");
+        var nestedCause = new IllegalStateException("Nested cause", rootCause);
+        var exception = new RuntimeException("Wrapper exception", nestedCause);
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, IllegalStateException.class)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrue_whenTopLevelExceptionMatchesType() {
+        var rootCause = new NullPointerException("Cause exception");
+        var nestedCause = new IllegalStateException("Nested cause", rootCause);
+        var exception = new SQLException("Wrapper exception", nestedCause);
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, SQLException.class)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalse_whenTypeDoesNotMatch() {
+        var exception = new RuntimeException("Test exception");
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, IllegalArgumentException.class)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenExceptionChainDoesNotMatchType() {
+        var cause = new IllegalArgumentException("Cause exception");
+        var exception = new RuntimeException("Wrapper exception", cause);
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, IllegalStateException.class)).isFalse();
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionForNullInputs() {
+        assertThatThrownBy(() -> Exceptions.doesStackTraceContainExceptionOfType(new RuntimeException("Test exception"), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You must supply an exception type");
+
+        assertThatThrownBy(() -> Exceptions.doesStackTraceContainExceptionOfType(null, RuntimeException.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You must supply an exception");
+    }
+
+    @Test
+    void shouldHandleCircularReferenceInExceptionChain() {
+        var exception = new RuntimeException("Outer exception");
+        var innerException = new RuntimeException("Inner exception");
+        exception.initCause(innerException);
+        innerException.initCause(exception); // Create circular reference
+
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, RuntimeException.class)).isTrue();
+        assertThat(Exceptions.doesStackTraceContainExceptionOfType(exception, IllegalArgumentException.class)).isFalse();
+    }
+
+    @Test
+    void shouldSneakyThrowCheckedException() {
+        assertThatThrownBy(() -> Exceptions.sneakyThrow(new Exception("Checked exception")))
+                .isInstanceOf(Exception.class)
+                .hasMessage("Checked exception");
+    }
+
+    @Test
+    void shouldSneakyThrowRuntimeException() {
+        assertThatThrownBy(() -> Exceptions.sneakyThrow(new IllegalStateException("IllegalStateException msg")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("IllegalStateException msg");
+    }
+
+    @Test
+    void shouldSneakyThrowIllegalArgumentExceptionWhenNullSupplied() {
+        assertThatThrownBy(() -> Exceptions.sneakyThrow(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You must supply an exception");
+    }
+
+    @Test
+    void shouldReturnStackTraceAsString() {
+        var exception = new RuntimeException("Simulated exception");
+        var stackTrace = Exceptions.getStackTrace(exception);
+
+        assertThat(stackTrace).contains("RuntimeException: Simulated exception");
+        assertThat(stackTrace).contains("at"); // Validate some stack trace content
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenGetStackTraceCalledWithNull() {
+        assertThatThrownBy(() -> Exceptions.getStackTrace(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You must specify a throwable");
+    }
+
+    @Test
+    void shouldReturnRootCause() {
+        var rootCause = new IllegalArgumentException("Root cause exception");
+        var middleException = new RuntimeException("Middle exception", rootCause);
+        var topException = new Exception("Top-level exception", middleException);
+
+        assertThat(Exceptions.getRootCause(topException)).isSameAs(rootCause);
+    }
+
+    @Test
+    void shouldReturnRootCauseWhenExceptionHasNoCause() {
+        var exception = new RuntimeException("Standalone exception");
+        assertThat(Exceptions.getRootCause(exception)).isSameAs(exception);
+    }
+
+    @Test
+    void shouldHandleCircularReferencesInGetRootCause() {
+        var topException = new RuntimeException("Top-level exception");
+        var middleException = new RuntimeException("Middle exception", topException);
+        topException.initCause(middleException);
+
+        assertThat(Exceptions.getRootCause(topException)).isSameAs(middleException);
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionWhenGetRootCauseCalledWithNull() {
+        assertThatThrownBy(() -> Exceptions.getRootCause(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You must supply an exception");
+    }
+}

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/MessageFormatterTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/MessageFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/ListsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/ListsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/StreamsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/collections/StreamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunctionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedBiFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumerTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedConsumerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedFunctionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnableTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedRunnableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplierTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedSupplierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunctionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/CheckedTripleFunctionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/PairTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/PairTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/TupleTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/TupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTupleTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/functional/tuple/comparable/ComparableTupleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChainTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/interceptor/DefaultInterceptorChainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/logic/IfExpressionTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/logic/IfExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MessageTemplatesTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MessageTemplatesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MyMessageTemplates.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/messages/MyMessageTemplates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ClassesTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ClassesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ConstructorsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ConstructorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/FieldsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/FieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/InterfacesTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/InterfacesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/MethodsTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/MethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ParametersTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ReflectorTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/ReflectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvokerTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvokerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker_with_MessageHandlerTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/PatternMatchingMethodInvoker_with_MessageHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/EventHandler.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/Message.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandler.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithoutFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/MessageHandlerWithoutFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderAccepted.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderAccepted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCancelled.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCancelled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCreated.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderCreated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEvent.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithoutFallback.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/invocation/test_subjects/OrderEventHandlerWithoutFallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseInterface.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseTestReflectionClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/BaseTestReflectionClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/ConcreteClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/ConcreteClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericInterface.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/GenericInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestInterface.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestReflectionClass.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/reflection/test_subjects/TestReflectionClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/time/StopWatchTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/time/StopWatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/types/GenericTypeTest.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/types/GenericTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/java/dk/cloudcreate/essentials/shared/types/TestSubject.java
+++ b/shared/src/test/java/dk/cloudcreate/essentials/shared/types/TestSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shared/src/test/resources/logback-test.xml
+++ b/shared/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-avro/pom.xml
+++ b/types-avro/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/AmountLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseBigDecimalTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseBigDecimalTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseCharSequenceConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseCharSequenceConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseDoubleTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseDoubleTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseFloatTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseFloatTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseInstantTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseInstantTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseIntegerTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseIntegerTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalDateTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLocalTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLongTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseLongTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseOffsetDateTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseOffsetDateTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseZonedDateTimeTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BaseZonedDateTimeTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BigDecimalTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/BigDecimalTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CharSequenceTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CharSequenceTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CountryCodeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/CurrencyCodeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/DoubleTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/DoubleTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/EmailAddressLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/FloatTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/FloatTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/InstantTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/InstantTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/IntegerTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/IntegerTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalDateTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/LocalTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/OffsetDateTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/OffsetDateTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/PercentageLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/SingleConcreteBigDecimalTypeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/SingleConcreteBigDecimalTypeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/ZonedDateTimeTypeLogicalType.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/ZonedDateTimeTypeLogicalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/CreatedLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/DueDateLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/LastUpdatedLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/OrderIdLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TimeOfDayLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransactionTimeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeConversion.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeLogicalTypeFactory.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/TransferTimeLogicalTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/package-info.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/Created.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/DueDate.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/LastUpdated.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/OrderId.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TimeOfDay.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransactionTime.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransferTime.java
+++ b/types-avro/src/main/java/dk/cloudcreate/essentials/types/avro/test/types/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-avro/src/test/java/dk/cloudcreate/essentials/types/avro/CustomConversionsTest.java
+++ b/types-avro/src/test/java/dk/cloudcreate/essentials/types/avro/CustomConversionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/pom.xml
+++ b/types-jackson/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/CharSequenceTypeJsonSerializer.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/CharSequenceTypeJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/EssentialTypesJacksonModule.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/EssentialTypesJacksonModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/MoneyDeserializer.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/MoneyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/NumberTypeJsonSerializer.java
+++ b/types-jackson/src/main/java/dk/cloudcreate/essentials/jackson/types/NumberTypeJsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/EssentialTypesJacksonModuleTest.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/EssentialTypesJacksonModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/AccountId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Created.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/CustomerId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/DueDate.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/LastUpdated.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/OrderId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductId.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductIdKeyDeserializer.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Quantity.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/SerializationTestSubject.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/SerializationTestSubject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TimeOfDay.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransactionTime.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransferTime.java
+++ b/types-jackson/src/test/java/dk/cloudcreate/essentials/jackson/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/pom.xml
+++ b/types-jdbi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/AmountColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigDecimalTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BigIntegerTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BooleanTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BooleanTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package dk.cloudcreate.essentials.types.jdbi;
 
-import dk.cloudcreate.essentials.types.BigDecimalType;
 import dk.cloudcreate.essentials.types.BooleanType;
 import org.jdbi.v3.core.argument.*;
 import org.jdbi.v3.core.config.ConfigRegistry;

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BooleanTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/BooleanTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ByteTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CharSequenceTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CountryCodeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/CurrencyCodeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/DoubleTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/EmailAddressColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/FloatTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/InstantTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/IntegerTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalDateTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LocalTimeTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/LongTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/OffsetDateTimeTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/PercentageColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ShortTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeArgumentFactory.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeColumnMapper.java
+++ b/types-jdbi/src/main/java/dk/cloudcreate/essentials/types/jdbi/ZonedDateTimeTypeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/AmountArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/AmountArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/AmountColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/AmountColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigDecimalValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BigIntegerValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BooleanValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BooleanValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BooleanValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/BooleanValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ByteValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/CountryCodeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/CountryCodeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/CountryCodeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/CountryCodeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/DoubleValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/FloatValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/InstantValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/IntValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateTimeValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalDateValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LocalTimeValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/LongValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/OffsetDateTimeValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ShortValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/StringValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeArgumentFactory.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeArgumentFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeColumnMapper.kt
+++ b/types-jdbi/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/ZonedDateTimeValueTypeColumnMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/SingleValueTypeArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/AccountIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/Created.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CreatedColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/CustomerIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDate.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/DueDateColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdated.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/LastUpdatedColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/OrderIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductId.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/ProductIdColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDay.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TimeOfDayColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTime.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransactionTimeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTime.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeArgumentFactory.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeArgumentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeColumnMapper.java
+++ b/types-jdbi/src/test/java/dk/cloudcreate/essentials/types/jdbi/model/TransferTimeColumnMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/KotlinValueTypeArgumentsTest.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/KotlinValueTypeArgumentsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *   
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/AccountId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/AccountId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/Created.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/Created.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/CustomertId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/CustomertId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/DueDate.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/DueDate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/LastUpdated.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/LastUpdated.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/OrderId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/OrderId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/ProductId.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/ProductId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TimeOfDay.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TimeOfDay.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package dk.cloudcreate.essentials.kotlin.types.jdbi.model
 import dk.cloudcreate.essentials.kotlin.types.LocalTimeValueType
 import dk.cloudcreate.essentials.kotlin.types.jdbi.LocalTimeValueTypeArgumentFactory
 import dk.cloudcreate.essentials.kotlin.types.jdbi.LocalTimeValueTypeColumnMapper
-import java.sql.Time
 import java.time.LocalTime
 
 @JvmInline

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransactionTime.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransactionTime.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransferTime.kt
+++ b/types-jdbi/src/test/kotlin/dk/cloudcreate/essentials/kotlin/types/jdbi/model/TransferTime.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-jdbi/src/test/resources/logback-test.xml
+++ b/types-jdbi/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-spring-web/pom.xml
+++ b/types-spring-web/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-spring-web/src/main/java/dk/cloudcreate/essentials/types/spring/web/SingleValueTypeConverter.java
+++ b/types-spring-web/src/main/java/dk/cloudcreate/essentials/types/spring/web/SingleValueTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxConfig.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxControllerIT.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebFluxControllerIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcConfig.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcControllerTest.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcSpringWebApplication.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/WebMvcSpringWebApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebFluxController.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebFluxController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebMvcController.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/controllers/WebMvcController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/AccountId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Created.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/CustomerId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/DueDate.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/LastUpdated.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Order.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/OrderId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductId.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductIdKeyDeserializer.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/ProductIdKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Quantity.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TimeOfDay.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransactionTime.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransferTime.java
+++ b/types-spring-web/src/test/java/dk/cloudcreate/essentials/types/spring/web/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-spring-web/src/test/resources/logback-test.xml
+++ b/types-spring-web/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/pom.xml
+++ b/types-springdata-jpa/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AmountAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AmountAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseBigDecimalTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseBigDecimalTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseByteTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseByteTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseCharSequenceTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseCharSequenceTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseDoubleTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseDoubleTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseFloatTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseFloatTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseInstantTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseInstantTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseIntegerTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseIntegerTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalDateTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLocalTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLongTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseLongTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseOffsetDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseOffsetDateTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseShortTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseShortTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseZonedDateTimeTypeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/BaseZonedDateTimeTypeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CountryCodeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CountryCodeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CurrencyCodeAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CurrencyCodeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/EmailAddressAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/EmailAddressAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/PercentageAttributeConverter.java
+++ b/types-springdata-jpa/src/main/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/PercentageAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/OrderRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/ProductRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/TypesSpringDataJpaApplicationTests.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/TypesSpringDataJpaApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AccountIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/AccountIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CreatedAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CreatedAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CustomerIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/CustomerIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/DueDateAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/DueDateAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/LastUpdatedAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/LastUpdatedAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/OrderIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/OrderIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/ProductIdAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/ProductIdAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/QuantityAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/QuantityAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TimeOfDayAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TimeOfDayAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransactionTimeAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransactionTimeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransferTimeAttributeConverter.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/converters/TransferTimeAttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/AccountId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Created.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/CustomerId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/DueDate.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/LastUpdated.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderRepository.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/OrderRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Price.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Price.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductId.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductRepository.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/ProductRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Quantity.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TimeOfDay.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransactionTime.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransferTime.java
+++ b/types-springdata-jpa/src/test/java/dk/cloudcreate/essentials/types/springdata/jpa/model/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-jpa/src/test/resources/logback-test.xml
+++ b/types-springdata-jpa/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/pom.xml
+++ b/types-springdata-mongo/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeConverter.java
+++ b/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeRandomIdGenerator.java
+++ b/types-springdata-mongo/src/main/java/dk/cloudcreate/essentials/types/springdata/mongo/SingleValueTypeRandomIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/OrderRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/ProductRepositoryIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/TypesSpringDataMongoApplicationTests.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/TypesSpringDataMongoApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/AccountId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Created.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/CustomerId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/DueDate.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/LastUpdated.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Order.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderRepository.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/OrderRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Price.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Price.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Product.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductId.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductRepository.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/ProductRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Quantity.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/Quantity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/TimeOfDay.java
+++ b/types-springdata-mongo/src/test/java/dk/cloudcreate/essentials/types/springdata/mongo/model/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types-springdata-mongo/src/test/resources/logback-test.xml
+++ b/types-springdata-mongo/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types/pom.xml
+++ b/types/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Amount.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Amount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/BigDecimalType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/BigDecimalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/BigIntegerType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/BigIntegerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/BooleanType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/BooleanType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/ByteType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/ByteType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/CharSequenceType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/CharSequenceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/CountryCode.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/CountryCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/CurrencyCode.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/CurrencyCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/DoubleType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/DoubleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/EmailAddress.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/EmailAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/FloatType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/FloatType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Identifier.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Identifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/InstantType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/InstantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/IntegerType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/IntegerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/JSR310SingleValueType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/JSR310SingleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LocalDateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LocalTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LocalTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LongRange.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LongRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/LongType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/LongType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Money.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Money.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/NumberType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/NumberType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/OffsetDateTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/OffsetDateTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/Percentage.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/Percentage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/ShortType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/ShortType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/SingleValueType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/SingleValueType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/TimeWindow.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/TimeWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/java/dk/cloudcreate/essentials/types/ZonedDateTimeType.java
+++ b/types/src/main/java/dk/cloudcreate/essentials/types/ZonedDateTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/Amount.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/Amount.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigDecimalValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigDecimalValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigIntegerValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BigIntegerValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BooleanValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/BooleanValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ByteValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ByteValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/CountryCode.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/CountryCode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/DoubleValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/DoubleValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/FloatValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/FloatValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/InstantValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/InstantValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/IntValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/IntValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateTimeValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalDateValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LocalTimeValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LongValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/LongValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/OffsetDateTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/OffsetDateTimeValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ShortValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ShortValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/StringValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/StringValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ZonedDateTimeValueType.kt
+++ b/types/src/main/kotlin/dk/cloudcreate/essentials/kotlin/types/ZonedDateTimeValueType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/AmountTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/AmountTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/CharSequenceTypeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/CharSequenceTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/CountryCodeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/CountryCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/CurrencyCodeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/CurrencyCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/DateTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/DateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/EmailAddressTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/EmailAddressTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/LongRangeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/LongRangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/LongTypeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/LongTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/MoneyTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/MoneyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/PercentageTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/PercentageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/SingleValueTypeTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/SingleValueTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/TimeWindowTest.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/TimeWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/Created.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/Created.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/DueDate.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/DueDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/LastUpdated.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/LastUpdated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/TimeOfDay.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/TimeOfDay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransactionTime.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransactionTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransferTime.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/dates/TransferTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/AccountId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/AccountId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/CustomerId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/CustomerId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/MessageId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/MessageId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/OrderId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/OrderId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/ProductId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/ProductId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/java/dk/cloudcreate/essentials/types/ids/TransactionId.java
+++ b/types/src/test/java/dk/cloudcreate/essentials/types/ids/TransactionId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/types/src/test/resources/logback-test.xml
+++ b/types/src/test/resources/logback-test.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/versions-update-rules.xml
+++ b/versions-update-rules.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2021-2024 the original author or authors.
+  ~ Copyright 2021-2025 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Added additional `isIOException` check to `DBFencedLockManager` to reduce logging severity in case of IO issues
- Allowed `DBFencedLockManager.acquireLockAsync` to be performed without the `DBFencedLockManager` having been started
- Added additional `isIOException` check to `MultiTableChangeListener.unlisten` to reduce logging severity in case of IO issues
- Added more `IOExceptionUtil.isIOException` checks to `ListenNotify` and `MultiTableChangeListener`
- Added a `toString` method to the class returned from `QueuePollingOptimizer.None()`
- Added additional `isIOException` check to `DefaultDurableQueueConsumer` to reduce logging severity in case of IO issues
- Added `DurableQueueConsumer.consumerName()` method
- Improved `DurableQueueBasedInbox` and `DurableQueueBasedOutbox` logging
- Added additional `isIOException` check to `PostgresqlDurableSubscriptionRepository.saveResumePoints` to reduce logging severity in case of IO issues
- Added additional logging to `PostgresqlDurableQueues.consumeFromQueue` and `MongoDurableQueues.consumeFromQueue`
- Switched from using `ArrayList` to using `CopyOnWriteArrayList` for the list of interceptors
- Changed `DefaultLifecycleManager` to use the `SmartLifecycle` to attempt to start Essentials `Lifecycle` beans AFTER other resources, such as DataSource, has been started; as well as stop `Lifecycle` Beans are stopped prior other resources
- Refined the `IOExceptionUtil.isIOException` method
  - Generalized many of the special cases into the following logic:
     - Exception or its Root-Cause is a subclass of `IOException`
     - The Exception's message contains a known error messages across Jdbi, JPA, JDBC, Mongo
     - If the exception's causal chain contains an exception that is either a subclass of `ConnectionException` or a subclass of `MongoSocketException`
     - Removed checks for `org.jdbi.v3.core.statement.UnableToExecuteStatementException` - **please report back if this is an issue**
  - Added `IOExceptionUtilTest` in `foundation`, `postgresql-queue` and `springdata-mongo-queue`
- Refined `Exceptions.getRootCause`
  - Added `ExceptionsTest`
- Added support for `QueuedMessage.markForRedeliveryIn(Duration deliveryDelay)`
  - Made `causeForRetry` in `DurableQueues.retryMessage` optional
- Clarified `RedeliveryPolicy.isPermanentError` arguments
- Clarified `MessageDeliveryErrorHandler.isPermanentError` arguments
  - Adjusted `MessageDeliveryErrorHandler.StopRedeliveryOn`'s `isPermanentError` to use the new `Exceptions.doesStackTraceContainExceptionOfType` method
  - Adjusted `MessageDeliveryErrorHandlerBuilder.shouldAlwaysRetryOn` logic to use the new `Exceptions.doesStackTraceContainExceptionOfType` method
- `PostgresqlDurableQueues`
  - Switched to use `Instant.now()` instead of `OffsetDateTime.now(Clock.systemUTC())`
  - Added null handling for getCauseForRetry()
- `MongoDurableQueues`
  - Added null handling for getCauseForRetry()
- Updated copyright year

Updated 3rd party dependencies:
- spring-framework 6.1.16
- log4j 2.24.3
- junit 5.11.4
- jackson 2.28.2
- mockito 5.15.2
- logback 1.5.16
- reactor 2023.0.14
- assertj 3.27.3
- postgresql 42.7.5
- netty 4.1.117.Final

Updated maven plugins:
- dokka 2.0.0
- maven-project-info-reports-plugin 3.8.0
- maven-site-plugin 3.21.0
- maven-javadoc-plugin 3.11.2
- dependency-check-maven 12.0.1