### PR TITLE
Release 0.40.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -167,7 +167,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -183,7 +183,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -265,7 +265,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -339,7 +339,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -385,7 +385,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -432,7 +432,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -508,7 +508,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 
@@ -524,7 +524,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/foundation/pom.xml
+++ b/components/foundation/pom.xml
@@ -129,6 +129,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLockManager.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/fencedlock/DBFencedLockManager.java
@@ -343,9 +343,15 @@ public abstract class DBFencedLockManager<UOW extends UnitOfWork, LOCK extends D
                 try {
                     lock.release();
                 } catch (Exception e) {
-                    log.warn(msg("[{}] Failed to release FencedLock with name '{}'",
-                                 lockManagerInstanceId,
-                                 lock.getName()), e);
+                    if (IOExceptionUtil.isIOException(e)) {
+                        log.debug(msg("[{}] Failed to release FencedLock with name '{}'",
+                                     lockManagerInstanceId,
+                                     lock.getName()), e);
+                    } else {
+                        log.warn(msg("[{}] Failed to release FencedLock with name '{}'",
+                                     lockManagerInstanceId,
+                                     lock.getName()), e);
+                    }
                 }
             });
             started = false;

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
@@ -257,7 +257,7 @@ public abstract class DefaultDurableQueueConsumer<DURABLE_QUEUES extends Durable
 
     private void handleProcessNextMessageReadyForDeliveryException(Exception e) {
         if (IOExceptionUtil.isIOException(e)) {
-            LOG.trace(msg("[{}] {} - Experienced a Connection issue, will retry later",
+            LOG.debug(msg("[{}] {} - Experienced a Connection issue, will retry later",
                           queueName,
                           consumeFromQueue.consumerName), e);
         } else {
@@ -301,7 +301,7 @@ public abstract class DefaultDurableQueueConsumer<DURABLE_QUEUES extends Durable
 //                                                                .timeout(Duration.ofSeconds(5))
                                                                 .onErrorResume(throwable -> {
                                                                     if (IOExceptionUtil.isIOException(throwable)) {
-                                                                        LOG.trace(msg("[{}] {} - Error occurred during {}.getNextMessageReadyForDelivery queue processing",
+                                                                        LOG.debug(msg("[{}] {} - Error occurred during {}.getNextMessageReadyForDelivery queue processing",
                                                                                       queueName,
                                                                                       consumeFromQueue.consumerName,
                                                                                       durableQueues.getClass().getSimpleName()), throwable);

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -19,18 +19,12 @@ package dk.cloudcreate.essentials.components.foundation.messaging.queue;
 import dk.cloudcreate.essentials.components.foundation.Lifecycle;
 import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLock;
 import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Inbox;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.MessageConsumptionMode;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.Outbox;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.*;
-import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
-import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkFactory;
+import dk.cloudcreate.essentials.components.foundation.transaction.*;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.time.*;
+import java.util.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
@@ -511,7 +505,7 @@ public interface DurableQueues extends Lifecycle {
      * Note this method MUST be called within an existing {@link UnitOfWork} IF
      * using {@link TransactionalMode#FullyTransactional}
      *
-     * @param queueEntryId                    the unique id of the message that must be marked as a Dead Letter Message
+     * @param queueEntryId the unique id of the message that must be marked as a Dead Letter Message
      * @return the {@link QueuedMessage} message wrapped in an {@link Optional} if the operation was successful, otherwise it returns an {@link Optional#empty()}
      */
     default Optional<QueuedMessage> markAsDeadLetterMessage(QueueEntryId queueEntryId) {
@@ -670,7 +664,8 @@ public interface DurableQueues extends Lifecycle {
 
     /**
      * Get the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
-     * @param queueName  the name of the Queue where we will query for the number of queued messages
+     *
+     * @param queueName the name of the Queue where we will query for the number of queued messages
      * @return the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
      */
     default QueuedMessageCounts getQueuedMessageCountsFor(QueueName queueName) {
@@ -679,6 +674,7 @@ public interface DurableQueues extends Lifecycle {
 
     /**
      * Get the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
+     *
      * @param operation the {@link GetQueuedMessageCountsFor} operation
      * @return the total number of (non-dead-letter) messages queued and number of queued dead-letter Messages for the given queue
      */

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
@@ -288,7 +288,7 @@ public final class MultiTableChangeListener<T extends TableChangeNotification> i
             getHandle(null).execute("UNLISTEN " + resolveTableChangeChannelName(tableName));
         } catch (Exception e) {
             if (IOExceptionUtil.isIOException(e)) {
-                log.trace("Failed to unlisten table '{}'", tableName, e);
+                log.debug("Failed to unlisten table '{}'", tableName, e);
             } else {
                 throw new RuntimeException(msg("Failed to unlisten table '{}'", tableName), e);
             }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/MultiTableChangeListener.java
@@ -107,17 +107,29 @@ public final class MultiTableChangeListener<T extends TableChangeNotification> i
     public void close() {
         log.info("Closing");
         try {
-            scheduledFuture.cancel(true);
-            for (String tableName : listenForNotificationsRelatedToTables.keySet()) {
-                try {
-                    unlisten(tableName);
-                } catch (Exception e) {
-                    log.error("Failed to unlisten table '{}'", tableName, e);
-                }
+            if (scheduledFuture != null) {
+                log.info("Cancelling scheduled future");
+                scheduledFuture.cancel(true);
             }
-            scheduledFuture = null;
         } catch (Exception e) {
-            // Do nothing
+            log.trace("Failed to cancel scheduledFuture", e);
+        } finally {
+            scheduledFuture = null;
+        }
+
+        for (String tableName : listenForNotificationsRelatedToTables.keySet()) {
+            try {
+                unlisten(tableName);
+            } catch (Exception e) {
+                log.error("Failed to unlisten table '{}'", tableName, e);
+            }
+        }
+
+        if (executorService != null) {
+            log.info("Shutting down scheduled executor service");
+            executorService.shutdownNow();
+            executorService = null;
+            log.info("Scheduled Executor service shutdown");
         }
         log.info("Closed");
     }
@@ -310,6 +322,11 @@ public final class MultiTableChangeListener<T extends TableChangeNotification> i
         log.trace("Polling for notifications related to {} tables: {}",
                   listenForNotificationsRelatedToTables.size(),
                   listenForNotificationsRelatedToTables.keySet());
+
+        if (scheduledFuture == null || scheduledFuture.isCancelled() || scheduledFuture.isDone()) {
+            log.trace("Skipping polling since scheduledFuture is missing, cancelled or done");
+            return;
+        }
 
         if (listenForNotificationsRelatedToTables.isEmpty()) return;
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBusBuilder.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/reactive/command/DurableLocalCommandBusBuilder.java
@@ -91,8 +91,8 @@ public final class DurableLocalCommandBusBuilder {
     }
 
     /**
-     * Set the Exception handler that will handle errors that occur during {@link CommandBus#sendAndDontWait(Object)}/{@link CommandBus#sendAndDontWait(Object, Duration)}. If this handler doesn't rethrow the exeption,
-     * then the message will not be retried by the underlying {@link DurableQueues}
+     * Set the Exception handler that will handle errors that occur while processing Commands sent using {@link CommandBus#sendAndDontWait(Object)}/{@link CommandBus#sendAndDontWait(Object, Duration)}. If this handler doesn't rethrow the exception,
+     * then the message will not be retried by the underlying {@link DurableQueues} nor will the message be marked as a dead-letter/poison message.
      *
      * @param sendAndDontWaitErrorHandler The Exception handler that will handle errors that occur during {@link CommandBus#sendAndDontWait(Object)}/{@link CommandBus#sendAndDontWait(Object, Duration)}. If this handler doesn't rethrow the exeption,
      *                                    then the message will not be retried by the underlying {@link DurableQueues}

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
@@ -19,6 +19,7 @@ package dk.cloudcreate.essentials.components.foundation.messaging;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuedMessage;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkException;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.net.ConnectException;

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/messaging/MessageDeliveryErrorHandlerBuilderTest.java
@@ -19,39 +19,51 @@ package dk.cloudcreate.essentials.components.foundation.messaging;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuedMessage;
 import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkException;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.springframework.web.client.HttpClientErrorException;
 
 import java.net.ConnectException;
+import java.nio.charset.Charset;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class MessageDeliveryErrorHandlerBuilderTest {
     @Test
     void test_builder_with_only_stop_redelivery_on() {
         var errorHandler = MessageDeliveryErrorHandler.builder()
-                                                      .stopRedeliveryOn(IllegalStateException.class, IllegalArgumentException.class)
+                                                      .stopRedeliveryOn(IllegalStateException.class,
+                                                                        IllegalArgumentException.class,
+                                                                        HttpClientErrorException.class,
+                                                                        HttpClientErrorException.BadRequest.class)
                                                       .build();
 
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new RuntimeException()))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new IllegalStateException()))
                 .isTrue();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException()))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new RuntimeException())))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new IllegalStateException())))
                 .isTrue();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new IllegalStateException(new RuntimeException()))))
                 .isTrue();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new IllegalArgumentException()))
+                .isTrue();
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
+                                                 HttpClientErrorException.create(HttpStatus.BAD_REQUEST,
+                                                                                 "Bad Request",
+                                                                                 new HttpHeaders(),
+                                                                                 new byte[0],
+                                                                                 Charset.defaultCharset())))
                 .isTrue();
     }
 
@@ -62,40 +74,40 @@ class MessageDeliveryErrorHandlerBuilderTest {
                                                       .alwaysRetryOn(IllegalArgumentException.class, ConnectException.class)
                                                       .build();
 
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new RuntimeException()))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new IllegalStateException()))
                 .isTrue();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException()))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new RuntimeException())))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new IllegalStateException())))
                 .isTrue();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new IllegalStateException(new RuntimeException()))))
                 .isTrue();
 
         // Assert that alwaysRetryOn has higher priority than stopRedeliveryOn
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new ConnectException()))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new ConnectException())))
                 .isFalse();
 
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new IllegalArgumentException()))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new IllegalArgumentException())))
                 .isFalse();
-        assertThat(errorHandler.isPermanentError(Mockito.mock(QueuedMessage.class),
+        assertThat(errorHandler.isPermanentError(mock(QueuedMessage.class),
                                                  new UnitOfWorkException(new IllegalStateException(new IllegalArgumentException()))))
                 .isFalse();
 

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -597,6 +597,7 @@ public class MyEventHandler extends PatternMatchingPersistedEventHandler {
 
 }
 ```
+
 ### EventProcessor
 
 The easiest way to asynchronously subscribe to Events from one or more AggregatesTypes/EventStreams is to use the EventProcessor.  
@@ -625,13 +626,9 @@ public class ShippingEventKafkaPublisher extends EventProcessor {
     private final       KafkaTemplate<String, Object> kafkaTemplate;
 
 
-    public ShippingEventKafkaPublisher(@NonNull Inboxes inboxes,
-                                       @NonNull DurableLocalCommandBus commandBus,
-                                       @NonNull EventStoreSubscriptionManager eventStoreSubscriptionManager,
+    public ShippingEventKafkaPublisher(@NonNull EventProcessorDependencies eventProcessorDependencies,
                                        @NonNull KafkaTemplate<String, Object> kafkaTemplate) {
-        super(eventStoreSubscriptionManager,
-              inboxes,
-              commandBus);
+        super(eventProcessorDependencies);
         this.kafkaTemplate = kafkaTemplate;
     }
 
@@ -661,6 +658,7 @@ public class ShippingEventKafkaPublisher extends EventProcessor {
 
 #### Example Subscribing for Aggregate events and publishing an External Event to Kafka via an Outbox
 
+If you don't want to use the `EventProcessor` then you can use this example of how to subscribe for events and forwarding matching events via an `Outbox`
 ![Subscribe for Aggregate](images/event-subscription.png)
 
 ```java

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -782,6 +782,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/EventStore.java
@@ -32,7 +32,7 @@ import java.time.Duration;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventOrder.FIRST_EVENT_ORDER;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.EventOrder.*;
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 
 /**
@@ -139,7 +139,7 @@ public interface EventStore {
                                                       List<?> eventsToAppend) {
         return appendToStream(aggregateType,
                               aggregateId,
-                              Optional.empty(),
+                              NO_EVENTS_PREVIOUSLY_PERSISTED,
                               eventsToAppend);
     }
 
@@ -160,7 +160,7 @@ public interface EventStore {
                                                       Object... eventsToAppend) {
         return appendToStream(aggregateType,
                               aggregateId,
-                              Optional.empty(),
+                              NO_EVENTS_PREVIOUSLY_PERSISTED,
                               List.of(eventsToAppend));
     }
 

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/InTransactionEventProcessor.java
@@ -80,12 +80,12 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  *     private final Accounts                accounts;
  *     private final IntraBankMoneyTransfers intraBankMoneyTransfers;
  *
- *     public TransferMoneyProcessor(@NonNull Accounts accounts,
- *                                   @NonNull IntraBankMoneyTransfers intraBankMoneyTransfers,
- *                                   @NonNull EventProcessorDependencies eventProcessorDependencies) {
+ *     public TransferMoneyProcessor(Accounts accounts,
+ *                                   IntraBankMoneyTransfers intraBankMoneyTransfers,
+ *                                   EventProcessorDependencies eventProcessorDependencies) {
  *         super(eventProcessorDependencies, true);
- *         this.accounts = accounts;
- *         this.intraBankMoneyTransfers = intraBankMoneyTransfers;
+ *         this.accounts = requireNonNull(accounts, "No Accounts provided);
+ *         this.intraBankMoneyTransfers = requireNonNull(intraBankMoneyTransfers, "No IntraBankMoneyTransfers provided");
  *     }
  *
  *     @Override
@@ -99,8 +99,8 @@ import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
  *                        IntraBankMoneyTransfers.AGGREGATE_TYPE);
  *     }
  *
- *     @Handler
- *     public void handle(@NonNull RequestIntraBankMoneyTransfer cmd) {
+ *     @CmdHandler
+ *     public void handle(RequestIntraBankMoneyTransfer cmd) {
  *         if (accounts.isAccountMissing(cmd.fromAccount)) {
  *             throw new TransactionException(msg("Couldn't find fromAccount with id '{}'", cmd.fromAccount));
  *         }

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/PostgresqlDurableSubscriptionRepository.java
@@ -269,7 +269,7 @@ public final class PostgresqlDurableSubscriptionRepository implements DurableSub
             });
         } catch (Exception e) {
             if (IOExceptionUtil.isIOException(e)) {
-                log.trace("Failed to save the {} ResumePoints", resumePoints.size(), e);
+                log.debug("Failed to save the {} ResumePoints", resumePoints.size(), e);
             } else {
                 log.error("Failed to save the {} ResumePoints", resumePoints.size(), e);
             }

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -1058,7 +1058,7 @@ public final class MongoDurableQueues implements DurableQueues {
                                                            log.trace("[{}] MongoInterruptedException", queueName);
                                                            return Optional.<QueuedMessage>empty();
                                                        } else if (IOExceptionUtil.isIOException(e)) {
-                                                           log.trace("[{}] Experienced a Mongo related IO exception '{}'", queueName, e.getClass().getSimpleName());
+                                                           log.debug("[{}] Experienced a Mongo related IO exception '{}'", queueName, e.getClass().getSimpleName());
                                                            return Optional.<QueuedMessage>empty();
                                                        } else if (e instanceof IllegalStateException && Objects.equals(e.getMessage(), "state should be: open")) {
                                                            log.trace("[{}] Mongo Session is not open", queueName);

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <minimum-maven-version>3.8.8</minimum-maven-version>
-        <dependency-check-maven.version>12.0.1</dependency-check-maven.version>
+        <dependency-check-maven.version>12.0.2</dependency-check-maven.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendAndDontWaitErrorHandler.java
+++ b/reactive/src/main/java/dk/cloudcreate/essentials/reactive/command/SendAndDontWaitErrorHandler.java
@@ -28,7 +28,7 @@ import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
  */
 public interface SendAndDontWaitErrorHandler {
     /**
-     * Handle an exception that occurred during {@link CommandBus#sendAndDontWait(Object)}/{@link CommandBus#sendAndDontWait(Object, Duration)}
+     * Handle an exception that occurred while processing a Command sent using {@link CommandBus#sendAndDontWait(Object)}/{@link CommandBus#sendAndDontWait(Object, Duration)}
      *
      * @param exception      the exception that occurred during {@link CommandBus#sendAndDontWait(Object)}/{@link CommandBus#sendAndDontWait(Object, Duration)}
      * @param commandMessage the command message that caused the exception (can be wrapped in an infrastructure wrapper, such as a Message/QueuedMessage, depending on which transport channel is used)

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -58,7 +58,24 @@ Triple<String, String, String> stringTuple2 = tuple.map(Object::toString, Object
 
 Different utility functions for working with Collections, such as
 
-`Stream<Pair<Integer, String>> indexedStream = Lists.toIndexedStream(List.of("A", "B", "C"));`
+```java
+Stream<Pair<Integer, String>> indexedStream = Lists.toIndexedStream(List.of("A", "B", "C"));
+String first = Lists.first(List.of("A", "B", "C")); // first = "A"
+String last = Lists.last(List.of("A", "B", "C")); // first = "C"
+```
+### Streams
+
+Provides a zip function for streams of equal lengths
+
+```java
+var tStream = Stream.of("A", "B", "C", "D", "E");
+var uStream = Stream.of("1", "2", "3", "4", "5");
+
+List<String> result = Streams.zipOrderedAndEqualSizedStreams(tStream, uStream, (t, u) -> t + ":" + u)
+                        .collect(Collectors.toList());
+
+assertThat(result).isEqualTo(List.of("A:1", "B:2", "C:3", "D:4", "E:5"));
+```
 
 ### Functional interfaces
 
@@ -230,10 +247,13 @@ Using this class makes it possible to capture a generic/parameterized argument t
 When you specify a type reference using `.class` you loose any Generic/Parameterized information, as you cannot write `List<Money>.class`, only `List.class`.
 
 With `GenericType` you can specify and capture parameterized type information:  
-`var genericType = new GenericType<List<Money>>(){};` 
+```java
+var genericType = new GenericType<List<Money>>(){};
+```
 
-where genericType.getType() will return `List.class`  
-and genericType#getGenericType() will return `ParameterizedType`, which can be introspected further
+where:
+- `genericType.getType()` will return `List.class`  
+- `genericType#getGenericType()` will return a `ParameterizedType`, which can be introspected further
 
 ### `StopWatch` for timing different methods/operations
 
@@ -249,6 +269,18 @@ Duration duration = result.getDuration();
 String result = result.getResult();
 ```
 
+### `concurrent`
+
+Provides a `ThreadFactoryBuilder` for usage with e.g. `Executors`:
+
+```java
+Executors.newScheduledThreadPool(PARALLEL_CONSUMERS, 
+                                 ThreadFactoryBuilder.builder()
+                                                     .daemon(true)
+                                                     .nameFormat("Handler-Thread-%d")
+                                                     .build());
+```
+
 ### `Exceptions`
 
 That support `sneakyThrow` (use with caution) as well as getting a stacktrace as a String.
@@ -262,7 +294,7 @@ try {
 }
 ```
 
-### High level Reflection package
+### High level `Reflection` package
 
 Writing reflection can be cumbersome and there are many checked exception to handle. The `Reflector` class, and it's supporting classes
 (`Accessibles`, `BoxedTypes`, `Classes`, `Constructors`, `Fields`, `Interfaces`, `Methods`), makes working with Reflection easier.

--- a/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Streams.java
+++ b/shared/src/main/java/dk/cloudcreate/essentials/shared/collections/Streams.java
@@ -23,7 +23,43 @@ import java.util.stream.*;
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 
+/**
+ * Utility class for working with streams.
+ */
 public final class Streams {
+    /**
+     * Combines two streams into a single stream by applying a zip function to pairs of elements from the two streams.
+     * The streams must have equal sizes. The resulting stream will have the same order as the input streams.
+     *
+     * <p>The zip operation combines elements of the two streams pairwise: the first element from {@code streamT} with the
+     * first element from {@code streamU}, the second element with the second, and so on. The provided {@code zipFunction}
+     * determines how the elements are combined into the resulting stream.
+     *
+     * <p>The resulting stream will automatically close both input streams when it is closed.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * var tStream = Stream.of("A", "B", "C", "D", "E");
+     * var uStream = Stream.of("1", "2", "3", "4", "5");
+     *
+     * List<String> result = Streams.zipOrderedAndEqualSizedStreams(tStream, uStream, (t, u) -> t + ":" + u)
+     *                         .collect(Collectors.toList());
+     *
+     * assertThat(result).isEqualTo(List.of("A:1", "B:2", "C:3", "D:4", "E:5"));
+     * }
+     * </pre>
+     *
+     * @param <R>         The type of elements in the resulting stream.
+     * @param <T>         The type of elements in the first input stream.
+     * @param <U>         The type of elements in the second input stream.
+     * @param streamT     the first input stream; must be non-null.
+     * @param streamU     the second input stream; must be non-null.
+     * @param zipFunction a function to combine elements from {@code streamT} and {@code streamU}; must be non-null.
+     * @return a new stream consisting of elements resulting from applying the {@code zipFunction} to pairs of elements
+     * from {@code streamT} and {@code streamU}.
+     * @throws IllegalArgumentException if {@code streamT}, {@code streamU}, or {@code zipFunction} is null or
+     *                                  if {@code streamT} or {@code streamU} do not have equal sizes.
+     */
     public static <R, T, U> Stream<R> zipOrderedAndEqualSizedStreams(Stream<T> streamT, Stream<U> streamU, BiFunction<T, U, R> zipFunction) {
         requireNonNull(streamT, "No streamT provided");
         requireNonNull(streamU, "No streamU provided");

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.19</version>
+    <version>0.40.21</version>
 </dependency>
 ```
 


### PR DESCRIPTION
- Improved `shared` module documentation
- Improved `EventProcessor` and `InTransactionEventProcessor` JavaDoc
- `EventStore`'s `startStream` now calls `appendToStream` with `NO_EVENTS_PREVIOUSLY_PERSISTED` (-1) as `appendEventsAfterEventOrder` value to ensure that `startStream` only can be used to start a new aggregate event-stream
- Refined `SendAndDontWaitErrorHandler` documentation
- Refined `SendAndDontWaitErrorHandler` documentation in the context of `DurableLocalCommandBusBuilder`
- Added `IOExceptionUtil.isIOException` checks to `DBFencedLockManager.stop`
- Added more assertions to `MessageDeliveryErrorHandlerBuilderTest`
- `MultiTableChangeListener`
  - `stop`: Added additional try/catch around `scheduledFuture.cancel` and an explicit call to `executorService.shutdownNow`
  - `pollForNotifications`: Added additional `scheduledFuture` checks to skip polling early
- Added `spring-web` test dependency
- `DurableQueues`: Formatted code and organized imports
- `PostgresqlDurableQueues`:
  - Formatted code and organized imports
  - Added additional `IOExceptionUtil.isIOException` during `stop`
  - Removed interception of `ConsumeFromQueue` and `StopConsumingFromQueue` in `SingleOperationTransactionDurableQueuesInterceptor` as they don't require to be run in a `UnitOfWork`
- `MongoDurableQueues`:
  - Formatted code and organized imports
  - Added additional `IOExceptionUtil.isIOException` during `stop`
- Aligned log level to `DEBUG` for all log statements logged when `IOExceptionUtil.isIOException` returns true
- Updated dependency-check-maven to 12.0.2