### PR TITLE
Queue improvements - release 0.40.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ Essentials is released under version 2.0 of the [Apache License](https://www.apa
 
 ## Versions
 
-| Essentials version                                                                   | Java compatibility | Spring Boot compatibility | Notes                      |
-|--------------------------------------------------------------------------------------|--------------------|---------------------------|----------------------------|
-| [0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)            | 11-16              | 2.7.x                     | No longer being maintained |
+| Essentials version                                                             | Java compatibility | Spring Boot compatibility | Notes                      |
+|--------------------------------------------------------------------------------|--------------------|---------------------------|----------------------------|
+| [0.9.*](https://github.com/cloudcreate-dk/essentials-project/tree/java11)      | 11-16              | 2.7.x                     | No longer being maintained |
 | [0.20.*](https://github.com/cloudcreate-dk/essentials-project/tree/springboot_3_0_x) | 17+                | 3.0.x                     | No longer being maintained |
 | [0.30.*](https://github.com/cloudcreate-dk/essentials-project/tree/springboot_3_1_x) | 17+                | 3.1.x                     | No longer being maintained |
-| [0.40.*](https://github.com/cloudcreate-dk/essentials-project/tree/main)             | 17+                | 3.2.x                     | Under active development   |
+| [0.40.*-0.40.23](https://github.com/cloudcreate-dk/essentials-project/tree/main) | 17+                | 3.2.x                     |    |
+| [0.40.24-](https://github.com/cloudcreate-dk/essentials-project/tree/main)     | 17+                | 3.3.x                     | Under active development   |
 
 The Essentials philosophy is to provide high level building blocks and coding constructs that allows for concise and
 strongly typed code, which doesn't depend on other libraries or frameworks, but instead allows easy integrations with

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -167,7 +167,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -183,7 +183,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -265,7 +265,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -316,7 +316,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -339,7 +339,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -385,7 +385,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -432,7 +432,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -508,7 +508,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 
@@ -524,7 +524,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/eventsourced-aggregates/README.md
+++ b/components/eventsourced-aggregates/README.md
@@ -74,7 +74,7 @@ To use `EventSourced Aggregates` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components/groupId>
     <artifactId>eventsourced-aggregates</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/DurableQueuesIT.java
@@ -358,6 +358,96 @@ public abstract class DurableQueuesIT<DURABLE_QUEUES extends DurableQueues, UOW 
     }
 
     @Test
+    void verify_hasOrderedMessageQueuedForKey() {
+        // Given
+        var queueName = QueueName.of("TestQueue");
+        durableQueues.purgeQueue(queueName);
+        var otherQueueName = QueueName.of("OtherQueueName");
+        durableQueues.purgeQueue(otherQueueName);
+
+        var key1 = "Key1";
+        var key2 = "Key2";
+        var nonExistentKey = "NonExistentKey";
+
+        // When no messages are queued
+        // Then
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, nonExistentKey)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, nonExistentKey)).isFalse();
+
+        // When queuing an ordered message with key1
+        usingDurableQueue(() -> {
+            durableQueues.queueMessage(queueName, OrderedMessage.of("Message1", key1, 0));
+        });
+
+        // Then
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key1)).isTrue();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, nonExistentKey)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, nonExistentKey)).isFalse();
+
+        // When queuing an ordered message with key2
+        usingDurableQueue(() -> {
+            durableQueues.queueMessage(queueName, OrderedMessage.of("Message2", key2, 0));
+        });
+
+        // Then
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key1)).isTrue();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key2)).isTrue();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, nonExistentKey)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, nonExistentKey)).isFalse();
+
+        // When acknowledging all messages
+        var queuedMessages = durableQueues.getQueuedMessages(queueName, DurableQueues.QueueingSortOrder.ASC, 0, 10);
+        usingDurableQueue(() -> {
+            queuedMessages.forEach(message -> durableQueues.acknowledgeMessageAsHandled(message.getId()));
+        });
+
+
+        // Then
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, nonExistentKey)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, nonExistentKey)).isFalse();
+
+        // When queuing a dead letter message with key1
+        usingDurableQueue(() -> {
+            durableQueues.queueMessageAsDeadLetterMessage(queueName, 
+                                                         OrderedMessage.of("DeadLetterMessage", key1, 1),
+                                                         new RuntimeException("On purpose"));
+        });
+
+        // Then - should still return true for key1 since the method ignores the dead letter flag
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key1)).isTrue();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, nonExistentKey)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, nonExistentKey)).isFalse();
+
+        // When deleting all dead-letter messages
+        var deadLetterMessages = durableQueues.getDeadLetterMessages(queueName, DurableQueues.QueueingSortOrder.ASC, 0, 10);
+        usingDurableQueue(() -> {
+            deadLetterMessages.forEach(message -> durableQueues.deleteMessage(message.getId()));
+        });
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key1)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, key2)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(queueName, nonExistentKey)).isFalse();
+        assertThat(durableQueues.hasOrderedMessageQueuedForKey(otherQueueName, nonExistentKey)).isFalse();
+    }
+
+    @Test
     void verify_failed_messages_are_redelivered() {
         // Given
         var queueName = QueueName.of("TestQueue");

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -180,7 +180,7 @@ public abstract class LocalOrderedMessagesRedeliveryDurableQueueIT<DURABLE_QUEUE
             var lastSentMessageOrder = messageKeyIndexNextMessageOrder.get(intMsgKey);
             for (int i = 0; i < lastSentMessageOrder; i++) {
                 assertThat(messagesInReceivedOrder.get(i).order)
-                        .describedAs("Message with Key %s and received as msg number %d (zero based)", strMsgKey, i)
+                        .describedAs("Message with Key '%s' and received as msg number %d (zero based) has identical message order %d", strMsgKey, i, messagesInReceivedOrder.get(i).order)
                         .isEqualTo(i);
             }
         });

--- a/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/foundation-test/src/main/java/dk/cloudcreate/essentials/components/foundation/test/messaging/queue/LocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -150,7 +150,7 @@ public abstract class LocalOrderedMessagesRedeliveryDurableQueueIT<DURABLE_QUEUE
                                                      );
 
         // Then
-        Awaitility.waitAtMost(Duration.ofSeconds(80))
+        Awaitility.waitAtMost(Duration.ofSeconds(120))
                   .untilAsserted(() -> {
                       if (durableQueues.getTotalDeadLetterMessagesQueuedFor(queueName) > 0) {
                           System.out.println("""

--- a/components/foundation-types/README.md
+++ b/components/foundation-types/README.md
@@ -50,7 +50,7 @@ To use `foundation-types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation-types</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/foundation/README.md
+++ b/components/foundation/README.md
@@ -42,7 +42,7 @@ To use `foundation` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>foundation</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtil.java
@@ -21,6 +21,7 @@ import dk.cloudcreate.essentials.shared.Exceptions;
 import org.jdbi.v3.core.ConnectionException;
 
 import java.io.IOException;
+import java.sql.SQLTransientException;
 import java.util.concurrent.*;
 
 import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
@@ -41,8 +42,11 @@ public final class IOExceptionUtil {
         requireNonNull(e, "No exception provided");
         var message = e.getMessage() != null ? e.getMessage() : "";
 
+        var rootCause = Exceptions.getRootCause(e);
         return e instanceof IOException ||
-                Exceptions.getRootCause(e) instanceof IOException ||
+                rootCause instanceof IOException ||
+                e instanceof SQLTransientException ||
+                rootCause instanceof SQLTransientException ||
                 containsKnownErrorMessage(message) ||
                 isJdbiRelatedException(e) ||
                 isMongoRelatedException(e);

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/RedeliveryPolicy.java
@@ -180,11 +180,36 @@ public final class RedeliveryPolicy {
      * If an exception occurs during message handling, the {@link #isPermanentError(QueuedMessage, Throwable)} will be called with
      * only the top-level exception - the associated {@link MessageDeliveryErrorHandler#isPermanentError(QueuedMessage, Throwable)} must itself check the error exceptions causal chain
      * to determine if it represents a permanent error.
+     *
      * @param queuedMessage The message being processed by the message handler
-     * @param error the exception that occurred
+     * @param error         the exception that occurred
      * @return true if the error represents a permanent error, otherwise false
      */
     public boolean isPermanentError(QueuedMessage queuedMessage, Throwable error) {
         return deliveryErrorHandler.isPermanentError(queuedMessage, error);
+    }
+
+    public Duration getInitialRedeliveryDelay() {
+        return initialRedeliveryDelay;
+    }
+
+    public Duration getFollowupRedeliveryDelay() {
+        return followupRedeliveryDelay;
+    }
+
+    public double getFollowupRedeliveryDelayMultiplier() {
+        return followupRedeliveryDelayMultiplier;
+    }
+
+    public Duration getMaximumFollowupRedeliveryThreshold() {
+        return maximumFollowupRedeliveryThreshold;
+    }
+
+    public int getMaximumNumberOfRedeliveries() {
+        return maximumNumberOfRedeliveries;
+    }
+
+    public MessageDeliveryErrorHandler getDeliveryErrorHandler() {
+        return deliveryErrorHandler;
     }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/BatchMessageFetchingCapableDurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/BatchMessageFetchingCapableDurableQueues.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.cloudcreate.essentials.components.foundation.messaging.queue;
+
+import java.util.*;
+
+/**
+ * Extension interface for {@link DurableQueues} implementations that support batch fetching of messages
+ * across multiple queues in a single operation.
+ * @see CentralizedMessageFetcher
+ */
+public interface BatchMessageFetchingCapableDurableQueues extends DurableQueues {
+    /**
+     * Fetch the next batch of messages ready for delivery across multiple queues.
+     * The implementation must respect the same ordering rules as {@link DurableQueues#getNextMessageReadyForDelivery}
+     * but do it in a way that minimizes database queries.
+     *
+     * @param queueNames                   the queue names to fetch messages for
+     * @param excludeKeysPerQueue          map of queue name to set of keys to exclude (for ordered messages)
+     * @param availableWorkerSlotsPerQueue map of queue name to number of available worker slots
+     * @return list of queued messages ready for delivery
+     */
+    List<QueuedMessage> fetchNextBatchOfMessages(Collection<QueueName> queueNames,
+                                                 Map<QueueName, Set<String>> excludeKeysPerQueue,
+                                                 Map<QueueName, Integer> availableWorkerSlotsPerQueue);
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/CentralizedMessageFetcher.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/CentralizedMessageFetcher.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.cloudcreate.essentials.components.foundation.messaging.queue;
+
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import dk.cloudcreate.essentials.components.foundation.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.*;
+import dk.cloudcreate.essentials.shared.Exceptions;
+import org.slf4j.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.stream.Collectors;
+
+import static dk.cloudcreate.essentials.shared.Exceptions.rethrowIfCriticalError;
+import static dk.cloudcreate.essentials.shared.FailFast.*;
+import static dk.cloudcreate.essentials.shared.interceptor.InterceptorChain.newInterceptorChainForOperation;
+
+/**
+ * Centralized message fetcher that fetches messages from queues using a single polling thread
+ * and distributes them to {@link DurableQueueConsumer} worker threads.
+ * <p>
+ * This design:
+ * - Reduces database load by having a single polling thread per {@link DurableQueues} instance
+ * - Maintains ordering guarantees for ordered messages
+ * - Respects each consumer's thread allocation
+ * - Supports dynamic thread allocation
+ * - Optimizes polling frequency based on queue activity
+ */
+public class CentralizedMessageFetcher implements Lifecycle {
+    private static final Logger log = LoggerFactory.getLogger(CentralizedMessageFetcher.class);
+
+    private final DurableQueues                                              durableQueues;
+    private final ScheduledExecutorService                                   scheduler;
+    private final ConcurrentMap<QueueName, DurableQueueConsumerRegistration> consumerRegistrations;
+    private final AtomicBoolean                                              started;
+    private final long                                                       pollingIntervalMs;
+    private final List<DurableQueuesInterceptor>                             interceptors;
+
+    /**
+     * Messages currently being processed per queue with their key
+     * Map: QueueName -> (Set of {@link OrderedMessage#getKey()}'s currently being processed)
+     */
+    private final ConcurrentMap<QueueName, Set<String>> inProcessOrderedKeys;
+
+    /**
+     * Create a new CentralizedMessageFetcher
+     *
+     * @param durableQueues     the DurableQueues instance to work with
+     * @param pollingIntervalMs the polling interval in milliseconds
+     */
+    public CentralizedMessageFetcher(DurableQueues durableQueues,
+                                     long pollingIntervalMs,
+                                     List<DurableQueuesInterceptor> interceptors) {
+        this.durableQueues = requireNonNull(durableQueues, "No durableQueues provided");
+        this.pollingIntervalMs = pollingIntervalMs;
+        this.interceptors = new CopyOnWriteArrayList<>(requireNonNull(interceptors, "interceptors is missing"));
+        this.consumerRegistrations = new ConcurrentHashMap<>();
+        this.inProcessOrderedKeys = new ConcurrentHashMap<>();
+        this.scheduler = Executors.newScheduledThreadPool(1, r -> {
+            Thread thread = new Thread(r);
+            thread.setName("DurableQueues-CentralizedMessageFetcher");
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.started = new AtomicBoolean(false);
+    }
+
+    /**
+     * Register a consumer with the centralized fetcher
+     *
+     * @param queueName            the queue name to consume from
+     * @param consumer             the consumer instance
+     * @param messageHandler       the message handler
+     * @param workerPool           the worker pool to use
+     * @param maxParallelConsumers the maximum number of parallel consumers
+     */
+    public void registerConsumer(QueueName queueName,
+                                 DurableQueueConsumer consumer,
+                                 QueuedMessageHandler messageHandler,
+                                 ExecutorService workerPool,
+                                 int maxParallelConsumers) {
+        requireNonNull(queueName, "No queueName provided");
+        requireNonNull(consumer, "No consumer provided");
+        requireNonNull(messageHandler, "No messageHandler provided");
+        requireNonNull(workerPool, "No workerPool provided");
+        requireTrue(maxParallelConsumers > 0, "maxParallelConsumers must be > 0");
+
+        log.debug("[{}] Registering consumer with max {} parallel consumers",
+                  queueName,
+                  maxParallelConsumers);
+
+        consumerRegistrations.putIfAbsent(queueName,
+                                          new DurableQueueConsumerRegistration(
+                                                  queueName,
+                                                  consumer,
+                                                  messageHandler,
+                                                  workerPool,
+                                                  maxParallelConsumers));
+
+        inProcessOrderedKeys.putIfAbsent(queueName, ConcurrentHashMap.newKeySet());
+    }
+
+    /**
+     * Unregister a consumer
+     *
+     * @param queueName the queue name to unregister
+     */
+    public void unregisterConsumer(QueueName queueName) {
+        requireNonNull(queueName, "No queueName provided");
+
+        log.debug("[{}] Unregistering consumer", queueName);
+        consumerRegistrations.remove(queueName);
+        inProcessOrderedKeys.remove(queueName);
+    }
+
+    @Override
+    public void start() {
+        if (started.compareAndSet(false, true)) {
+            log.info("Starting CentralizedMessageFetcher with polling interval {} ms", pollingIntervalMs);
+
+            scheduler.scheduleAtFixedRate(() -> {
+                if (!started.get()) {
+                    return;
+                }
+
+                try {
+                    fetchAndDistributeMessages();
+                } catch (Throwable e) {
+                    rethrowIfCriticalError(e);
+                    if (IOExceptionUtil.isIOException(e)) {
+                        log.debug("I/O issue while polling queues", e);
+                    } else {
+                        log.error("Error during centralized message fetching", e);
+                    }
+                }
+            }, 0, pollingIntervalMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (started.compareAndSet(true, false)) {
+            log.info("Stopping CentralizedMessageFetcher");
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Override
+    public boolean isStarted() {
+        return started.get();
+    }
+
+    /**
+     * Main method that fetches and distributes messages to workers
+     */
+    private void fetchAndDistributeMessages() {
+        if (consumerRegistrations.isEmpty()) {
+            log.trace("No consumers registered, skipping fetch and distribute");
+            return;
+        }
+
+        // Collect active queue names and determine available worker slots
+        var availableWorkerSlotsPerQueue = calculateAvailableWorkerSlotsPerQueue();
+
+        // Skip if no capacity available
+        if (availableWorkerSlotsPerQueue.values().stream().mapToInt(Integer::intValue).sum() == 0) {
+            log.trace("No worker capacity available, skipping fetch and distribute");
+            return;
+        }
+
+        // Prepare excluded keys map for batch fetching
+        var excludeKeysPerQueue = new HashMap<QueueName, Set<String>>();
+        availableWorkerSlotsPerQueue.forEach((queueName, slots) -> {
+            if (slots > 0) {
+                excludeKeysPerQueue.put(queueName, new HashSet<>(inProcessOrderedKeys.getOrDefault(queueName, ConcurrentHashMap.newKeySet())));
+            }
+        });
+
+        try {
+            // Ask the DurableQueues implementation if it supports batch fetching
+            if (durableQueues instanceof BatchMessageFetchingCapableDurableQueues batchCapableDurableQueues) {
+                // Use batch fetching for better efficiency
+                var messages = batchCapableDurableQueues.fetchNextBatchOfMessages(
+                        availableWorkerSlotsPerQueue.keySet(),
+                        excludeKeysPerQueue,
+                        availableWorkerSlotsPerQueue);
+
+                // Debug logging when using batch fetching
+                if (log.isDebugEnabled()) {
+                    var messageCountsByQueue = messages.stream()
+                                                       .collect(Collectors.groupingBy(QueuedMessage::getQueueName, Collectors.counting()));
+                    log.debug("Batch fetched {} messages across {} queues: {}",
+                              messages.size(),
+                              availableWorkerSlotsPerQueue.size(),
+                              messageCountsByQueue);
+                }
+
+                // Process all messages without duplicates and with error handling for each
+                for (var message : messages) {
+                    var queueName = message.getQueueName();
+                    try {
+                        processMessage(queueName, message);
+                    } catch (Exception e) {
+                        // Log errors but continue processing other messages
+                        log.error("[{}:{}] Error processing message in batch: {}",
+                                  queueName, message.getId(), e.getMessage(), e);
+                    }
+                }
+            } else {
+                // Fall back to per-queue fetching for non-batch-capable implementations
+                availableWorkerSlotsPerQueue.forEach((queueName, availableSlots) -> {
+                    if (availableSlots <= 0) {
+                        return;
+                    }
+
+                    var keysBeingProcessed = inProcessOrderedKeys.getOrDefault(queueName, Collections.emptySet());
+
+                    try {
+                        for (int i = 0; i < availableSlots; i++) {
+                            var messageOpt = durableQueues.getNextMessageReadyForDelivery(
+                                    new GetNextMessageReadyForDelivery(queueName, new ArrayList<>(keysBeingProcessed)));
+
+                            if (messageOpt.isEmpty()) {
+                                log.trace("[{}] No more messages to process for this queue. Slot: {} (1-based)", queueName, i + 1);
+                                break;
+                            }
+
+                            processMessage(queueName, messageOpt.get());
+                        }
+                    } catch (Exception e) {
+                        log.error("[{}] Error fetching messages: {}", queueName, e.getMessage(), e);
+                    }
+                });
+            }
+        } catch (Exception e) {
+            log.error("Error during batch message fetching: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Process a message by submitting it to the appropriate worker pool
+     */
+    private void processMessage(QueueName queueName, QueuedMessage message) {
+        // Track ordered message keys
+        var sharedKeysBeingProcessed = inProcessOrderedKeys.computeIfAbsent(queueName, _queueName -> ConcurrentHashMap.newKeySet());
+
+        // Add the key if this is an ordered message
+        if (message.getMessage() instanceof OrderedMessage orderedMessage) {
+            sharedKeysBeingProcessed.add(orderedMessage.getKey());
+        }
+
+        var registration = consumerRegistrations.get(queueName);
+        if (registration == null) {
+            log.warn("[{}] Received message for unregistered consumer - will retry the message", queueName);
+            durableQueues.retryMessage(message.getId(),
+                                       null,
+                                       registration.consumer.getRedeliveryPolicy().initialRedeliveryDelay);
+            return;
+        }
+
+        registration.activeWorkers.incrementAndGet();
+        log.debug("[{}] Submitting message {} to worker pool",
+                  queueName,
+                  message.getId());
+
+        // Submit message for processing
+        registration.workerPool.submit(() -> {
+            try {
+                var operation = new HandleQueuedMessage(message, registration.messageHandler);
+                newInterceptorChainForOperation(operation,
+                                                interceptors,
+                                                (interceptor, interceptorChain) -> interceptor.intercept(operation, interceptorChain),
+                                                () -> {
+                                                    registration.messageHandler.handle(message);
+                                                    return (Void) null;
+                                                })
+                        .proceed();
+
+                if (message.isManuallyMarkedForRedelivery()) {
+                    log.debug("[{}:{}] Message handler manually requested redelivery",
+                              queueName,
+                              message.getId());
+
+                    try {
+                        durableQueues.retryMessage(message.getId(),
+                                                   null,
+                                                   message.getRedeliveryDelay());
+                    } catch (Exception ex) {
+                        // If retry fails due to connectivity issues, then it will be picked up by resetMessagesStuckBeingDelivered
+                        log.warn("[{}:{}] Could not manually mark message for redelivery: {}",
+                                 queueName,
+                                 message.getId(),
+                                 ex.getMessage());
+                    }
+                } else {
+                    log.debug("[{}:{}] Message handled successfully, acknowledging",
+                              queueName,
+                              message.getId());
+
+                    try {
+                        boolean acknowledged = durableQueues.acknowledgeMessageAsHandled(message.getId());
+                        if (!acknowledged) {
+                            // Message was already acknowledged or deleted
+                            log.debug("[{}:{}] Message acknowledgment reported message already handled or deleted",
+                                      queueName,
+                                      message.getId());
+                        }
+                    } catch (Exception ex) {
+                        // If acknowledgment fails due to connectivity issues, the message will be
+                        // picked up by resetMessagesStuckBeingDelivered after the handling timeout
+                        log.warn("[{}:{}] Failed to acknowledge message: {}",
+                                 queueName,
+                                 message.getId(),
+                                 ex.getMessage());
+                    }
+                }
+            } catch (Throwable e) {
+                rethrowIfCriticalError(e);
+
+                try {
+                    boolean isPermanentError = isPermanentError(message, e);
+                    if (isPermanentError || message.getTotalDeliveryAttempts() >= registration.consumer.getRedeliveryPolicy().getMaximumNumberOfRedeliveries() + 1) {
+                        log.error("[{}:{}] Marking message as dead letter due to error: {}",
+                                  queueName,
+                                  message.getId(),
+                                  e.getMessage(),
+                                  e);
+
+                        durableQueues.markAsDeadLetterMessage(message.getId(), e);
+                    } else {
+                        // Redelivery
+                        var redeliveryDelay = registration.consumer.getRedeliveryPolicy()
+                                                                   .calculateNextRedeliveryDelay(message.getRedeliveryAttempts());
+
+                        log.debug("[{}:{}] Will retry message with delay {}: {}",
+                                  queueName,
+                                  message.getId(),
+                                  redeliveryDelay,
+                                  e.getMessage());
+
+                        durableQueues.retryMessage(message.getId(), e, redeliveryDelay);
+                    }
+                } catch (Exception retryEx) {
+                    log.error("[{}:{}] Error handling message failure: {}",
+                              queueName,
+                              message.getId(),
+                              retryEx.getMessage(),
+                              retryEx);
+                }
+            } finally {
+                // Cleanup from both the shared concurrent set
+                if (message.getMessage() instanceof OrderedMessage orderedMessage) {
+                    var key = orderedMessage.getKey();
+
+                    // Remove from shared state
+                    var currentKeysBeingProcessed = inProcessOrderedKeys.get(queueName);
+                    if (currentKeysBeingProcessed != null) {
+                        currentKeysBeingProcessed.remove(key);
+                    }
+                }
+
+                registration.activeWorkers.decrementAndGet();
+            }
+        });
+    }
+
+    /**
+     * Calculate available worker slots for each queue
+     *
+     * @return Map of queue name to available worker slots
+     */
+    private Map<QueueName, Integer> calculateAvailableWorkerSlotsPerQueue() {
+        var result = new HashMap<QueueName, Integer>();
+
+        // Process registrations in a thread-safe way
+        for (Map.Entry<QueueName, DurableQueueConsumerRegistration> entry : consumerRegistrations.entrySet()) {
+            var queueName = entry.getKey();
+            var reg       = entry.getValue();
+
+            if (reg == null) {
+                // Skip if registration is somehow null
+                log.warn("Registration for queue '{}' is null, skipping", queueName);
+                continue;
+            }
+
+            // Ensure we have at least one slot available (even if max workers is reached)
+            // to prevent complete starvation when using a small number of workers
+            int activeWorkers  = reg.activeWorkers.get();
+            int availableSlots = Math.max(1, reg.maxParallelConsumers - activeWorkers);
+
+            // Adjust the slots to prevent overloading when nearing capacity
+            if (activeWorkers > 0 && activeWorkers >= reg.maxParallelConsumers * 0.8) {
+                // When we're at 80% capacity or higher, limit new slots 
+                availableSlots = Math.min(availableSlots, 2);
+            }
+
+            // Add result to map
+            result.put(queueName, availableSlots);
+        }
+
+        return result;
+    }
+
+    /**
+     * Determine if an error is permanent and should mark the message as a dead letter
+     */
+    private boolean isPermanentError(QueuedMessage queuedMessage, Throwable e) {
+        DurableQueueConsumerRegistration registration = consumerRegistrations.get(queuedMessage.getQueueName());
+        if (registration == null) {
+            // If registration is gone, treat as permanent to avoid message being stuck
+            return true;
+        }
+
+        var rootCause = Exceptions.getRootCause(e);
+        return registration.consumer.getRedeliveryPolicy().isPermanentError(queuedMessage, e) ||
+                e instanceof DurableQueueDeserializationException ||
+                e instanceof ClassCastException || rootCause instanceof ClassCastException ||
+                e instanceof NoClassDefFoundError || rootCause instanceof NoClassDefFoundError ||
+                rootCause instanceof MismatchedInputException ||
+                e instanceof IllegalArgumentException || rootCause instanceof IllegalArgumentException;
+    }
+
+    public boolean containsConsumerFor(QueueName queueName) {
+        requireNonNull(queueName, "No queueName provided");
+        return consumerRegistrations.containsKey(queueName);
+    }
+
+    /**
+     * Internal class to track consumer registrations
+     */
+    private static class DurableQueueConsumerRegistration {
+        private final QueueName            queueName;
+        private final DurableQueueConsumer consumer;
+        private final QueuedMessageHandler messageHandler;
+        private final ExecutorService      workerPool;
+        private final int                  maxParallelConsumers;
+        private final AtomicInteger        activeWorkers     = new AtomicInteger(0);
+
+        private DurableQueueConsumerRegistration(QueueName queueName,
+                                                 DurableQueueConsumer consumer,
+                                                 QueuedMessageHandler messageHandler,
+                                                 ExecutorService workerPool,
+                                                 int maxParallelConsumers) {
+            this.queueName = requireNonNull(queueName, "No queueName provided");
+            this.consumer = requireNonNull(consumer, "No consumer provided");
+            this.messageHandler = requireNonNull(messageHandler, "No messageHandler provided");
+            this.workerPool = requireNonNull(workerPool, "No workerPool provided");
+            this.maxParallelConsumers = maxParallelConsumers;
+        }
+    }
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/CentralizedMessageFetcherDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/CentralizedMessageFetcherDurableQueueConsumer.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.cloudcreate.essentials.components.foundation.messaging.queue;
+
+import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.ConsumeFromQueue;
+import dk.cloudcreate.essentials.shared.concurrent.ThreadFactoryBuilder;
+import org.slf4j.*;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * A specialized {@link DurableQueueConsumer} implementation that works with the
+ * {@link CentralizedMessageFetcher}. Instead of each consumer polling for messages
+ * independently, this consumer registers with the centralized fetcher and receives
+ * messages when they become available.
+ */
+public class CentralizedMessageFetcherDurableQueueConsumer implements DurableQueueConsumer {
+    private static final Logger log = LoggerFactory.getLogger(CentralizedMessageFetcherDurableQueueConsumer.class);
+
+    private final QueueName                      queueName;
+    private final String                         consumerName;
+    private final QueuedMessageHandler           messageHandler;
+    private final AtomicBoolean                  started;
+    private final RedeliveryPolicy               redeliveryPolicy;
+    private final Consumer<DurableQueueConsumer> removeDurableQueueConsumer;
+    private final ExecutorService                workerPool;
+    private final int                            parallelConsumers;
+    private final CentralizedMessageFetcher      centralizedMessageFetcher;
+
+    /**
+     * Create a new CentralizedPostgresqlDurableQueueConsumer
+     *
+     * @param consumeFromQueue           the consume from queue operation
+     * @param durableQueues              the durable queues instance
+     * @param removeDurableQueueConsumer callback to invoke when the consumer is stopped
+     * @param centralizedMessageFetcher  the centralized message fetcher
+     */
+    public CentralizedMessageFetcherDurableQueueConsumer(ConsumeFromQueue consumeFromQueue,
+                                                         BatchMessageFetchingCapableDurableQueues durableQueues,
+                                                         Consumer<DurableQueueConsumer> removeDurableQueueConsumer,
+                                                         CentralizedMessageFetcher centralizedMessageFetcher) {
+        requireNonNull(consumeFromQueue, "No consumeFromQueue provided");
+        requireNonNull(durableQueues, "No durableQueues provided");
+
+        this.queueName = consumeFromQueue.queueName;
+        this.consumerName = consumeFromQueue.consumerName;
+        this.messageHandler = consumeFromQueue.queueMessageHandler;
+        this.redeliveryPolicy = consumeFromQueue.getRedeliveryPolicy();
+        this.removeDurableQueueConsumer = requireNonNull(removeDurableQueueConsumer, "No removeDurableQueueConsumer provided");
+        this.started = new AtomicBoolean(false);
+        this.parallelConsumers = consumeFromQueue.getParallelConsumers();
+        this.centralizedMessageFetcher = requireNonNull(centralizedMessageFetcher, "No centralizedMessageFetcher provided");
+
+        // Create worker pool
+        this.workerPool = consumeFromQueue.getConsumerExecutorService()
+                                          .orElseGet(() -> Executors.newScheduledThreadPool(
+                                                  consumeFromQueue.getParallelConsumers(),
+                                                  new ThreadFactoryBuilder()
+                                                          .nameFormat("Queue-" + queueName + "-Worker-%d")
+                                                          .daemon(true)
+                                                          .build()));
+
+        log.info("[{}] '{}' - Created CentralizedMessageFetcherDurableQueueConsumer with {} workers",
+                 queueName,
+                 consumerName,
+                 parallelConsumers);
+    }
+
+    @Override
+    public void start() {
+        if (started.compareAndSet(false, true)) {
+            log.info("[{}] '{}' - Starting with {} workers",
+                     queueName,
+                     consumerName,
+                     parallelConsumers);
+
+            // Register with the centralized fetcher
+            centralizedMessageFetcher.registerConsumer(
+                    queueName,
+                    this,
+                    messageHandler,
+                    workerPool,
+                    parallelConsumers);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (started.compareAndSet(true, false)) {
+            log.info("[{}] '{}' - Stopping",
+                     queueName,
+                     consumerName);
+
+            // Allow for worker pool shutdown if not provided externally
+            if (!workerPool.isShutdown()) {
+                workerPool.shutdown();
+            }
+
+            removeDurableQueueConsumer.accept(this);
+
+            // If the removeDurableQueueConsumer didn't unregister the consumer, then unregister it here
+            if (centralizedMessageFetcher.containsConsumerFor(queueName)) {
+                centralizedMessageFetcher.unregisterConsumer(queueName);
+            }
+
+            log.info("[{}] '{}' - Stopped",
+                     queueName,
+                     consumerName);
+        }
+    }
+
+    @Override
+    public boolean isStarted() {
+        return started.get();
+    }
+
+    @Override
+    public QueueName queueName() {
+        return queueName;
+    }
+
+    @Override
+    public String consumerName() {
+        return consumerName;
+    }
+
+    @Override
+    public void cancel() {
+        stop();
+    }
+
+    @Override
+    public RedeliveryPolicy getRedeliveryPolicy() {
+        return redeliveryPolicy;
+    }
+}

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/CentralizedMessageFetcherDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/CentralizedMessageFetcherDurableQueueConsumer.java
@@ -151,4 +151,13 @@ public class CentralizedMessageFetcherDurableQueueConsumer implements DurableQue
     public RedeliveryPolicy getRedeliveryPolicy() {
         return redeliveryPolicy;
     }
+
+    @Override
+    public String toString() {
+        return "CentralizedMessageFetcherDurableQueueConsumer{" +
+                "queueName=" + queueName +
+                ", consumerName='" + consumerName + '\'' +
+                ", started=" + started +
+                '}';
+    }
 }

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DefaultDurableQueueConsumer.java
@@ -18,6 +18,7 @@ package dk.cloudcreate.essentials.components.foundation.messaging.queue;
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import dk.cloudcreate.essentials.components.foundation.IOExceptionUtil;
+import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.QueuedMessage.DeliveryMode;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.*;
 import dk.cloudcreate.essentials.components.foundation.transaction.*;
@@ -193,6 +194,10 @@ public abstract class DefaultDurableQueueConsumer<DURABLE_QUEUES extends Durable
         stop();
     }
 
+    @Override
+    public RedeliveryPolicy getRedeliveryPolicy() {
+        return consumeFromQueue.getRedeliveryPolicy();
+    }
 
     private void pollQueue() {
         if (!started) {
@@ -403,7 +408,7 @@ public abstract class DefaultDurableQueueConsumer<DURABLE_QUEUES extends Durable
                                             (interceptor, interceptorChain) -> interceptor.intercept(operation, interceptorChain),
                                             () -> {
                                                 consumeFromQueue.queueMessageHandler.handle(queuedMessage);
-                                                return (Void)null;
+                                                return (Void) null;
                                             })
                     .proceed();
 

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/DurableQueues.java
@@ -644,6 +644,16 @@ public interface DurableQueues extends Lifecycle {
      */
     boolean hasMessagesQueuedFor(QueueName queueName);
 
+
+    /**
+     * Check if there are any ordered messages queued (ignoring the dead letter message flag) with the specified key in the given queue
+     *
+     * @param queueName the name of the queue to check
+     * @param key the key to check for
+     * @return true if there are ordered messages queued with the specified key in the given queue, otherwise false
+     */
+    boolean hasOrderedMessageQueuedForKey(QueueName queueName, String key);
+
     /**
      * Get the total number of messages queued (i.e. not including Dead Letter Messages) for the given queue
      *

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageMetaData.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/messaging/queue/MessageMetaData.java
@@ -36,7 +36,7 @@ public final class MessageMetaData implements Map<String, String>, Serializable 
      * to coordinate message consumption, then you can find the {@link FencedLock#getCurrentToken()}
      * of the consumer under this key
      */
-    public static String              FENCED_LOCK_TOKEN   = "FENCED_LOCK_TOKEN";
+    public static String              FENCED_LOCK_TOKEN = "FENCED_LOCK_TOKEN";
     private final Map<String, String> metaData;
 
     public MessageMetaData(Map<String, String> metaData) {
@@ -223,12 +223,15 @@ public final class MessageMetaData implements Map<String, String>, Serializable 
 
     @Override
     public boolean equals(Object o) {
-        return metaData.equals(o);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MessageMetaData that = (MessageMetaData) o;
+        return Objects.equals(metaData, that.metaData);
     }
 
     @Override
     public int hashCode() {
-        return metaData.hashCode();
+        return Objects.hash(metaData);
     }
 
     @Override

--- a/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
+++ b/components/foundation/src/main/java/dk/cloudcreate/essentials/components/foundation/postgresql/ListenNotify.java
@@ -411,7 +411,7 @@ public final class ListenNotify {
                                    log.error(msg("Failed to close the listener Handle for table '{}'", tableName),
                                              e);
 
-                                   return Flux.error(ex);
+                                   return Flux.empty();
                                }
                            }
                            handleReference.set(null);

--- a/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
+++ b/components/foundation/src/test/java/dk/cloudcreate/essentials/components/foundation/IOExceptionUtilTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.net.ConnectException;
-import java.sql.SQLException;
+import java.sql.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +31,12 @@ public class IOExceptionUtilTest {
     @Test
     void shouldIdentifyIOException_whenRootCauseIsIOException() {
         var ioException = new IOException("Root IO Exception");
+        assertThat(IOExceptionUtil.isIOException(ioException)).isTrue();
+    }
+
+    @Test
+    void shouldIdentifyIOException_whenRootCauseIsSQLTransientException() {
+        var ioException = new SQLTransientException("Root IO Exception");
         assertThat(IOExceptionUtil.isIOException(ioException)).isTrue();
     }
 

--- a/components/postgresql-distributed-fenced-lock/README.md
+++ b/components/postgresql-distributed-fenced-lock/README.md
@@ -38,7 +38,7 @@ To use `PostgreSQL Distributed Fenced Lock` just add the following Maven depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-distributed-fenced-lock</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/postgresql-event-store/README.md
+++ b/components/postgresql-event-store/README.md
@@ -782,6 +782,6 @@ To use `Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-event-store</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/AbstractEventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/AbstractEventProcessor.java
@@ -1,0 +1,449 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.foundation.json.JSONDeserializationException;
+import dk.cloudcreate.essentials.components.foundation.messaging.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+import dk.cloudcreate.essentials.components.foundation.types.SubscriberId;
+import dk.cloudcreate.essentials.reactive.Handler;
+import dk.cloudcreate.essentials.reactive.command.*;
+import dk.cloudcreate.essentials.shared.Lifecycle;
+import dk.cloudcreate.essentials.types.LongRange;
+import org.slf4j.*;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.*;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * The AbstractEventProcessor provides base functionality for event processors that react to events
+ * associated with one or more aggregate event streams stored in the {@link EventStore}.
+ * It manages event subscriptions and message handling mechanisms.
+ * <br>
+ * It includes integration with durable queues and supports handling of message handler interceptors,
+ * command bus handling, and resettable subscriptions.
+ * <br>
+ * Subclasses can customize behavior by overriding specific methods or providing their own
+ * configurations such as message handler interceptors, subscription policies, and processing logic.
+ * This class requires concrete subclasses to define the set of {@link AggregateType}s they are reacting to
+ * as well as the processor's name.
+ */
+public abstract class AbstractEventProcessor implements Lifecycle {
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    protected final EventStoreSubscriptionManager eventStoreSubscriptionManager;
+    protected final DurableLocalCommandBus        commandBus;
+    protected final EventStore                    eventStore;
+
+    protected volatile boolean                         started;
+    protected          List<EventStoreSubscription>    eventStoreSubscriptions;
+    protected          AnnotatedCommandHandler         commandBusHandlerDelegate;
+    protected          List<MessageHandlerInterceptor> messageHandlerInterceptors;
+
+    protected QueueName durableQueueName;
+
+    /**
+     * Resolves a unique {@link SubscriberId} by combining the processor name and aggregate type.
+     *
+     * @param aggregateType the type of aggregate associated with the subscriber
+     * @param processorName the name of the processor for which the {@link SubscriberId} is being resolved
+     * @return a unique {@link SubscriberId} for the given processor name and aggregate type
+     */
+    public static SubscriberId resolveSubscriberId(AggregateType aggregateType, String processorName) {
+        requireNonNull(aggregateType, "aggregateType is null");
+        requireNonNull(processorName, "processorName is null");
+        return SubscriberId.of(processorName + ":" + aggregateType);
+    }
+
+
+    /**
+     * Create a new {@link AbstractEventProcessor} instance
+     *
+     * @param eventStoreSubscriptionManager The {@link EventStoreSubscriptionManager} used for managing {@link EventStore} subscriptions<br>
+     *                                      The  {@link EventStore} instance associated with the {@link EventStoreSubscriptionManager} is used to only query references to
+     *                                      the {@link PersistedEvent}. Before an event reference message is forwarded to the corresponding {@link MessageHandler} we load the {@link PersistedEvent}'s
+     *                                      payload and forward it to the {@link MessageHandler} annotated method. This avoids double storing event payloads
+     * @param commandBus                    The {@link CommandBus} where any {@link Handler} or {@link CmdHandler} annotated methods in the subclass of the {@link AbstractEventProcessor} will be registered
+     * @param messageHandlerInterceptors    The {@link MessageHandlerInterceptor}'s that will intercept calls to the {@link MessageHandler} annotated methods.<br>
+     *                                      Unless you override {@link #getMessageHandlerInterceptors()} then these are the {@link MessageHandlerInterceptor}'s that will be used.
+     */
+    protected AbstractEventProcessor(EventStoreSubscriptionManager eventStoreSubscriptionManager,
+                                     DurableLocalCommandBus commandBus,
+                                     List<MessageHandlerInterceptor> messageHandlerInterceptors) {
+        this.eventStoreSubscriptionManager = requireNonNull(eventStoreSubscriptionManager, "No eventStoreSubscriptionManager provided");
+        this.commandBus = requireNonNull(commandBus, "No commandBus provided");
+        this.eventStore = requireNonNull(eventStoreSubscriptionManager.getEventStore(), "No eventStore is associated with the eventStoreSubscriptionManager provided");
+        this.messageHandlerInterceptors = new CopyOnWriteArrayList<>(requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors list provided"));
+        setupCommandHandler();
+    }
+
+    /**
+     * Setup the EventProcessor's {@link CommandHandler} capabilities - default delegates any matching commands on to
+     * {@link Handler} or {@link CmdHandler} annotated methods in the subclass of the {@link AbstractEventProcessor}
+     */
+    protected void setupCommandHandler() {
+        commandBusHandlerDelegate = new AnnotatedCommandHandler(this);
+        commandBus.addCommandHandler(commandBusHandlerDelegate);
+    }
+
+    /**
+     * Default: The {@link MessageHandlerInterceptor}'s provided in the {@link AbstractEventProcessor#AbstractEventProcessor(EventStoreSubscriptionManager, DurableLocalCommandBus, List)} constructor<br>
+     * You can also override this method to provide your own {@link MessageHandlerInterceptor}'s that should be used when calling {@link MessageHandler} annotated methods<br>
+     * This method will be called during {@link AbstractEventProcessor#start()} time
+     *
+     * @return the {@link MessageHandlerInterceptor}'s that should be used when calling {@link MessageHandler} annotated methods
+     */
+    protected List<MessageHandlerInterceptor> getMessageHandlerInterceptors() {
+        return messageHandlerInterceptors;
+    }
+
+    /**
+     * This method returns true if one or more underlying {@link EventStoreSubscription} are active<br>
+     * Otherwise it returns false
+     *
+     * @return see description above
+     */
+    public boolean isActive() {
+        return eventStoreSubscriptions.stream()
+                                      .anyMatch(EventStoreSubscription::isActive);
+    }
+
+    /**
+     * Creates and returns a {@link Consumer} to handle queued messages. The consumer processes the
+     * given message by distinguishing between ordered messages containing event references and
+     * other generic messages. For event references, it fetches the associated event from the
+     * event store and delegates the handling of the deserialized event to the specified
+     * {@link PatternMatchingMessageHandler}. If the message does not contain an event reference,
+     * it is directly delegated to the handler.
+     *
+     * @param patternMatchingMessageHandlerDelegate the delegate to handle the processed message,
+     *                                              after optional deserialization.
+     *                                              This handler is responsible for applying custom
+     *                                              processing logic to the incoming message.
+     * @return a configured {@link Consumer} of {@link Message}, which processes queued messages
+     * appropriately and invokes the specified delegate for handling events or direct messages.
+     */
+    protected Consumer<Message> handleQueuedMessageConsumer(PatternMatchingMessageHandler patternMatchingMessageHandlerDelegate) {
+        return msg -> {
+            if (msg instanceof OrderedMessage orderedMessage && AbstractEventProcessor.EventReferenceOrderedMessage.isEventReference(orderedMessage)) {
+                var aggregateType         = (AggregateType) orderedMessage.getPayload();
+                var aggregateIdSerializer = resolveAggregateIdSerializer(aggregateType);
+
+                var stringAggregateId = orderedMessage.getKey();
+                var aggregateId       = aggregateIdSerializer.deserialize(stringAggregateId);
+
+                var eventOrder = orderedMessage.order;
+                log.trace("Looking up event for aggregate '{}' with id '{}' and event-order {}",
+                          aggregateType,
+                          aggregateId,
+                          eventOrder);
+                var events = eventStore.fetchStream(aggregateType,
+                                                    aggregateId,
+                                                    LongRange.only(eventOrder))
+                                       .orElseThrow(() -> new IllegalArgumentException(msg("Couldn't find a matching event for aggregate '{}' with id '{}' and event-order {}",
+                                                                                           aggregateType,
+                                                                                           aggregateId,
+                                                                                           eventOrder)))
+                                       .eventList();
+                if (events.size() != 1) {
+                    throw new IllegalArgumentException(msg("Couldn't find a matching event for aggregate '{}' with id '{}' and event-order {}",
+                                                           aggregateType,
+                                                           aggregateId,
+                                                           eventOrder));
+                }
+                var persistedEvent = events.get(0);
+                log.debug("[{}:{}] Handling Event of type '{}'", aggregateType, aggregateId, persistedEvent.event().getEventTypeOrNamePersistenceValue());
+                try {
+                    patternMatchingMessageHandlerDelegate.accept(OrderedMessage.of(persistedEvent.event().deserialize(),
+                                                                                   stringAggregateId,
+                                                                                   eventOrder,
+                                                                                   msg.getMetaData()));
+                } catch (JSONDeserializationException e) {
+                    log.error("Failed to deserialize PersistedEvent '{}'", persistedEvent.event().getEventTypeOrNamePersistenceValue(), e);
+                    throw e;
+                }
+            } else {
+                patternMatchingMessageHandlerDelegate.accept(msg);
+            }
+        };
+    }
+
+    /**
+     * Resets all event store subscriptions to their initial state.
+     * This method sets the global event order for each subscription to the first global event order, purges the durable queue
+     * and invokes the provided callback function to reset durable queues.
+     *
+     * @param resetDurableQueueCallback a callback function executed if the durable queue is going to be purged - the actual queue reset logic must be implemented in this callback
+     */
+    protected void resetAllSubscriptions(Consumer<QueueName> resetDurableQueueCallback) {
+        var resetParameters = eventStoreSubscriptions.stream()
+                                                     .map(EventStoreSubscription::aggregateType)
+                                                     .collect(toMap(identity(), aggregateType -> GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER));
+        resetSubscriptions(resetParameters, true, resetDurableQueueCallback);
+    }
+
+    /**
+     * Reset the specific {@link AggregateType} fromAndIncluding the specified {@link GlobalEventOrder}<br>
+     * {@link #onSubscriptionsReset(AggregateType, GlobalEventOrder)} will be called for each {@link AggregateType}<br>
+     * <br>
+     * Note: This method does NOT purge the durable queue
+     *
+     * @param resetAggregateSubscriptionsFromAndIncluding a map of {@link AggregateType} and reset-fromAndIncluding {@link GlobalEventOrder}
+     */
+    protected void resetSubscriptions(Map<AggregateType, GlobalEventOrder> resetAggregateSubscriptionsFromAndIncluding) {
+        resetSubscriptions(resetAggregateSubscriptionsFromAndIncluding, false, queueName -> {
+        });
+    }
+
+    /**
+     * Resets the subscriptions for specified {@link AggregateType}s from a given {@link GlobalEventOrder}
+     * and optionally resets the durable queue once.<br>
+     * {@link #onSubscriptionsReset(AggregateType, GlobalEventOrder)} will be called for each {@link AggregateType}<br>
+     *
+     * @param resetAggregateSubscriptionsFromAndIncluding a map of {@link AggregateType} and the {@link GlobalEventOrder}
+     *                                                    from and including which the subscription should be reset
+     * @param resetDurableQueue                           a flag indicating whether the durable queue should be purged
+     * @param resetDurableQueueCallback                   a callback function executed if the durable queue is going to be purged - the actual queue reset logic must be implemented in this callback
+     */
+    protected void resetSubscriptions(Map<AggregateType, GlobalEventOrder> resetAggregateSubscriptionsFromAndIncluding,
+                                      boolean resetDurableQueue,
+                                      Consumer<QueueName> resetDurableQueueCallback) {
+        requireNonNull(resetAggregateSubscriptionsFromAndIncluding, "resetAggregateSubscriptionsFromAndIncluding is null");
+        requireNonNull(resetDurableQueueCallback, "resetDurableQueueCallback is null");
+        log.info("[{}] Resetting EventProcessor subscriptions with resetDurableQueue '{}'", getProcessorName(), resetDurableQueue);
+        var isResetDurableQueue = new AtomicBoolean(resetDurableQueue);
+        resetAggregateSubscriptionsFromAndIncluding.forEach((aggregateType, resubscribeFromAndIncluding) -> {
+            findSubscription(aggregateType).ifPresentOrElse(eventStoreSubscription -> {
+                                                                doResetSubscription(eventStoreSubscription, resubscribeFromAndIncluding, isResetDurableQueue.get(), resetDurableQueueCallback);
+                                                                isResetDurableQueue.set(false);
+                                                            },
+                                                            () -> {
+                                                                throw new IllegalArgumentException(msg("[{}] Cannot reset subscription for {} '{}' since the {} doesn't subscribe to events for this aggregate type",
+                                                                                                       getProcessorName(),
+                                                                                                       AggregateType.class.getSimpleName(),
+                                                                                                       aggregateType,
+                                                                                                       EventProcessor.class.getSimpleName()));
+                                                            });
+        });
+    }
+
+    /**
+     * Reset subscription from and including global order and reset durable queue with callback (called by {@link #resetSubscriptions(Map, boolean, Consumer)} for each {@link AggregateType} being reset)
+     *
+     * @param eventStoreSubscription      event store subscription
+     * @param resubscribeFromAndIncluding reset from and including global order
+     * @param resetDurableQueue           should durable queue be purged
+     * @param resetDurableQueueCallback   a callback function executed if the durable queue is going to be purged - the actual queue reset logic must be implemented in this callback
+     */
+    protected void doResetSubscription(EventStoreSubscription eventStoreSubscription,
+                                       GlobalEventOrder resubscribeFromAndIncluding,
+                                       boolean resetDurableQueue,
+                                       Consumer<QueueName> resetDurableQueueCallback) {
+        requireNonNull(eventStoreSubscription, "eventStoreSubscription is null");
+        requireNonNull(resubscribeFromAndIncluding, "resubscribeFromAndIncluding is null");
+        requireNonNull(resetDurableQueueCallback, "resetDurableQueueCallback is null");
+
+        log.info("[{}] Resetting subscription for '{}' restartingFromAndIncluding globalEventOrder '{}'",
+                 getProcessorName(),
+                 eventStoreSubscription.subscriberId(),
+                 resubscribeFromAndIncluding);
+
+        eventStoreSubscription.resetFrom(resubscribeFromAndIncluding, r -> {
+            if (resetDurableQueue) {
+                log.info("[{}] Deleting all messages for durable queue'{}'", getProcessorName(), durableQueueName);
+                resetDurableQueueCallback.accept(durableQueueName);
+            }
+            onSubscriptionsReset(eventStoreSubscription.aggregateType(), r);
+        });
+    }
+
+    /**
+     * Finds the {@link EventStoreSubscription} for the specified {@link AggregateType}.
+     * This method searches through the collection of event store subscriptions
+     * to find one that matches the given aggregate type.
+     *
+     * @param aggregateType the {@link AggregateType} for which the subscription is being searched
+     * @return an {@link Optional} containing the found {@link EventStoreSubscription}
+     * if one exists for the specified {@link AggregateType}, or an empty {@link Optional} if not
+     */
+    protected Optional<EventStoreSubscription> findSubscription(AggregateType aggregateType) {
+        return eventStoreSubscriptions.stream()
+                                      .filter(eventStoreSubscription -> eventStoreSubscription.aggregateType().equals(aggregateType))
+                                      .findFirst();
+    }
+
+    /**
+     * Will be called when {@link #resetSubscriptions(Map, boolean, Consumer)}, {@link #resetAllSubscriptions(Consumer)} or {@link #resetSubscriptions(Map)} - override this method
+     * perform any reset related side effects that may be required (e.g. resetting a view)
+     *
+     * @param aggregateType               the {@link AggregateType} for which the subscription is being reset
+     * @param resubscribeFromAndIncluding the {@link GlobalEventOrder} that the subscription will restart from and including
+     */
+    protected void onSubscriptionsReset(AggregateType aggregateType, GlobalEventOrder resubscribeFromAndIncluding) {
+    }
+
+    /**
+     * Resolves the {@link AggregateIdSerializer} for the specified {@link AggregateType}.
+     * Retrieves the {@link AggregateIdSerializer} associated with the given {@link AggregateType}
+     * from the {@link EventStore}'s aggregate event stream configuration.
+     *
+     * @param aggregateType The {@link AggregateType} for which the {@link AggregateIdSerializer} is being resolved.
+     * @return The {@link AggregateIdSerializer} associated with the specified {@link AggregateType}.
+     */
+    protected AggregateIdSerializer resolveAggregateIdSerializer(AggregateType aggregateType) {
+        return ((ConfigurableEventStore<?>) eventStore).getAggregateEventStreamConfiguration(aggregateType).aggregateIdSerializer;
+    }
+
+    /**
+     * Get the name of the underlying durable queue
+     *
+     * @return the {@link QueueName of the underlying durable queue}
+     */
+    public QueueName getDurableQueueName() {
+        return durableQueueName;
+    }
+
+    /**
+     * Get the name of the event processor.<br>
+     * This name is used as value for the underlying {@link EventStoreSubscription#subscriberId()}'s
+     * and for the durable queue's name (queue naming is implementation dependent)
+     *
+     * @return the name of the event processor
+     */
+    public abstract String getProcessorName();
+
+    /**
+     * Get the {@link AggregateType}'s who's events this {@link EventProcessor} is reacting to
+     *
+     * @return the {@link AggregateType}'s who's events this {@link EventProcessor} is reacting to
+     */
+    protected abstract List<AggregateType> reactsToEventsRelatedToAggregateTypes();
+
+    /**
+     * Get the number of message consumption threads that will consume messages from the underlying Durable queue<br>
+     * Default is: 1
+     *
+     * @return the number of message consumption threads that will consume messages from the underlying Durable queue
+     */
+    protected int getNumberOfParallelQueuedMessageConsumers() {
+        return 1;
+    }
+
+    /**
+     * Get the {@link RedeliveryPolicy} used when consuming messages from the underlying Durable queue
+     *
+     * @return the {@link RedeliveryPolicy} used when consuming messages from the underlying Durable queue
+     */
+    protected RedeliveryPolicy getDurableQueueRedeliveryPolicy() {
+        return RedeliveryPolicy.exponentialBackoff()
+                               .setInitialRedeliveryDelay(Duration.ofMillis(200))
+                               .setFollowupRedeliveryDelay(Duration.ofMillis(200))
+                               .setFollowupRedeliveryDelayMultiplier(1.1d)
+                               .setMaximumFollowupRedeliveryDelayThreshold(Duration.ofSeconds(3))
+                               .setMaximumNumberOfRedeliveries(20)
+                               .build();
+    }
+
+    /**
+     * Determines the starting {@link GlobalEventOrder} for new event subscriptions.
+     * Depending on the configuration, it may start from the latest persisted global event order
+     * or from the first global event order.
+     * <p>
+     * If {@link #isStartSubscriptionFromLatestEvent()} is true, the starting global event order
+     * will be the next global event order after the highest persisted one for a given {@link AggregateType}.
+     * If it's false, the subscription will start from {@link GlobalEventOrder#FIRST_GLOBAL_EVENT_ORDER}.
+     *
+     * @return a {@link Function} that provides the starting {@link GlobalEventOrder} for each {@link AggregateType}.
+     */
+    protected Function<AggregateType, GlobalEventOrder> resolveStartSubscriptionFromGlobalEventOrder() {
+        if (isStartSubscriptionFromLatestEvent()) {
+            return aggregateType -> eventStore.getUnitOfWorkFactory().withUnitOfWork(() -> eventStore.findHighestGlobalEventOrderPersisted(aggregateType)
+                                                                                                     .map(GlobalEventOrder::increment)
+                                                                                                     .orElse(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER));
+        }
+        return aggregateType -> GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER;
+    }
+
+    /**
+     * New subscriptions should start consuming events from the latest event. Default false
+     *
+     * @return is new subscriptions should start consuming events from the latest event.
+     */
+    protected boolean isStartSubscriptionFromLatestEvent() {
+        return false;
+    }
+
+    /**
+     * Retrieves the instance of the EventStore associated with this processor
+     *
+     * @return the {@link EventStore} instance
+     */
+    protected final EventStore getEventStore() {
+        return eventStore;
+    }
+
+    /**
+     * Retrieves the instance of the {@link DurableLocalCommandBus} associated with this processor.
+     *
+     * @return the {@link DurableLocalCommandBus} instance
+     */
+    protected final DurableLocalCommandBus getCommandBus() {
+        return commandBus;
+    }
+
+    /**
+     * Variant of {@link OrderedMessage} that stores the {@link AggregateType} associated with the Message as the payload,
+     * the {@link PersistedEvent#aggregateId()} as the {@link OrderedMessage#getKey()} and
+     * the {@link PersistedEvent#eventOrder()} as the {@link OrderedMessage#getOrder()}
+     */
+    public static class EventReferenceOrderedMessage extends OrderedMessage {
+        /**
+         * {@link MessageMetaData} key, that's used as a flag to indicate
+         * that an {@link OrderedMessage} is an {@link EventProcessor.EventReferenceOrderedMessage}
+         */
+        public static final String EVENT_REFERENCE_METADATA_KEY = "EVENT_REFERENCE";
+
+        public EventReferenceOrderedMessage(AggregateType aggregateType, Object aggregateId, EventOrder eventOrder) {
+            this(aggregateType, aggregateId, eventOrder, MessageMetaData.of());
+        }
+
+        public EventReferenceOrderedMessage(AggregateType aggregateType, Object aggregateId, EventOrder eventOrder, MessageMetaData metaData) {
+            super(aggregateType, aggregateId.toString(), eventOrder.longValue(), metaData);
+            metaData.put(EVENT_REFERENCE_METADATA_KEY, "true");
+        }
+
+        public static boolean isEventReference(OrderedMessage msg) {
+            requireNonNull(msg, "No msg provided");
+            return "true".equals(msg.getMetaData().get(EVENT_REFERENCE_METADATA_KEY));
+        }
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessor.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessor.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreSubscription;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
+import dk.cloudcreate.essentials.components.foundation.Lifecycle;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+import org.slf4j.*;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * Experimental: The {@code ViewEventProcessor} class is an abstraction for processing events that are projected into views (e.g. in a relational database).
+ * It integrates with a distributed locking mechanism to ensure exclusive access during processing.<br>
+ * {@link PersistedEvent}'s are processed directly and only in case of an error handling the event will this event (and later events associated with the same aggregate id)
+ * by queued onto the underlying durable queue associated with this processor.
+ */
+public abstract class ViewEventProcessor extends AbstractEventProcessor {
+    private final Logger                        logger = LoggerFactory.getLogger(this.getClass());
+    private final PatternMatchingMessageHandler patternMatchingMessageHandlerDelegate;
+    private final FencedLockManager             fencedLockManager;
+    private final DurableQueues                 durableQueues;
+    private final Consumer<Message>             queuedMessageConsumer;
+    private       DurableQueueConsumer          durableQueueConsumer;
+    private       LockName                      lockName;
+
+    /**
+     * Constructs a {@code ViewEventProcessor} using the provided dependencies.
+     *
+     * @param eventProcessorDependencies the dependencies required for initializing the {@code ViewEventProcessor}.
+     *                                   Must include an {@code EventStoreSubscriptionManager}, a {@code FencedLockManager},
+     *                                   {@code DurableQueues}, a {@code DurableLocalCommandBus}, and a list of
+     *                                   {@code MessageHandlerInterceptor}s.
+     * @throws IllegalArgumentException if {@code eventProcessorDependencies} is null.
+     */
+    protected ViewEventProcessor(ViewEventProcessorDependencies eventProcessorDependencies) {
+        this(requireNonNull(eventProcessorDependencies, "eventProcessorDependencies is null").eventStoreSubscriptionManager(),
+             eventProcessorDependencies.fencedLockManager(),
+             eventProcessorDependencies.durableQueues(),
+             eventProcessorDependencies.commandBus(),
+             eventProcessorDependencies.messageHandlerInterceptors());
+    }
+
+    /**
+     * Constructs a {@code ViewEventProcessor} using the provided dependencies.
+     *
+     * @param subscriptionManager the {@code EventStoreSubscriptionManager} instance used for managing event store subscriptions.
+     * @param fencedLockManager   the {@code FencedLockManager} instance used for obtaining distributed locks.
+     * @param durableQueues       the {@code DurableQueues} instance used for managing durable message queues.
+     * @param commandBus          the {@code DurableLocalCommandBus} instance used for dispatching commands locally.
+     * @param interceptors        a list of {@code MessageHandlerInterceptor} instances used to intercept and process messages.
+     * @throws IllegalArgumentException if any of the required parameters are null.
+     */
+    protected ViewEventProcessor(
+            EventStoreSubscriptionManager subscriptionManager,
+            FencedLockManager fencedLockManager,
+            DurableQueues durableQueues,
+            DurableLocalCommandBus commandBus,
+            List<MessageHandlerInterceptor> interceptors) {
+        super(subscriptionManager, commandBus, interceptors);
+        this.fencedLockManager = requireNonNull(fencedLockManager, "fencedLockManager is null");
+        this.durableQueues = requireNonNull(durableQueues, "durableQueues is null");
+        patternMatchingMessageHandlerDelegate = new PatternMatchingMessageHandler(this, getMessageHandlerInterceptors());
+        patternMatchingMessageHandlerDelegate.allowUnmatchedMessages();
+        queuedMessageConsumer = handleQueuedMessageConsumer(patternMatchingMessageHandlerDelegate);
+    }
+
+    @Override
+    public void start() {
+        if (started) return;
+        started = true;
+        var processorName              = requireNonNull(getProcessorName(), "getProcessorName() returned null");
+        var subscribeToEventsRelatedTo = requireNonNull(reactsToEventsRelatedToAggregateTypes(), "reactsToEventsRelatedToAggregateTypes() returned null");
+        logger.info("🎑⚙️  [{}] Starting ViewEventProcessor - will subscribe to events related to these AggregatesType's: {}",
+                    processorName,
+                    subscribeToEventsRelatedTo);
+        this.durableQueueName = QueueName.of(processorName + ":queue");
+        this.lockName = LockName.of(processorName + ":lock");
+        fencedLockManager.acquireLockAsync(lockName,
+                                           LockCallback.builder()
+                                                       .onLockAcquired(lock -> {
+                                                           logger.info("FencedLock '{}' for ViewProcessor '{}' with DurableQueue '{}' was ACQUIRED - will start Exclusive DurableQueueConsumer", lockName, processorName, durableQueueName);
+                                                           startSubscribersAndDurableConsumer(processorName, subscribeToEventsRelatedTo, lock);
+                                                           logger.info("Exclusive DurableQueueConsumer for Queue '{}': {}", durableQueueName, durableQueueConsumer);
+                                                       })
+                                                       .onLockReleased(lock -> {
+                                                           if (durableQueueConsumer != null) {
+                                                               logger.info("FencedLock '{}' for ViewProcessor '{}' was RELEASED - will stop {} subscriber(s)", lockName, processorName, eventStoreSubscriptions.size());
+                                                               eventStoreSubscriptions.forEach(Lifecycle::stop);
+                                                               logger.info("FencedLock '{}' for ViewProcessor '{}' and DurableQueue '{}' was RELEASED - will stop Exclusive DurableQueueConsumer: {}", lockName, processorName, durableQueueName, durableQueueConsumer);
+                                                               durableQueueConsumer.cancel();
+                                                               logger.info("Stopped Exclusive DurableQueueConsumer for Queue '{}': {}", durableQueueName, durableQueueConsumer);
+                                                           } else {
+                                                               logger.warn("FencedLock '{}' for ViewProcessor '{}' was RELEASED - didn't find an Exclusive DurableQueueConsumer for Queue '{}'!", lockName, processorName, durableQueueName);
+                                                           }
+                                                       })
+                                                       .build());
+    }
+
+    private void startSubscribersAndDurableConsumer(String processorName, List<AggregateType> subscribeToEventsRelatedTo, FencedLock lock) {
+        durableQueueConsumer = durableQueues.consumeFromQueue(durableQueueName,
+                                                              getDurableQueueRedeliveryPolicy(),
+                                                              getNumberOfParallelQueuedMessageConsumers(),
+                                                              queuedMessage -> {
+                                                                  queuedMessage.getMetaData().put(MessageMetaData.FENCED_LOCK_TOKEN,
+                                                                                                  lock.getCurrentToken().toString());
+                                                                  eventStore.getUnitOfWorkFactory().usingUnitOfWork(uow -> {
+                                                                      handleQueuedMessage(queuedMessage);
+                                                                  });
+                                                              }
+                                                             );
+        eventStoreSubscriptions = subscribeToEventsRelatedTo.stream()
+                                                            .map(aggregateType -> {
+                                                                var subscriberId = AbstractEventProcessor.resolveSubscriberId(aggregateType, processorName);
+                                                                var subscription = eventStoreSubscriptionManager.subscribeToAggregateEventsAsynchronously(
+                                                                        subscriberId,
+                                                                        aggregateType,
+                                                                        resolveStartSubscriptionFromGlobalEventOrder(),
+                                                                        this::handlePersistedEvent);
+                                                                logger.info("🎑⚙️ [{}] Created non-exclusive async '{}' subscription: {}",
+                                                                            processorName,
+                                                                            aggregateType,
+                                                                            subscription);
+                                                                return subscription;
+                                                            })
+                                                            .toList();
+
+        logger.info("🎑⚙️  [{}] Started. There are #{} undelivered queue messages",
+                    processorName,
+                    durableQueues.getTotalMessagesQueuedFor(durableQueueName));
+    }
+
+    @Override
+    public void stop() {
+        if (!started) return;
+        started = false;
+        logger.info("🎑⚙️  [{}] Stopping ViewEventProcessor",
+                    getProcessorName());
+        fencedLockManager.cancelAsyncLockAcquiring(lockName);
+        logger.info("🎑⚙️  [{}] ViewEventProcessor Stopped ", getProcessorName());
+    }
+
+    @Override
+    public boolean isStarted() {
+        return started;
+    }
+
+    /**
+     * Retrieves the durable queues associated with this event processor.
+     *
+     * @return the {@link DurableQueues} instance associated with this event processor.
+     */
+    public DurableQueues getDurableQueues() {
+        return durableQueues;
+    }
+
+    private void handlePersistedEvent(PersistedEvent event) {
+        var aggregateType = event.aggregateType();
+        var serializer    = resolveAggregateIdSerializer(aggregateType);
+        var key           = serializer.serialize(event.aggregateId());
+        var order         = event.eventOrder().longValue();
+        var payload       = event.event().deserialize();
+        var meta          = new MessageMetaData(event.metaData().deserialize());
+        var msg           = OrderedMessage.of(payload, key, order, meta);
+
+        try {
+            if (durableQueues.hasOrderedMessageQueuedForKey(durableQueueName, key)) {
+                logger.debug("[{}:{}] The queue already has ordered message queued for key '{}'. Queueing message with event-order '{}'", aggregateType, key, key, order);
+                durableQueues.queueMessage(durableQueueName,
+                                           new EventReferenceOrderedMessage(aggregateType, key, event.eventOrder(), meta));
+            } else {
+                patternMatchingMessageHandlerDelegate.accept(msg);
+            }
+        } catch (Exception e) {
+            logger.debug("[{}:{}] Direct handling failed for event '{}', enqueuing for retry.",
+                         aggregateType, key, event.event().getEventTypeOrNamePersistenceValue(), e);
+            durableQueues.queueMessage(durableQueueName, new EventReferenceOrderedMessage(
+                    aggregateType, key, event.eventOrder(), meta));
+        }
+    }
+
+    private void handleQueuedMessage(QueuedMessage queuedMessage) {
+        if (queuedMessage instanceof EventReferenceOrderedMessage orderedMessage) {
+            logger.debug("[{}] Handling queued message '{}' for Aggregate '{}' with key '{}' and event-order '{}'", durableQueueName, queuedMessage.getId(), orderedMessage.getPayload(), orderedMessage.key, orderedMessage.order);
+        } else {
+            logger.debug("[{}] Handling queued message '{}'", durableQueueName, queuedMessage.getId());
+        }
+        var msg = queuedMessage.getMessage();
+        queuedMessageConsumer.accept(msg);
+    }
+
+    /**
+     * Reset all event store subscriptions and purge the durable queue.
+     *
+     * @see AbstractEventProcessor#resetAllSubscriptions(Consumer)
+     */
+    public void resetAllSubscriptions() {
+        resetAllSubscriptions(durableQueues::purgeQueue);
+    }
+
+    /**
+     * Resets the subscriptions for specified aggregate types starting from the given global event order
+     * and optionally purges the durable queue associated with them.
+     *
+     * @param resetAggregateSubscriptionsFromAndIncluding a map where the key represents the {@link AggregateType} for which the subscription
+     *                                                    will be reset, and the value specifies the {@link GlobalEventOrder} from where the
+     *                                                    subscription should start processing events.
+     * @param resetDurableQueue                           a flag indicating whether the durable queue associated with the subscriptions
+     *                                                    should be purged during the reset.
+     */
+    public void resetSubscriptions(Map<AggregateType, GlobalEventOrder> resetAggregateSubscriptionsFromAndIncluding,
+                                   boolean resetDurableQueue) {
+        resetSubscriptions(resetAggregateSubscriptionsFromAndIncluding,
+                           resetDurableQueue,
+                           durableQueues::purgeQueue);
+
+    }
+
+    /**
+     * Resets the given event store subscription to start processing events from the specified global order
+     * and optionally purges the associated durable queue.
+     *
+     * @param eventStoreSubscription      the event store subscription that will be reset
+     * @param resubscribeFromAndIncluding the global order from which the subscription will start processing events
+     * @param resetDurableQueue           flag indicating whether the associated durable queue should be purged
+     */
+    public void doResetSubscription(EventStoreSubscription eventStoreSubscription,
+                                    GlobalEventOrder resubscribeFromAndIncluding,
+                                    boolean resetDurableQueue) {
+        doResetSubscription(eventStoreSubscription, resubscribeFromAndIncluding, resetDurableQueue, durableQueues::purgeQueue);
+    }
+
+    @Override
+    public String toString() {
+        return "🎑⚙️ " + this.getClass().getSimpleName() + " { " +
+                "processorName='" + getProcessorName() + "'" +
+                ", reactsToEventsRelatedToAggregateTypes=" + reactsToEventsRelatedToAggregateTypes() +
+                ", started=" + started +
+                " }";
+    }
+
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessorDependencies.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessorDependencies.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.MessageHandlerInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+
+import java.util.List;
+
+import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+
+/**
+ * A container class that encapsulates dependencies for the {@link ViewEventProcessor}.
+ */
+public record ViewEventProcessorDependencies(
+        EventStoreSubscriptionManager eventStoreSubscriptionManager,
+        FencedLockManager fencedLockManager,
+        DurableQueues durableQueues,
+        DurableLocalCommandBus commandBus,
+        List<MessageHandlerInterceptor> messageHandlerInterceptors
+) {
+
+    /**
+     * Creates and returns a new instance of {@link ViewEventProcessorDependenciesBuilder}.
+     * This builder is used to construct instances of {@link ViewEventProcessorDependencies}
+     * by allowing the configuration of its dependencies through a fluent API.
+     *
+     * @return a new instance of {@link ViewEventProcessorDependenciesBuilder}
+     */
+    public static ViewEventProcessorDependenciesBuilder builder() {
+        return new ViewEventProcessorDependenciesBuilder();
+    }
+
+    /**
+     * Constructs an instance of {@code ViewEventProcessorDependencies} with the provided dependencies.
+     *
+     * @param eventStoreSubscriptionManager the subscription manager for the event store, used to handle event store subscriptions
+     * @param fencedLockManager             the manager for coordinating distributed locks
+     * @param durableQueues                 the durable queues used for managing reliable message processing
+     * @param commandBus                    the command bus for sending and delivering commands
+     * @param messageHandlerInterceptors    the list of interceptors applied to message handlers
+     */
+    public ViewEventProcessorDependencies(EventStoreSubscriptionManager eventStoreSubscriptionManager,
+                                          FencedLockManager fencedLockManager,
+                                          DurableQueues durableQueues,
+                                          DurableLocalCommandBus commandBus,
+                                          List<MessageHandlerInterceptor> messageHandlerInterceptors) {
+        this.eventStoreSubscriptionManager = requireNonNull(eventStoreSubscriptionManager, "No eventStoreSubscriptionManager provided");
+        this.fencedLockManager = requireNonNull(fencedLockManager, "No fencedLockManager provided");
+        this.durableQueues = requireNonNull(durableQueues, "No durableQueues provided");
+        this.commandBus = requireNonNull(commandBus, "No commandBus provided");
+        this.messageHandlerInterceptors = requireNonNull(messageHandlerInterceptors, "No messageHandlerInterceptors provided");
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessorDependenciesBuilder.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessorDependenciesBuilder.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStore;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.EventStoreSubscriptionManager;
+import dk.cloudcreate.essentials.components.foundation.fencedlock.FencedLockManager;
+import dk.cloudcreate.essentials.components.foundation.messaging.MessageHandler;
+import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.MessageHandlerInterceptor;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.DurableQueues;
+import dk.cloudcreate.essentials.components.foundation.reactive.command.DurableLocalCommandBus;
+import dk.cloudcreate.essentials.reactive.Handler;
+import dk.cloudcreate.essentials.reactive.command.*;
+
+import java.util.List;
+
+/**
+ * Builder class for constructing instances of {@link ViewEventProcessorDependencies}.
+ * This class helps in managing the dependencies required by the {@link ViewEventProcessorDependencies}
+ * by providing a fluent API to set each dependency.
+ * <p>
+ * The builder ensures that the dependencies are set up before creating the
+ * {@link ViewEventProcessorDependencies} instance using the {@code build()} method.
+ */
+public class ViewEventProcessorDependenciesBuilder {
+    private EventStoreSubscriptionManager   eventStoreSubscriptionManager;
+    private FencedLockManager               fencedLockManager;
+    private DurableQueues                   durableQueues;
+    private DurableLocalCommandBus          commandBus;
+    private List<MessageHandlerInterceptor> messageHandlerInterceptors = List.of();
+
+    /**
+     * @param eventStoreSubscriptionManager The {@link EventStoreSubscriptionManager} used for managing {@link EventStore} subscriptions<br>
+     *                                      The  {@link EventStore} instance associated with the {@link EventStoreSubscriptionManager} is used to only query references to
+     *                                      the {@link PersistedEvent}. Before an event reference message is forwarded to the corresponding {@link MessageHandler} we load the {@link PersistedEvent}'s
+     * @return this builder instance
+     */
+    public ViewEventProcessorDependenciesBuilder setEventStoreSubscriptionManager(EventStoreSubscriptionManager eventStoreSubscriptionManager) {
+        this.eventStoreSubscriptionManager = eventStoreSubscriptionManager;
+        return this;
+    }
+
+    /**
+     * @param fencedLockManager the manager providing mechanisms for distributed lock handling
+     * @return this builder instance
+     */
+    public ViewEventProcessorDependenciesBuilder setFencedLockManager(FencedLockManager fencedLockManager) {
+        this.fencedLockManager = fencedLockManager;
+        return this;
+    }
+
+    /**
+     * @param durableQueues a collection of durable queues used for reliable message processing
+     * @return this builder instance
+     */
+    public ViewEventProcessorDependenciesBuilder setDurableQueues(DurableQueues durableQueues) {
+        this.durableQueues = durableQueues;
+        return this;
+    }
+
+    /**
+     * @param commandBus The {@link CommandBus} where any {@link Handler} or {@link CmdHandler} annotated methods in the subclass of the {@link ViewEventProcessor} will be registered
+     * @return this builder instance
+     */
+    public ViewEventProcessorDependenciesBuilder setCommandBus(DurableLocalCommandBus commandBus) {
+        this.commandBus = commandBus;
+        return this;
+    }
+
+    /**
+     * @param messageHandlerInterceptors a list of interceptors that can modify or monitor message handling processes
+     * @return this builder instance
+     */
+    public ViewEventProcessorDependenciesBuilder setMessageHandlerInterceptors(List<MessageHandlerInterceptor> messageHandlerInterceptors) {
+        this.messageHandlerInterceptors = messageHandlerInterceptors;
+        return this;
+    }
+
+    /**
+     * Builds and returns a new {@link ViewEventProcessorDependencies} instance
+     * using the configured dependencies.
+     *
+     * @return an instance of {@link ViewEventProcessorDependencies},
+     *         containing the configured components required for processing view events
+     */
+    public ViewEventProcessorDependencies build() {
+        return new ViewEventProcessorDependencies(eventStoreSubscriptionManager, fencedLockManager, durableQueues, commandBus, messageHandlerInterceptors);
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/BatchedPersistedEventHandler.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/BatchedPersistedEventHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.EventStoreSubscription;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+
+import java.util.List;
+
+/**
+ * Handler for processing batches of {@link PersistedEvent}s. Implementations can
+ * optimize processing by handling events in bulk rather than one at a time.
+ * <p>
+ * This handler is used by the {@link BatchedPersistedEventSubscriber}, which collects
+ * events up to a specified batch size or maximum latency before invoking the handler.
+ */
+public interface BatchedPersistedEventHandler {
+    /**
+     * Handle a batch of {@link PersistedEvent}s. The batch is provided as an immutable
+     * list of events in the order they were received.
+     * <p>
+     * This method is called within the context of a {@link UnitOfWork}
+     * and is automatically retried for IO related exceptions according to the retry policy
+     * configured in the {@link BatchedPersistedEventSubscriber}.
+     * <p>
+     * The method can return an integer indicating the number of events to request from
+     * the event store after processing this batch. A value of 0 or negative means
+     * to request a default of 1 event.
+     *
+     * @param events the batch of events to handle, guaranteed to be non-empty and in order
+     * @return number of events to request next (0 or negative values will request 1 event)
+     */
+    int handleBatch(List<PersistedEvent> events);
+
+    /**
+     * Called when the subscription is reset to start from a specific {@link GlobalEventOrder}
+     *
+     * @param subscription                         the subscription that will be reset
+     * @param subscribeFromAndIncludingGlobalOrder the global order to reset to
+     */
+    default void onResetFrom(EventStoreSubscription subscription, GlobalEventOrder subscribeFromAndIncludingGlobalOrder) {
+        // Default is no-op
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/BatchedPersistedEventSubscriber.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/BatchedPersistedEventSubscriber.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription;
+
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.PersistedEvent;
+import dk.cloudcreate.essentials.components.foundation.IOExceptionUtil;
+import dk.cloudcreate.essentials.shared.Exceptions;
+import dk.cloudcreate.essentials.shared.collections.Lists;
+import org.reactivestreams.Subscription;
+import org.slf4j.*;
+import reactor.core.publisher.*;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.*;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.concurrent.locks.*;
+import java.util.function.BiConsumer;
+
+import static dk.cloudcreate.essentials.shared.FailFast.*;
+import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+
+/**
+ * Batching alternative to the {@link EventStoreSubscriptionManager.DefaultEventStoreSubscriptionManager.PersistedEventSubscriber} that processes events in batches
+ * to improve throughput and reduce database load. This is a specialized subscriber
+ * that should be used when high throughput is needed and the event handlers can
+ * efficiently process batches of events.
+ * <p>
+ * Key features:
+ * <ul>
+ *   <li>Processes events in batches for improved throughput</li>
+ *   <li>Uses the same retry mechanism as PersistedEventSubscriber</li>
+ *   <li>Tracks batch progress and updates resume points only after entire batch completes</li>
+ *   <li>Only requests more events after batch processing completes</li>
+ *   <li>Supports max latency for processing partial batches</li>
+ * </ul>
+ */
+public class BatchedPersistedEventSubscriber extends BaseSubscriber<PersistedEvent> {
+    private static final Logger log = LoggerFactory.getLogger(BatchedPersistedEventSubscriber.class);
+
+    private final BatchedPersistedEventHandler          eventHandler;
+    private final EventStoreSubscription                eventStoreSubscription;
+    private final BiConsumer<PersistedEvent, Throwable> onErrorHandler;
+    private final RetryBackoffSpec                      forwardToEventHandlerRetryBackoffSpec;
+    private final long                                  eventStorePollingBatchSize;
+    private final EventStore                            eventStore;
+    private final int                                   maxBatchSize;
+    private final Duration                              maxLatency;
+
+    // Thread-safe priority queue of events being collected for a batch, sorted by global event order
+    private final ConcurrentLinkedQueue<PersistedEvent> eventQueue;
+    private final AtomicInteger                         queueSize;
+    private final Lock                                  processingLock;
+    private final ScheduledExecutorService              scheduler;
+    private final AtomicReference<ScheduledFuture<?>>   scheduledProcessing;
+    private final AtomicLong                            lastEventTimestamp;
+
+    /**
+     * Subscribe with indefinite retries in relation to Exceptions where {@link IOExceptionUtil#isIOException(Throwable)} return true
+     *
+     * @param eventHandler               The event handler that batches of {@link PersistedEvent}'s are forwarded to
+     * @param eventStoreSubscription     the {@link EventStoreSubscription} (as created by {@link EventStoreSubscriptionManager})
+     * @param onErrorHandler             The error handler called for any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec})
+     *                                   Similar to the {@link EventStoreSubscriptionManager.DefaultEventStoreSubscriptionManager.PersistedEventSubscriber} error handler
+     * @param eventStorePollingBatchSize The batch size used when polling events from the {@link EventStore}
+     * @param eventStore                 The {@link EventStore} to use
+     * @param maxBatchSize               The maximum number of events to include in a batch before processing
+     * @param maxLatency                 The maximum time to wait before processing a partial batch
+     */
+    public BatchedPersistedEventSubscriber(BatchedPersistedEventHandler eventHandler,
+                                           EventStoreSubscription eventStoreSubscription,
+                                           BiConsumer<PersistedEvent, Throwable> onErrorHandler,
+                                           long eventStorePollingBatchSize,
+                                           EventStore eventStore,
+                                           int maxBatchSize,
+                                           Duration maxLatency) {
+        this(eventHandler,
+             eventStoreSubscription,
+             onErrorHandler,
+             Retry.backoff(Long.MAX_VALUE, Duration.ofMillis(100)) // Initial delay of 100ms
+                  .maxBackoff(Duration.ofSeconds(1)) // Maximum backoff of 1 second
+                  .jitter(0.5)
+                  .filter(IOExceptionUtil::isIOException),
+             eventStorePollingBatchSize,
+             eventStore,
+             maxBatchSize,
+             maxLatency);
+    }
+
+    /**
+     * Subscribe with custom {@link RetryBackoffSpec}
+     *
+     * @param eventHandler                          The event handler that batches of {@link PersistedEvent}'s are forwarded to
+     * @param eventStoreSubscription                the {@link EventStoreSubscription} (as created by {@link EventStoreSubscriptionManager})
+     * @param onErrorHandler                        The error handler called for any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec})
+     * @param forwardToEventHandlerRetryBackoffSpec The {@link RetryBackoffSpec} used
+     * @param eventStorePollingBatchSize            The batch size used when polling events from the {@link EventStore}
+     * @param eventStore                            The {@link EventStore} to use
+     * @param maxBatchSize                          The maximum number of events to include in a batch before processing
+     * @param maxLatency                            The maximum time to wait before processing a partial batch
+     */
+    public BatchedPersistedEventSubscriber(BatchedPersistedEventHandler eventHandler,
+                                           EventStoreSubscription eventStoreSubscription,
+                                           BiConsumer<PersistedEvent, Throwable> onErrorHandler,
+                                           RetryBackoffSpec forwardToEventHandlerRetryBackoffSpec,
+                                           long eventStorePollingBatchSize,
+                                           EventStore eventStore,
+                                           int maxBatchSize,
+                                           Duration maxLatency) {
+        this.eventHandler = requireNonNull(eventHandler, "No eventHandler provided");
+        this.eventStoreSubscription = requireNonNull(eventStoreSubscription, "No eventStoreSubscription provided");
+        this.onErrorHandler = requireNonNull(onErrorHandler, "No errorHandler provided");
+        this.forwardToEventHandlerRetryBackoffSpec = requireNonNull(forwardToEventHandlerRetryBackoffSpec, "No retryBackoffSpec provided");
+        this.eventStorePollingBatchSize = eventStorePollingBatchSize;
+        this.eventStore = requireNonNull(eventStore, "No eventStore provided");
+        this.maxBatchSize = maxBatchSize;
+        this.maxLatency = requireNonNull(maxLatency, "No maxLatency provided");
+
+        requireTrue(eventStorePollingBatchSize > 0, "eventStorePollingBatchSize must be > 0");
+        requireTrue(maxBatchSize > 0, "maxBatchSize must be > 0");
+
+        // Verify that the provided eventStoreSubscription supports resume-points
+        eventStoreSubscription.currentResumePoint().orElseThrow(() ->
+                                                                        new IllegalArgumentException(msg("The provided {} doesn't support resume-points",
+                                                                                                         eventStoreSubscription.getClass().getName())));
+
+        // Initialize thread-safe collections and scheduler
+        this.eventQueue = new ConcurrentLinkedQueue<>();
+        this.queueSize = new AtomicInteger(0);
+        this.processingLock = new ReentrantLock();
+        this.lastEventTimestamp = new AtomicLong(System.currentTimeMillis());
+
+        // Create a daemon scheduler for the latency-based batch processing
+        var executor = new ScheduledThreadPoolExecutor(1, r -> {
+            Thread thread = new Thread(r);
+            thread.setName("BatchedEventSubscriber-" + eventStoreSubscription.subscriberId() + "-Timer");
+            thread.setDaemon(true);
+            return thread;
+        });
+        executor.setRemoveOnCancelPolicy(true);
+        this.scheduler = executor;
+        this.scheduledProcessing = new AtomicReference<>();
+
+        // Schedule the first check for partial batches
+        schedulePartialBatchProcessing();
+    }
+
+    @Override
+    protected void hookOnSubscribe(Subscription subscription) {
+        log.debug("[{}-{}] On Subscribe with eventStorePollingBatchSize {}, maxBatchSize {}, maxLatency {}",
+                  eventStoreSubscription.subscriberId(),
+                  eventStoreSubscription.aggregateType(),
+                  eventStorePollingBatchSize,
+                  maxBatchSize,
+                  maxLatency
+                 );
+        eventStoreSubscription.request(eventStorePollingBatchSize);
+    }
+
+    @Override
+    protected void hookOnNext(PersistedEvent event) {
+        // Add the event to our queue
+        eventQueue.add(event);
+        int currentSize = queueSize.incrementAndGet();
+        lastEventTimestamp.set(System.currentTimeMillis());
+
+        log.trace("[{}-{}] Added event #{} to batch (batch size: {}/{})",
+                  eventStoreSubscription.subscriberId(),
+                  eventStoreSubscription.aggregateType(),
+                  event.globalEventOrder(),
+                  currentSize,
+                  maxBatchSize);
+
+        // Process the batch if we've reached max batch size
+        if (currentSize >= maxBatchSize) {
+            processBatchIfNotAlreadyProcessing();
+        }
+    }
+
+    @Override
+    protected void hookOnComplete() {
+        // Process any remaining events in the batch when the stream completes
+        if (!eventQueue.isEmpty()) {
+            processBatchIfNotAlreadyProcessing();
+        }
+
+        // Clean up the scheduler
+        cancelScheduledProcessing();
+        scheduler.shutdown();
+
+        super.hookOnComplete();
+    }
+
+    @Override
+    protected void hookOnCancel() {
+        // Clean up the scheduler
+        cancelScheduledProcessing();
+        scheduler.shutdown();
+
+        super.hookOnCancel();
+    }
+
+    @Override
+    protected void hookOnError(Throwable throwable) {
+        // Clean up the scheduler
+        cancelScheduledProcessing();
+        scheduler.shutdown();
+
+        super.hookOnError(throwable);
+    }
+
+    /**
+     * Schedule a check for partial batch processing based on max latency
+     */
+    private void schedulePartialBatchProcessing() {
+        // Cancel any existing scheduled task
+        cancelScheduledProcessing();
+
+        // Schedule a new check
+        var future = scheduler.schedule(() -> {
+            try {
+                var currentTime   = System.currentTimeMillis();
+                var lastEventTime = lastEventTimestamp.get();
+                var currentSize   = queueSize.get();
+
+                // Process if we have events and have exceeded max latency
+                if (currentSize > 0 && currentTime - lastEventTime >= maxLatency.toMillis()) {
+                    log.debug("[{}-{}] Processing partial batch of {} events due to max latency ({} ms)",
+                              eventStoreSubscription.subscriberId(),
+                              eventStoreSubscription.aggregateType(),
+                              currentSize,
+                              maxLatency.toMillis());
+
+                    processBatchIfNotAlreadyProcessing();
+                }
+            } catch (Throwable t) {
+                log.error("[{}-{}] Error in scheduled partial batch processing",
+                          eventStoreSubscription.subscriberId(),
+                          eventStoreSubscription.aggregateType(),
+                          t);
+            } finally {
+                // Reschedule for next check if not disposed
+                if (!isDisposed()) {
+                    schedulePartialBatchProcessing();
+                }
+            }
+        }, maxLatency.toMillis(), TimeUnit.MILLISECONDS);
+
+        scheduledProcessing.set(future);
+    }
+
+    /**
+     * Cancel any scheduled batch processing
+     */
+    private void cancelScheduledProcessing() {
+        ScheduledFuture<?> future = scheduledProcessing.getAndSet(null);
+        if (future != null && !future.isDone()) {
+            future.cancel(false);
+        }
+    }
+
+    /**
+     * Process the current batch of events if not already processing
+     */
+    private void processBatchIfNotAlreadyProcessing() {
+        // Only process if we can acquire the lock
+        if (processingLock.tryLock()) {
+            try {
+                processBatch();
+            } finally {
+                processingLock.unlock();
+            }
+        } else {
+            log.trace("[{}-{}] Batch processing already in progress, skipping",
+                      eventStoreSubscription.subscriberId(),
+                      eventStoreSubscription.aggregateType());
+        }
+    }
+
+    /**
+     * A lock to ensure that batch processing occurs sequentially
+     */
+    private final Lock batchProcessingSequenceLock = new ReentrantLock();
+
+    /**
+     * Process the current batch of events
+     */
+    private void processBatch() {
+        // Return early if queue is empty
+        if (eventQueue.isEmpty()) {
+            return;
+        }
+
+        // Create a list from the current queue and reset queue
+        var            currentBatch = new ArrayList<PersistedEvent>(queueSize.get());
+        PersistedEvent event;
+        while ((event = eventQueue.poll()) != null) {
+            currentBatch.add(event);
+        }
+
+        // Reset the queue size counter
+        queueSize.set(0);
+
+        // Safety check
+        if (currentBatch.isEmpty()) {
+            return;
+        }
+
+        // Sort the batch by global event order to ensure in-order processing within the batch
+        currentBatch.sort(Comparator.comparing(PersistedEvent::globalEventOrder));
+
+        var firstEvent     = Lists.first(currentBatch).get();
+        var lastEvent      = Lists.last(currentBatch).get();
+        var immutableBatch = Collections.unmodifiableList(currentBatch);
+
+        log.debug("[{}-{}] Processing batch of {} events (global event order: [#{} - #{}])",
+                  eventStoreSubscription.subscriberId(),
+                  eventStoreSubscription.aggregateType(),
+                  currentBatch.size(),
+                  firstEvent.globalEventOrder(),
+                  lastEvent.globalEventOrder());
+
+        // Process the batch in a unit of work
+        Mono.fromCallable(() -> {
+                // Acquire the sequential processing lock to ensure batches are processed in order
+                batchProcessingSequenceLock.lock();
+                try {
+                    log.trace("[{}-{}] Forwarding batch of {} events (global event order: [#{} - #{}]) to EventHandler",
+                              eventStoreSubscription.subscriberId(),
+                              eventStoreSubscription.aggregateType(),
+                              immutableBatch.size(),
+                              firstEvent.globalEventOrder(),
+                              lastEvent.globalEventOrder());
+
+                    return eventStore.getUnitOfWorkFactory()
+                                     .withUnitOfWork(unitOfWork -> eventHandler.handleBatch(immutableBatch));
+                } finally {
+                    batchProcessingSequenceLock.unlock();
+                }
+            })
+            .subscribeOn(Schedulers.single())
+            .retryWhen(forwardToEventHandlerRetryBackoffSpec
+                               .doBeforeRetry(retrySignal -> {
+                                   log.trace("[{}-{}] Ready to perform {} attempt retry of batch processing (last event: #{})",
+                                             eventStoreSubscription.subscriberId(),
+                                             eventStoreSubscription.aggregateType(),
+                                             retrySignal.totalRetries() + 1,
+                                             lastEvent.globalEventOrder());
+                               })
+                               .doAfterRetry(retrySignal -> {
+                                   log.debug("[{}-{}] {} {} retry of batch processing (last event: #{})",
+                                             eventStoreSubscription.subscriberId(),
+                                             eventStoreSubscription.aggregateType(),
+                                             retrySignal.failure() != null ? "Failed" : "Succeeded",
+                                             retrySignal.totalRetries(),
+                                             lastEvent.globalEventOrder());
+                               }))
+            .doFinally(signalType -> {
+                // Update the resume point to after the last event in the batch
+                eventStoreSubscription.currentResumePoint().get()
+                                      .setResumeFromAndIncluding(lastEvent.globalEventOrder().increment());
+
+                // Reschedule latency check
+                schedulePartialBatchProcessing();
+            })
+            .subscribe(requestSize -> {
+                           // Handle the request for more events
+                           if (requestSize < 0) {
+                               requestSize = 1;
+                           }
+                           log.trace("[{}-{}] (#{}) Requesting {} events from the EventStore",
+                                     eventStoreSubscription.subscriberId(),
+                                     eventStoreSubscription.aggregateType(),
+                                     lastEvent.globalEventOrder(),
+                                     requestSize);
+                           if (requestSize > 0) {
+                               eventStoreSubscription.request(requestSize);
+                           }
+                       },
+                       error -> {
+                           // Handle errors for the entire batch
+                           Exceptions.rethrowIfCriticalError(error);
+                           onErrorHandler.accept(lastEvent, error.getCause());
+                       });
+    }
+}

--- a/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
+++ b/components/postgresql-event-store/src/main/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/EventStoreSubscriptionManager.java
@@ -46,7 +46,7 @@ import java.util.function.*;
 import java.util.stream.Collectors;
 
 import static dk.cloudcreate.essentials.shared.Exceptions.rethrowIfCriticalError;
-import static dk.cloudcreate.essentials.shared.FailFast.requireNonNull;
+import static dk.cloudcreate.essentials.shared.FailFast.*;
 import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
 
 /**
@@ -95,6 +95,40 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                                                     GlobalEventOrder onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
                                                                     Optional<Tenant> onlyIncludeEventsForTenant,
                                                                     PersistedEventHandler eventHandler);
+
+    /**
+     * Create an asynchronous batched subscription that will receive {@link PersistedEvent}s in batches after they have been committed to the {@link EventStore}<br>
+     * This ensures that the handling of events can occur in a separate transaction, than the one that persisted the events, thereby avoiding the dual write problem<br>
+     * This subscription method is a batching alternative that processes events in batches
+     * to improve throughput, at the cost of higher latency, and reduce database load. It should be used when high throughput is needed and the event handlers can
+     * efficiently process batches of events.
+     * <p>
+     * Key features:
+     * <ul>
+     *   <li>Processes events in batches for improved throughput</li>
+     *   <li>Tracks batch progress and updates resume points only after entire batch completes</li>
+     *   <li>Only requests more events after batch processing completes</li>
+     *   <li>Supports max latency for processing partial batches</li>
+     * </ul>
+     *
+     * @param subscriberId                                            the unique id for the subscriber
+     * @param forAggregateType                                        the type of aggregate that we're subscribing for {@link PersistedEvent}'s related to
+     * @param onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder If it's the first time the given <code>subscriberId</code> is subscribing then the subscription will be using this {@link GlobalEventOrder} as the starting point in the
+     *                                                                EventStream associated with the <code>aggregateType</code>
+     * @param onlyIncludeEventsForTenant                              if {@link Optional#isPresent()} then only include events that belong to the specified {@link Tenant}, otherwise all Events matching the criteria are returned
+     * @param maxBatchSize                                            the maximum batch size before processing
+     * @param maxLatency                                              the maximum time to wait before processing a partial batch
+     * @param eventHandler                                            the event handler that will receive the published {@link PersistedEvent}'s in batches<br>
+     *                                                                Exceptions thrown from the eventHandler will cause the events to be skipped.
+     * @return the subscription handle
+     */
+    EventStoreSubscription batchSubscribeToAggregateEventsAsynchronously(SubscriberId subscriberId,
+                                                                         AggregateType forAggregateType,
+                                                                         GlobalEventOrder onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
+                                                                         Optional<Tenant> onlyIncludeEventsForTenant,
+                                                                         int maxBatchSize,
+                                                                         Duration maxLatency,
+                                                                         BatchedPersistedEventHandler eventHandler);
 
     /**
      * Create an asynchronous subscription that will receive {@link PersistedEvent} after they have been committed to the {@link EventStore}<br>
@@ -747,6 +781,30 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                                                                                       onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
                                                                                       onlyIncludeEventsForTenant,
                                                                                       eventHandler));
+        }
+
+        @Override
+        public EventStoreSubscription batchSubscribeToAggregateEventsAsynchronously(SubscriberId subscriberId,
+                                                                                    AggregateType forAggregateType,
+                                                                                    GlobalEventOrder onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
+                                                                                    Optional<Tenant> onlyIncludeEventsForTenant,
+                                                                                    int maxBatchSize,
+                                                                                    Duration maxLatency,
+                                                                                    BatchedPersistedEventHandler eventHandler) {
+            requireNonNull(onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder, "No onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder provided");
+            requireNonNull(onlyIncludeEventsForTenant, "No onlyIncludeEventsForTenant option provided");
+            requireNonNull(eventHandler, "No eventHandler provided");
+            return addEventStoreSubscription(subscriberId,
+                                             forAggregateType,
+                                             new NonExclusiveBatchedAsynchronousSubscription(eventStore,
+                                                                                             durableSubscriptionRepository,
+                                                                                             forAggregateType,
+                                                                                             subscriberId,
+                                                                                             onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
+                                                                                             onlyIncludeEventsForTenant,
+                                                                                             maxBatchSize,
+                                                                                             maxLatency,
+                                                                                             eventHandler));
         }
 
         @Override
@@ -1511,8 +1569,6 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                         ", started=" + started +
                         '}';
             }
-
-
         }
 
         private class ExclusiveAsynchronousSubscription implements EventStoreSubscription {
@@ -1856,205 +1912,485 @@ public interface EventStoreSubscriptionManager extends Lifecycle {
                         '}';
             }
         }
-    }
 
-    /**
-     * Generic {@link BaseSubscriber} which forwards to the provided {@link PersistedEventHandler}
-     * with backpressure and handles indefinite retries in relation to {@link IOExceptionUtil#isIOException(Throwable)},
-     * if using constructor without any specified {@link RetryBackoffSpec}, updates {@link SubscriptionResumePoint} after each event handled
-     * and delegates any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec}) to the provided <code>onErrorHandler</code>,
-     * which is responsible for error handling and for calling {@link EventStoreSubscription#request(long)} to continue event processing
-     */
-    class PersistedEventSubscriber extends BaseSubscriber<PersistedEvent> {
-        private static final Logger log = LoggerFactory.getLogger(PersistedEventSubscriber.class);
+        private class NonExclusiveBatchedAsynchronousSubscription implements EventStoreSubscription {
+            private final EventStore                     eventStore;
+            private final DurableSubscriptionRepository  durableSubscriptionRepository;
+            private final AggregateType                  aggregateType;
+            private final SubscriberId                   subscriberId;
+            private final GlobalEventOrder               onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder;
+            private final Optional<Tenant>               onlyIncludeEventsForTenant;
+            private final int                            maxBatchSize;
+            private final Duration                       maxLatency;
+            private final BatchedPersistedEventHandler   eventHandler;
+            private       SubscriptionResumePoint        resumePoint;
+            private       BaseSubscriber<PersistedEvent> subscription;
 
-        private final PersistedEventHandler                 eventHandler;
-        private final EventStoreSubscription                eventStoreSubscription;
-        private final BiConsumer<PersistedEvent, Throwable> onErrorHandler;
-        private final RetryBackoffSpec                      forwardToEventHandlerRetryBackoffSpec;
-        private final long                                  eventStorePollingBatchSize;
-        private final EventStore                            eventStore;
+            private volatile boolean started;
 
-        /**
-         * Subscribe with indefinite retries in relation to Exceptions where {@link IOExceptionUtil#isIOException(Throwable)} return true
-         *
-         * @param eventHandler               The event handler that {@link PersistedEvent}'s are forwarded to
-         * @param eventStoreSubscription     the {@link EventStoreSubscription} (as created by {@link EventStoreSubscriptionManager})
-         * @param onErrorHandler             The error handler called for any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec})<br>
-         *                                   <b>Note: Default behaviour needs to at least request one more event</b><br>
-         *                                   Similar to:
-         *                                   <pre>{@code
-         *                                   void onErrorHandlingEvent(PersistedEvent e, Throwable cause) {
-         *                                        log.error(msg("[{}-{}] (#{}) Skipping {} event because of error",
-         *                                                        subscriberId,
-         *                                                        aggregateType,
-         *                                                        e.globalEventOrder(),
-         *                                                        e.event().getEventTypeOrName().getValue()), cause);
-         *                                        log.trace("[{}-{}] (#{}) Requesting 1 event from the EventStore",
-         *                                                    subscriberId(),
-         *                                                    aggregateType(),
-         *                                                    e.globalEventOrder()
-         *                                                    );
-         *                                        eventStoreSubscription.request(1);
-         *                                   }
-         *                                   }</pre>
-         * @param eventStorePollingBatchSize The batch size used when polling events from the {@link EventStore}
-         * @param eventStore                 The {@link EventStore} to use
-         */
-        public PersistedEventSubscriber(PersistedEventHandler eventHandler,
-                                        EventStoreSubscription eventStoreSubscription,
-                                        BiConsumer<PersistedEvent, Throwable> onErrorHandler,
-                                        long eventStorePollingBatchSize,
-                                        EventStore eventStore) {
-            this(eventHandler,
-                 eventStoreSubscription,
-                 onErrorHandler,
-                 Retry.backoff(Long.MAX_VALUE, Duration.ofMillis(100)) // Initial delay of 100ms
-                      .maxBackoff(Duration.ofSeconds(1)) // Maximum backoff of 1 second
-                      .jitter(0.5)
-                      .filter(IOExceptionUtil::isIOException),
-                 eventStorePollingBatchSize,
-                 eventStore);
-        }
+            public NonExclusiveBatchedAsynchronousSubscription(EventStore eventStore,
+                                                               DurableSubscriptionRepository durableSubscriptionRepository,
+                                                               AggregateType aggregateType,
+                                                               SubscriberId subscriberId,
+                                                               GlobalEventOrder onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
+                                                               Optional<Tenant> onlyIncludeEventsForTenant,
+                                                               int maxBatchSize,
+                                                               Duration maxLatency,
+                                                               BatchedPersistedEventHandler eventHandler) {
+                this.eventStore = requireNonNull(eventStore, "No eventStore provided");
+                this.durableSubscriptionRepository = requireNonNull(durableSubscriptionRepository, "No durableSubscriptionRepository provided");
+                this.aggregateType = requireNonNull(aggregateType, "No aggregateType provided");
+                this.subscriberId = requireNonNull(subscriberId, "No subscriberId provided");
+                this.onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder = requireNonNull(onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
+                                                                                              "No onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder provided");
+                this.onlyIncludeEventsForTenant = requireNonNull(onlyIncludeEventsForTenant, "No onlyIncludeEventsForTenant provided");
 
-        /**
-         * Subscribe with custom {@link RetryBackoffSpec}
-         *
-         * @param eventHandler                          The event handler that {@link PersistedEvent}'s are forwarded to
-         * @param eventStoreSubscription                the {@link EventStoreSubscription} (as created by {@link EventStoreSubscriptionManager})
-         * @param onErrorHandler                        The error handler called for any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec})<br>
-         *                                              <b>Note: Default behaviour needs to at least request one more event</b><br>
-         *                                              Similar to:
-         *                                              <pre>{@code
-         *                                              void onErrorHandlingEvent(PersistedEvent e, Throwable cause) {
-         *                                                   log.error(msg("[{}-{}] (#{}) Skipping {} event because of error",
-         *                                                                   subscriberId,
-         *                                                                   aggregateType,
-         *                                                                   e.globalEventOrder(),
-         *                                                                   e.event().getEventTypeOrName().getValue()), cause);
-         *                                                   log.trace("[{}-{}] (#{}) Requesting 1 event from the EventStore",
-         *                                                               subscriberId(),
-         *                                                               aggregateType(),
-         *                                                               e.globalEventOrder()
-         *                                                               );
-         *                                                   eventStoreSubscription.request(1);
-         *                                              }
-         *                                              }</pre>
-         * @param forwardToEventHandlerRetryBackoffSpec The {@link RetryBackoffSpec} used.<br>
-         *                                              Example:
-         *                                              <pre>{@code
-         *                                              Retry.backoff(Long.MAX_VALUE, Duration.ofMillis(100)) // Initial delay of 100ms
-         *                                                   .maxBackoff(Duration.ofSeconds(1)) // Maximum backoff of 1 second
-         *                                                   .jitter(0.5)
-         *                                                   .filter(IOExceptionUtil::isIOException)
-         *                                              }
-         *                                              </pre>
-         * @param eventStorePollingBatchSize            The batch size used when polling events from the {@link EventStore}
-         * @param eventStore                            The {@link EventStore} to use
-         */
-        public PersistedEventSubscriber(PersistedEventHandler eventHandler,
-                                        EventStoreSubscription eventStoreSubscription,
-                                        BiConsumer<PersistedEvent, Throwable> onErrorHandler,
-                                        RetryBackoffSpec forwardToEventHandlerRetryBackoffSpec,
-                                        long eventStorePollingBatchSize,
-                                        EventStore eventStore) {
-            this.eventHandler = requireNonNull(eventHandler, "No eventHandler provided");
-            this.eventStoreSubscription = requireNonNull(eventStoreSubscription, "No eventStoreSubscription provided");
-            this.onErrorHandler = requireNonNull(onErrorHandler, "No errorHandler provided");
-            this.forwardToEventHandlerRetryBackoffSpec = requireNonNull(forwardToEventHandlerRetryBackoffSpec, "No retryBackoffSpec provided");
-            this.eventStorePollingBatchSize = eventStorePollingBatchSize;
-            this.eventStore = requireNonNull(eventStore, "No eventStore provided");
-            // Verify that the provided eventStoreSubscription supports resume-points
-            eventStoreSubscription.currentResumePoint().orElseThrow(() -> new IllegalArgumentException(msg("The provided {} doesn't support resume-points", eventStoreSubscription.getClass().getName())));
-        }
+                requireTrue(maxBatchSize > 0, "maxBatchSize must be greater than 0");
+                this.maxBatchSize = maxBatchSize;
+                this.maxLatency = requireNonNull(maxLatency, "No maxLatency provided");
+                this.eventHandler = requireNonNull(eventHandler, "No eventHandler provided");
+            }
 
-        @Override
-        protected void hookOnSubscribe(Subscription subscription) {
-            log.debug("[{}-{}] On Subscribe with eventStorePollingBatchSize {}",
-                      eventStoreSubscription.subscriberId(),
-                      eventStoreSubscription.aggregateType(),
-                      eventStorePollingBatchSize
-                     );
-            eventStoreSubscription.request(eventStorePollingBatchSize);
-        }
+            @Override
+            public SubscriberId subscriberId() {
+                return subscriberId;
+            }
 
-        @Override
-        protected void hookOnNext(PersistedEvent e) {
-            Mono.fromCallable(() -> {
-                    log.trace("[{}-{}] (#{}) Forwarding {} event with eventId '{}', aggregateId: '{}', eventOrder: {} to EventHandler",
-                              eventStoreSubscription.subscriberId(),
-                              eventStoreSubscription.aggregateType(),
+            @Override
+            public AggregateType aggregateType() {
+                return aggregateType;
+            }
+
+            @Override
+            public void start() {
+                if (!started) {
+                    started = true;
+                    log.info("[{}-{}] Looking up subscription resumePoint",
+                             subscriberId,
+                             aggregateType);
+                    var resolveResumePointTiming = StopWatch.start("resolveResumePoint (" + subscriberId + ", " + aggregateType + ")");
+                    resumePoint = durableSubscriptionRepository.getOrCreateResumePoint(subscriberId,
+                                                                                       aggregateType,
+                                                                                       onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder);
+                    log.info("[{}-{}] Starting subscription from globalEventOrder: {}",
+                             subscriberId,
+                             aggregateType,
+                             resumePoint.getResumeFromAndIncluding());
+                    eventStoreSubscriptionObserver.resolveResumePoint(resumePoint,
+                                                                      onFirstSubscriptionSubscribeFromAndIncludingGlobalOrder,
+                                                                      DefaultEventStoreSubscriptionManager.NonExclusiveBatchedAsynchronousSubscription.this,
+                                                                      resolveResumePointTiming.stop().getDuration());
+
+                    subscription = new BatchedPersistedEventSubscriber(
+                            eventHandler,
+                            this,
+                            this::onErrorHandlingEvent,
+                            eventStorePollingBatchSize,
+                            eventStore,
+                            maxBatchSize,
+                            maxLatency);
+                    eventStore.pollEvents(aggregateType,
+                                          resumePoint.getResumeFromAndIncluding(),
+                                          Optional.of(eventStorePollingBatchSize),
+                                          Optional.of(eventStorePollingInterval),
+                                          onlyIncludeEventsForTenant,
+                                          Optional.of(subscriberId))
+                              .limitRate(eventStorePollingBatchSize)
+                              .subscribe(subscription);
+                } else {
+                    log.debug("[{}-{}] Subscription was already started",
+                              subscriberId,
+                              aggregateType);
+                }
+            }
+
+            @Override
+            public void request(long n) {
+                if (!started) {
+                    log.warn("[{}-{}] Cannot request {} event(s) as the subscriber isn't active",
+                             subscriberId,
+                             aggregateType,
+                             n);
+                    return;
+                }
+                log.trace("[{}-{}] Requesting {} event(s)",
+                          subscriberId,
+                          aggregateType,
+                          n);
+                eventStoreSubscriptionObserver.requestingEvents(n, this);
+                subscription.request(n);
+            }
+
+            /**
+             * The error handler called for any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec})<br>
+             * <b>Note: Default behaviour needs to at least request one more event</b><br>
+             * Similar to:
+             * <pre>{@code
+             * void onErrorHandlingEvent(PersistedEvent e, Throwable cause) {
+             *      log.error(msg("[{}-{}] (#{}) Skipping {} event because of error",
+             *                      subscriberId,
+             *                      aggregateType,
+             *                      e.globalEventOrder(),
+             *                      e.event().getEventTypeOrName().getValue()), cause);
+             *      log.trace("[{}-{}] (#{}) Requesting 1 event from the EventStore",
+             *                  subscriberId(),
+             *                  aggregateType(),
+             *                  e.globalEventOrder()
+             *                  );
+             *      eventStoreSubscription.request(1);
+             * }
+             * }</pre>
+             *
+             * @param e     the event that failed
+             * @param cause the cause of the failure
+             */
+            /**
+             * Error handler for batched event processing
+             */
+            protected void onErrorHandlingEvent(PersistedEvent e, Throwable cause) {
+                log.error(msg("[{}-{}] (#{}) Skipping {} event because of error",
+                              subscriberId,
+                              aggregateType,
                               e.globalEventOrder(),
-                              e.event().getEventTypeOrName().toString(),
-                              e.eventId(),
-                              e.aggregateId(),
-                              e.eventOrder()
-                             );
-                    return eventStore.getUnitOfWorkFactory()
-                                     .withUnitOfWork(unitOfWork -> {
-                                         var handleEventTiming = StopWatch.start("handleEvent (" + eventStoreSubscription.subscriberId() + ", " + eventStoreSubscription.aggregateType() + ")");
-                                         var result            = eventHandler.handleWithBackPressure(e);
-                                         eventStore.getEventStoreSubscriptionObserver().handleEvent(e,
-                                                                                                    eventHandler,
-                                                                                                    eventStoreSubscription,
-                                                                                                    handleEventTiming.stop().getDuration()
-                                                                                                   );
-                                         return result;
-                                     });
-                })
-                .retryWhen(forwardToEventHandlerRetryBackoffSpec
-                                   .doBeforeRetry(retrySignal -> {
-                                       log.trace("[{}-{}] (#{}) Ready to perform {} attempt retry of {} event with eventId '{}', aggregateId: '{}', eventOrder: {} to EventHandler",
-                                                 eventStoreSubscription.subscriberId(),
-                                                 eventStoreSubscription.aggregateType(),
-                                                 e.globalEventOrder(),
-                                                 retrySignal.totalRetries() + 1,
-                                                 e.event().getEventTypeOrName().getValue(),
-                                                 e.eventId(),
-                                                 e.aggregateId(),
-                                                 e.eventOrder()
-                                                );
+                              e.event().getEventTypeOrName().getValue()), cause);
+                log.trace("[{}-{}] (#{}) Requesting 1 event from the EventStore",
+                          subscriberId(),
+                          aggregateType(),
+                          e.globalEventOrder()
+                         );
+                request(1);
+            }
 
-                                   })
-                                   .doAfterRetry(retrySignal -> {
-                                       log.debug("[{}-{}] (#{}) {} {} retry of {} event with eventId '{}', aggregateId: '{}', eventOrder: {} to EventHandler",
-                                                 eventStoreSubscription.subscriberId(),
-                                                 eventStoreSubscription.aggregateType(),
-                                                 e.globalEventOrder(),
-                                                 retrySignal.failure() != null ? "Failed" : "Succeeded",
-                                                 retrySignal.totalRetries(),
-                                                 e.event().getEventTypeOrName().getValue(),
-                                                 e.eventId(),
-                                                 e.aggregateId(),
-                                                 e.eventOrder(),
-                                                 retrySignal.failure()
-                                                );
-                                   }))
-                .doFinally(signalType -> {
-                    eventStoreSubscription.currentResumePoint().get().setResumeFromAndIncluding(e.globalEventOrder().increment());
-                })
-                .subscribe(requestSize -> {
-                               if (requestSize < 0) {
-                                   requestSize = 1;
-                               }
-                               log.trace("[{}-{}] (#{}) Requesting {} events from the EventStore",
-                                         eventStoreSubscription.subscriberId(),
-                                         eventStoreSubscription.aggregateType(),
-                                         e.globalEventOrder(),
-                                         requestSize
-                                        );
-                               if (requestSize > 0) {
-                                   eventStoreSubscription.request(requestSize);
-                               }
-                           },
-                           error -> {
-                               rethrowIfCriticalError(error);
-                               eventStore.getEventStoreSubscriptionObserver().handleEventFailed(e,
-                                                                                                eventHandler,
-                                                                                                error,
-                                                                                                eventStoreSubscription);
-                               onErrorHandler.accept(e, error.getCause());
-                           });
+            @Override
+            public boolean isStarted() {
+                return started;
+            }
+
+            @Override
+            public void stop() {
+                if (started) {
+                    log.info("[{}-{}] Stopping subscription",
+                             subscriberId,
+                             aggregateType);
+                    try {
+                        log.debug("[{}-{}] Stopping subscription flux",
+                                  subscriberId,
+                                  aggregateType);
+                        subscription.dispose();
+                    } catch (Exception e) {
+                        log.error(msg("[{}-{}] Failed to dispose subscription flux",
+                                      subscriberId,
+                                      aggregateType), e);
+                    }
+                    try {
+                        // Allow the reactive components to complete
+                        Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                        // Ignore
+                        Thread.currentThread().interrupt();
+                    }
+                    // Save resume point to be the next global order event
+                    log.debug("[{}-{}] Storing ResumePoint with resumeFromAndIncluding {}",
+                              subscriberId,
+                              aggregateType,
+                              resumePoint.getResumeFromAndIncluding());
+
+                    durableSubscriptionRepository.saveResumePoint(resumePoint);
+                    started = false;
+                    log.info("[{}-{}] Stopped subscription",
+                             subscriberId,
+                             aggregateType);
+                }
+            }
+
+            @Override
+            public void unsubscribe() {
+                log.info("[{}-{}] Initiating unsubscription",
+                         subscriberId,
+                         aggregateType);
+                eventStoreSubscriptionObserver.unsubscribing(this);
+                DefaultEventStoreSubscriptionManager.this.unsubscribe(this);
+            }
+
+            @Override
+            public boolean isExclusive() {
+                return false;
+            }
+
+            @Override
+            public boolean isInTransaction() {
+                return false;
+            }
+
+            @Override
+            public void resetFrom(GlobalEventOrder subscribeFromAndIncludingGlobalOrder, Consumer<GlobalEventOrder> resetProcessor) {
+                requireNonNull(subscribeFromAndIncludingGlobalOrder, "subscribeFromAndIncludingGlobalOrder must not be null");
+                requireNonNull(resetProcessor, "resetProcessor must not be null");
+
+                eventStoreSubscriptionObserver.resettingFrom(subscribeFromAndIncludingGlobalOrder, this);
+                if (started) {
+                    log.info("[{}-{}] Resetting resume point and re-starts the subscriber from and including globalOrder {}",
+                             subscriberId,
+                             aggregateType,
+                             subscribeFromAndIncludingGlobalOrder);
+                    stop();
+                    overrideResumePoint(subscribeFromAndIncludingGlobalOrder);
+                    resetProcessor.accept(subscribeFromAndIncludingGlobalOrder);
+                    start();
+                } else {
+                    overrideResumePoint(subscribeFromAndIncludingGlobalOrder);
+                    resetProcessor.accept(subscribeFromAndIncludingGlobalOrder);
+                }
+            }
+
+            private void overrideResumePoint(GlobalEventOrder subscribeFromAndIncludingGlobalOrder) {
+                requireNonNull(subscribeFromAndIncludingGlobalOrder, "No subscribeFromAndIncludingGlobalOrder value provided");
+                // Override resume point
+                log.info("[{}-{}] Overriding resume point to start from-and-including-globalOrder {}",
+                         subscriberId,
+                         aggregateType,
+                         subscribeFromAndIncludingGlobalOrder);
+                resumePoint.setResumeFromAndIncluding(subscribeFromAndIncludingGlobalOrder);
+                durableSubscriptionRepository.saveResumePoint(resumePoint);
+                try {
+                    eventHandler.onResetFrom(this, subscribeFromAndIncludingGlobalOrder);
+                } catch (Exception e) {
+                    log.info(msg("[{}-{}] Failed to reset eventHandler '{}' to use start from-and-including-globalOrder {}",
+                                 subscriberId,
+                                 aggregateType,
+                                 eventHandler,
+                                 subscribeFromAndIncludingGlobalOrder),
+                             e);
+                }
+            }
+
+            @Override
+            public Optional<SubscriptionResumePoint> currentResumePoint() {
+                return Optional.ofNullable(resumePoint);
+            }
+
+            @Override
+            public Optional<Tenant> onlyIncludeEventsForTenant() {
+                return onlyIncludeEventsForTenant;
+            }
+
+            @Override
+            public boolean isActive() {
+                return started;
+            }
+
+            @Override
+            public String toString() {
+                return "NonExclusiveBatchedAsynchronousSubscription{" +
+                        "aggregateType=" + aggregateType +
+                        ", subscriberId=" + subscriberId +
+                        ", onlyIncludeEventsForTenant=" + onlyIncludeEventsForTenant +
+                        ", resumePoint=" + resumePoint +
+                        ", started=" + started +
+                        '}';
+            }
+
+
+        }
+
+        /**
+         * Generic {@link BaseSubscriber} which forwards to the provided {@link PersistedEventHandler}
+         * with backpressure and handles indefinite retries in relation to {@link IOExceptionUtil#isIOException(Throwable)},
+         * if using constructor without any specified {@link RetryBackoffSpec}, updates {@link SubscriptionResumePoint} after each event handled
+         * and delegates any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec}) to the provided <code>onErrorHandler</code>,
+         * which is responsible for error handling and for calling {@link EventStoreSubscription#request(long)} to continue event processing
+         */
+        class PersistedEventSubscriber extends BaseSubscriber<PersistedEvent> {
+            private static final Logger log = LoggerFactory.getLogger(PersistedEventSubscriber.class);
+
+            private final PersistedEventHandler                 eventHandler;
+            private final EventStoreSubscription                eventStoreSubscription;
+            private final BiConsumer<PersistedEvent, Throwable> onErrorHandler;
+            private final RetryBackoffSpec                      forwardToEventHandlerRetryBackoffSpec;
+            private final long                                  eventStorePollingBatchSize;
+            private final EventStore                            eventStore;
+
+            /**
+             * Subscribe with indefinite retries in relation to Exceptions where {@link IOExceptionUtil#isIOException(Throwable)} return true
+             *
+             * @param eventHandler               The event handler that {@link PersistedEvent}'s are forwarded to
+             * @param eventStoreSubscription     the {@link EventStoreSubscription} (as created by {@link EventStoreSubscriptionManager})
+             * @param onErrorHandler             The error handler called for any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec})<br>
+             *                                   <b>Note: Default behaviour needs to at least request one more event</b><br>
+             *                                   Similar to:
+             *                                   <pre>{@code
+             *                                   void onErrorHandlingEvent(PersistedEvent e, Throwable cause) {
+             *                                        log.error(msg("[{}-{}] (#{}) Skipping {} event because of error",
+             *                                                        subscriberId,
+             *                                                        aggregateType,
+             *                                                        e.globalEventOrder(),
+             *                                                        e.event().getEventTypeOrName().getValue()), cause);
+             *                                        log.trace("[{}-{}] (#{}) Requesting 1 event from the EventStore",
+             *                                                    subscriberId(),
+             *                                                    aggregateType(),
+             *                                                    e.globalEventOrder()
+             *                                                    );
+             *                                        eventStoreSubscription.request(1);
+             *                                   }
+             *                                   }</pre>
+             * @param eventStorePollingBatchSize The batch size used when polling events from the {@link EventStore}
+             * @param eventStore                 The {@link EventStore} to use
+             */
+            public PersistedEventSubscriber(PersistedEventHandler eventHandler,
+                                            EventStoreSubscription eventStoreSubscription,
+                                            BiConsumer<PersistedEvent, Throwable> onErrorHandler,
+                                            long eventStorePollingBatchSize,
+                                            EventStore eventStore) {
+                this(eventHandler,
+                     eventStoreSubscription,
+                     onErrorHandler,
+                     Retry.backoff(Long.MAX_VALUE, Duration.ofMillis(100)) // Initial delay of 100ms
+                          .maxBackoff(Duration.ofSeconds(1)) // Maximum backoff of 1 second
+                          .jitter(0.5)
+                          .filter(IOExceptionUtil::isIOException),
+                     eventStorePollingBatchSize,
+                     eventStore);
+            }
+
+            /**
+             * Subscribe with custom {@link RetryBackoffSpec}
+             *
+             * @param eventHandler                          The event handler that {@link PersistedEvent}'s are forwarded to
+             * @param eventStoreSubscription                the {@link EventStoreSubscription} (as created by {@link EventStoreSubscriptionManager})
+             * @param onErrorHandler                        The error handler called for any non-retryable Exceptions (as specified by the {@link RetryBackoffSpec})<br>
+             *                                              <b>Note: Default behaviour needs to at least request one more event</b><br>
+             *                                              Similar to:
+             *                                              <pre>{@code
+             *                                              void onErrorHandlingEvent(PersistedEvent e, Throwable cause) {
+             *                                                   log.error(msg("[{}-{}] (#{}) Skipping {} event because of error",
+             *                                                                   subscriberId,
+             *                                                                   aggregateType,
+             *                                                                   e.globalEventOrder(),
+             *                                                                   e.event().getEventTypeOrName().getValue()), cause);
+             *                                                   log.trace("[{}-{}] (#{}) Requesting 1 event from the EventStore",
+             *                                                               subscriberId(),
+             *                                                               aggregateType(),
+             *                                                               e.globalEventOrder()
+             *                                                               );
+             *                                                   eventStoreSubscription.request(1);
+             *                                              }
+             *                                              }</pre>
+             * @param forwardToEventHandlerRetryBackoffSpec The {@link RetryBackoffSpec} used.<br>
+             *                                              Example:
+             *                                              <pre>{@code
+             *                                              Retry.backoff(Long.MAX_VALUE, Duration.ofMillis(100)) // Initial delay of 100ms
+             *                                                   .maxBackoff(Duration.ofSeconds(1)) // Maximum backoff of 1 second
+             *                                                   .jitter(0.5)
+             *                                                   .filter(IOExceptionUtil::isIOException)
+             *                                              }
+             *                                              </pre>
+             * @param eventStorePollingBatchSize            The batch size used when polling events from the {@link EventStore}
+             * @param eventStore                            The {@link EventStore} to use
+             */
+            public PersistedEventSubscriber(PersistedEventHandler eventHandler,
+                                            EventStoreSubscription eventStoreSubscription,
+                                            BiConsumer<PersistedEvent, Throwable> onErrorHandler,
+                                            RetryBackoffSpec forwardToEventHandlerRetryBackoffSpec,
+                                            long eventStorePollingBatchSize,
+                                            EventStore eventStore) {
+                this.eventHandler = requireNonNull(eventHandler, "No eventHandler provided");
+                this.eventStoreSubscription = requireNonNull(eventStoreSubscription, "No eventStoreSubscription provided");
+                this.onErrorHandler = requireNonNull(onErrorHandler, "No errorHandler provided");
+                this.forwardToEventHandlerRetryBackoffSpec = requireNonNull(forwardToEventHandlerRetryBackoffSpec, "No retryBackoffSpec provided");
+                this.eventStorePollingBatchSize = eventStorePollingBatchSize;
+                this.eventStore = requireNonNull(eventStore, "No eventStore provided");
+                // Verify that the provided eventStoreSubscription supports resume-points
+                eventStoreSubscription.currentResumePoint().orElseThrow(() -> new IllegalArgumentException(msg("The provided {} doesn't support resume-points", eventStoreSubscription.getClass().getName())));
+            }
+
+            @Override
+            protected void hookOnSubscribe(Subscription subscription) {
+                log.debug("[{}-{}] On Subscribe with eventStorePollingBatchSize {}",
+                          eventStoreSubscription.subscriberId(),
+                          eventStoreSubscription.aggregateType(),
+                          eventStorePollingBatchSize
+                         );
+                eventStoreSubscription.request(eventStorePollingBatchSize);
+            }
+
+            @Override
+            protected void hookOnNext(PersistedEvent e) {
+                Mono.fromCallable(() -> {
+                        log.trace("[{}-{}] (#{}) Forwarding {} event with eventId '{}', aggregateId: '{}', eventOrder: {} to EventHandler",
+                                  eventStoreSubscription.subscriberId(),
+                                  eventStoreSubscription.aggregateType(),
+                                  e.globalEventOrder(),
+                                  e.event().getEventTypeOrName().toString(),
+                                  e.eventId(),
+                                  e.aggregateId(),
+                                  e.eventOrder()
+                                 );
+                        return eventStore.getUnitOfWorkFactory()
+                                         .withUnitOfWork(unitOfWork -> {
+                                             var handleEventTiming = StopWatch.start("handleEvent (" + eventStoreSubscription.subscriberId() + ", " + eventStoreSubscription.aggregateType() + ")");
+                                             var result            = eventHandler.handleWithBackPressure(e);
+                                             eventStore.getEventStoreSubscriptionObserver().handleEvent(e,
+                                                                                                        eventHandler,
+                                                                                                        eventStoreSubscription,
+                                                                                                        handleEventTiming.stop().getDuration()
+                                                                                                       );
+                                             return result;
+                                         });
+                    })
+                    .retryWhen(forwardToEventHandlerRetryBackoffSpec
+                                       .doBeforeRetry(retrySignal -> {
+                                           log.trace("[{}-{}] (#{}) Ready to perform {} attempt retry of {} event with eventId '{}', aggregateId: '{}', eventOrder: {} to EventHandler",
+                                                     eventStoreSubscription.subscriberId(),
+                                                     eventStoreSubscription.aggregateType(),
+                                                     e.globalEventOrder(),
+                                                     retrySignal.totalRetries() + 1,
+                                                     e.event().getEventTypeOrName().getValue(),
+                                                     e.eventId(),
+                                                     e.aggregateId(),
+                                                     e.eventOrder()
+                                                    );
+
+                                       })
+                                       .doAfterRetry(retrySignal -> {
+                                           log.debug("[{}-{}] (#{}) {} {} retry of {} event with eventId '{}', aggregateId: '{}', eventOrder: {} to EventHandler",
+                                                     eventStoreSubscription.subscriberId(),
+                                                     eventStoreSubscription.aggregateType(),
+                                                     e.globalEventOrder(),
+                                                     retrySignal.failure() != null ? "Failed" : "Succeeded",
+                                                     retrySignal.totalRetries(),
+                                                     e.event().getEventTypeOrName().getValue(),
+                                                     e.eventId(),
+                                                     e.aggregateId(),
+                                                     e.eventOrder(),
+                                                     retrySignal.failure()
+                                                    );
+                                       }))
+                    .doFinally(signalType -> {
+                        eventStoreSubscription.currentResumePoint().get().setResumeFromAndIncluding(e.globalEventOrder().increment());
+                    })
+                    .subscribe(requestSize -> {
+                                   if (requestSize < 0) {
+                                       requestSize = 1;
+                                   }
+                                   log.trace("[{}-{}] (#{}) Requesting {} events from the EventStore",
+                                             eventStoreSubscription.subscriberId(),
+                                             eventStoreSubscription.aggregateType(),
+                                             e.globalEventOrder(),
+                                             requestSize
+                                            );
+                                   if (requestSize > 0) {
+                                       eventStoreSubscription.request(requestSize);
+                                   }
+                               },
+                               error -> {
+                                   rethrowIfCriticalError(error);
+                                   eventStore.getEventStoreSubscriptionObserver().handleEventFailed(e,
+                                                                                                    eventHandler,
+                                                                                                    error,
+                                                                                                    eventStoreSubscription);
+                                   onErrorHandler.accept(e, error.getCause());
+                               });
+            }
         }
     }
 }

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessorIT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/processor/ViewEventProcessorIT.java
@@ -16,68 +16,55 @@
 
 package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.zaxxer.hikari.*;
 import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.PostgresqlEventStore;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.observability.EventStoreSubscriptionObserver;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.EventMetaData;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription.*;
 import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
-import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.GlobalEventOrder;
 import dk.cloudcreate.essentials.components.foundation.messaging.*;
-import dk.cloudcreate.essentials.components.foundation.messaging.eip.store_and_forward.*;
 import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
 import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
 import dk.cloudcreate.essentials.components.foundation.reactive.command.*;
-import dk.cloudcreate.essentials.components.foundation.types.*;
 import dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues;
-import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
-import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
 import dk.cloudcreate.essentials.reactive.command.CmdHandler;
 import dk.cloudcreate.essentials.shared.collections.Lists;
-import dk.cloudcreate.essentials.types.CharSequenceType;
+import org.awaitility.Awaitility;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.postgres.PostgresPlugin;
 import org.junit.jupiter.api.*;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 
-import java.time.*;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration;
-import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.EventProcessorIT.TestOrderEventProcessor.TEST_ORDERS;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.EventProcessorIT.createObjectMapper;
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.processor.ViewEventProcessorIT.TestOrderViewEventProcessor.TEST_ORDERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Integration test for the EventProcessor using the following scenarios:
- * <ol>
- *   <li>A PlaceOrderCommand causes an OrderPlacedEvent to be persisted.</li>
- *   <li>The OrderPlacedEvent is handled by a @MessageHandler which synchronously sends a ConfirmOrderCommand via getCommandBus().send(...),
- *       whose handler then persists an OrderConfirmedEvent.</li>
- *   <li>A FailingCommand sent via getInbox().sendAndDontWait(...) always fails.</li>
- * </ol>
- */
 @Testcontainers
-public class EventProcessorIT {
+public class ViewEventProcessorIT {
+
     public static final EventMetaData META_DATA = EventMetaData.of("Key1", "Value1", "Key2", "Value2");
 
+    private HikariConfig                                                            cfg;
+    private HikariDataSource                                                        ds;
     private Jdbi                                                                    jdbi;
     private EventStoreUnitOfWorkFactory<EventStoreUnitOfWork>                       unitOfWorkFactory;
-    private TestPersistableEventMapper                                              eventMapper;
+    private EventProcessorIT.TestPersistableEventMapper                             eventMapper;
     private PostgresqlEventStore<SeparateTablePerAggregateEventStreamConfiguration> eventStore;
 
     @Container
@@ -86,24 +73,29 @@ public class EventProcessorIT {
             .withUsername("test-user")
             .withPassword("secret-password");
 
-    private TestOrderEventProcessor          testProcessor;
-    private PostgresqlDurableQueues          durableQueues;
-    private EventStoreSubscriptionManager    eventStoreSubscriptionManager;
-    private PostgresqlFencedLockManager      fencedLockManager;
-    private Inboxes.DurableQueueBasedInboxes inboxes;
-    private DurableLocalCommandBus           commandBus;
-    private DurableSubscriptionRepository    durableSubscriptionRepository;
+    private TestOrderViewEventProcessor   testProcessor;
+    private PostgresqlDurableQueues       durableQueues;
+    private EventStoreSubscriptionManager eventStoreSubscriptionManager;
+    private PostgresqlFencedLockManager   fencedLockManager;
+    private DurableLocalCommandBus        commandBus;
+    private DurableSubscriptionRepository durableSubscriptionRepository;
 
     @BeforeEach
     void setup() {
-        jdbi = Jdbi.create(postgreSQLContainer.getJdbcUrl(),
-                           postgreSQLContainer.getUsername(),
-                           postgreSQLContainer.getPassword());
+        cfg = new HikariConfig();
+        cfg.setJdbcUrl(postgreSQLContainer.getJdbcUrl());
+        cfg.setUsername(postgreSQLContainer.getUsername());
+        cfg.setPassword(postgreSQLContainer.getPassword());
+        cfg.setMaximumPoolSize(20);
+
+        ds = new HikariDataSource(cfg);
+
+        jdbi = Jdbi.create(ds);
         jdbi.installPlugin(new PostgresPlugin());
         jdbi.setSqlLogger(new SqlExecutionTimeLogger());
 
         unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
-        eventMapper = new TestPersistableEventMapper();
+        eventMapper = new EventProcessorIT.TestPersistableEventMapper();
         var jsonSerializer = new JacksonJSONEventSerializer(createObjectMapper());
         var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
                                                                                        unitOfWorkFactory,
@@ -146,8 +138,6 @@ public class EventProcessorIT {
                                                .build();
         durableQueues.start();
 
-        inboxes = new Inboxes.DurableQueueBasedInboxes(durableQueues, fencedLockManager);
-
         commandBus = DurableLocalCommandBus.builder()
                                            .setInterceptors(new UnitOfWorkControllingCommandBusInterceptor(unitOfWorkFactory))
                                            .setDurableQueues(durableQueues)
@@ -155,18 +145,26 @@ public class EventProcessorIT {
                                            .build();
         commandBus.start();
 
-        testProcessor = new TestOrderEventProcessor(new EventProcessorDependencies(eventStoreSubscriptionManager,
-                                                                                   inboxes,
-                                                                                   commandBus,
-                                                                                   List.of()),
-                                                    eventStore);
+        testProcessor = new TestOrderViewEventProcessor(new ViewEventProcessorDependencies(eventStoreSubscriptionManager,
+                                                                                           fencedLockManager,
+                                                                                           durableQueues,
+                                                                                           commandBus,
+                                                                                           List.of()),
+                                                        eventStore);
         testProcessor.start();
     }
 
+
     @AfterEach
-    void teardown() {
+    public void tearDown() {
         if (testProcessor != null) {
             testProcessor.stop();
+        }
+        if (durableQueues != null) {
+            durableQueues.stop();
+        }
+        if (commandBus != null) {
+            commandBus.stop();
         }
         if (eventStoreSubscriptionManager != null) {
             eventStoreSubscriptionManager.stop();
@@ -174,27 +172,29 @@ public class EventProcessorIT {
         if (fencedLockManager != null) {
             fencedLockManager.stop();
         }
-        if (commandBus != null) {
-            commandBus.stop();
-        }
-        if (durableQueues != null) {
-            durableQueues.stop();
-        }
     }
 
-
-    // -------------------------------------------------------------------------------------------------------------------
-
-    /**
-     * Scenario 1 & 2:
-     * Sending a PlaceOrderCommand should cause an OrderPlacedEvent to be persisted.
-     * Its MessageHandler then synchronously sends a ConfirmOrderCommand which persists an OrderConfirmedEvent.
-     */
     @Test
-    void testPlaceOrderAndConfirmationFlow() throws Exception {
-        var orderId      = OrderId.random();
+    public void verify_view_event_processor_with_load() {
+        unitOfWorkFactory.usingUnitOfWork(uow -> {
+            IntStream.range(1, 10_001).sequential().forEach(value -> {
+                var orderId = EventProcessorIT.OrderId.random();
+                var event   = new EventProcessorIT.OrderPlacedEvent(orderId, "Load Order Details " + value);
+                eventStore.appendToStream(TEST_ORDERS, orderId, List.of(event));
+            });
+        });
+
+        Awaitility.waitAtMost(Duration.ofMinutes(2)).untilAsserted(() -> {
+            int orderPlacedEventCounter = testProcessor.getOrderPlacedEventCounter().get();
+            assert orderPlacedEventCounter == 10_000;
+        });
+    }
+
+    @Test
+    public void verify_view_event_processor_flow() {
+        var orderId      = EventProcessorIT.OrderId.random();
         var orderDetails = "Test order details";
-        var placeCmd     = new PlaceOrderCommand(orderId, orderDetails);
+        var placeCmd     = new EventProcessorIT.PlaceOrderCommand(orderId, orderDetails);
 
         // Send the command via the command bus
         commandBus.send(placeCmd);
@@ -211,19 +211,14 @@ public class EventProcessorIT {
         assertThat(events).hasSize(2);
         var event0 = events.get(0);
         var event1 = events.get(1);
-        assertThat(event0.event().getEventTypeAsJavaClass()).isPresent().isEqualTo(Optional.of(OrderPlacedEvent.class));
-        assertThat(event1.event().getEventTypeAsJavaClass()).isPresent().isEqualTo(Optional.of(OrderConfirmedEvent.class));
+        assertThat(event0.event().getEventTypeAsJavaClass()).isPresent().isEqualTo(Optional.of(EventProcessorIT.OrderPlacedEvent.class));
+        assertThat(event1.event().getEventTypeAsJavaClass()).isPresent().isEqualTo(Optional.of(EventProcessorIT.OrderConfirmedEvent.class));
     }
 
-    /**
-     * Scenario 3A:
-     * Send a FailingCommandSentUsingAsyncAndDontWaitViaCommandBus via the CommandBus. Its handler always throws an exception.
-     * This test also verifies that such a command does not prevent the integration test from shutting down.
-     */
     @Test
     void testFailingCommandSendViaCommandBus_sendAndDontWait_EventuallyEndsUpInAsADeadLetterMessage() throws Exception {
-        var orderId    = OrderId.random();
-        var failingCmd = new FailingCommandSentUsingAsyncAndDontWaitViaCommandBus(orderId, "Intentional failure for testing");
+        var orderId    = EventProcessorIT.OrderId.random();
+        var failingCmd = new EventProcessorIT.FailingCommandSentUsingAsyncAndDontWaitViaCommandBus(orderId, "Intentional failure for testing");
 
         // Verify we don't have any dead-letter messages
         var queueName = commandBus.getCommandQueueName();
@@ -239,41 +234,76 @@ public class EventProcessorIT {
 
         var deadLetterMessages = durableQueues.getDeadLetterMessages(queueName, DurableQueues.QueueingSortOrder.ASC, 0, 10);
         assertThat(deadLetterMessages).hasSize(1);
-        assertThat(deadLetterMessages.get(0).getPayload()).isInstanceOf(FailingCommandSentUsingAsyncAndDontWaitViaCommandBus.class);
+        assertThat(deadLetterMessages.get(0).getPayload()).isInstanceOf(EventProcessorIT.FailingCommandSentUsingAsyncAndDontWaitViaCommandBus.class);
     }
 
-    /**
-     * Scenario 3B:
-     * Send a FailingCommandSentViaInbox via the event processors Inbox. Its handler always throws an exception.
-     */
     @Test
-    void testFailingCommandSentViaInboxEventuallyEndsUpInAsADeadLetterMessage() throws Exception {
-        var orderId    = OrderId.random();
-        var failingCmd = new FailingCommandSentViaInbox(orderId, "Intentional failure for testing");
+    public void verify_failed_event_handling_gets_queued() {
+        var orderId      = EventProcessorIT.OrderId.random();
+        var orderDetails = "Fail order details";
+        var event        = new EventProcessorIT.OrderPlacedEvent(orderId, orderDetails);
+        unitOfWorkFactory.usingUnitOfWork(uow -> {
+            eventStore.appendToStream(TEST_ORDERS, orderId, List.of(event));
+        });
 
-        // Verify we don't have any dead-letter messages
-        var queueName = testProcessor.getInboxForTesting().name().asQueueName();
-        assertThat(durableQueues.getTotalDeadLetterMessagesQueuedFor(queueName)).isEqualTo(0);
+        var queueName = testProcessor.getDurableQueueName();
 
-        // Send the failing command using the processor's inbox (asynchronous, fire-and-forget)
-        testProcessor.getInboxForTesting().addMessageReceived(failingCmd);
-
-        Awaitility.waitAtMost(Duration.ofSeconds(2))
+        Awaitility.waitAtMost(Duration.ofSeconds(5))
                   .untilAsserted(() -> {
                       assertThat(durableQueues.getTotalDeadLetterMessagesQueuedFor(queueName)).isEqualTo(1);
                   });
 
         var deadLetterMessages = durableQueues.getDeadLetterMessages(queueName, DurableQueues.QueueingSortOrder.ASC, 0, 10);
         assertThat(deadLetterMessages).hasSize(1);
-        assertThat(deadLetterMessages.get(0).getPayload()).isInstanceOf(FailingCommandSentViaInbox.class);
+        assertThat(deadLetterMessages.get(0).getMessage()).isInstanceOf(OrderedMessage.class);
+        assertThat(deadLetterMessages.get(0).getPayload()).isInstanceOf(AggregateType.class);
+        assertThat(deadLetterMessages.get(0).getPayload()).isEqualTo(TEST_ORDERS);
+        assertThat(((OrderedMessage) deadLetterMessages.get(0).getMessage()).getKey()).isEqualTo(orderId.toString());
+        assertThat(((OrderedMessage) deadLetterMessages.get(0).getMessage()).getOrder()).isEqualTo(0);
+    }
+
+    @Test
+    public void verify_failed_event_handling_additional_event_gets_queued() {
+        var orderId      = EventProcessorIT.OrderId.random();
+        var orderDetails = "Fail order details";
+        var event        = new EventProcessorIT.OrderPlacedEvent(orderId, orderDetails);
+        unitOfWorkFactory.usingUnitOfWork(uow -> {
+            eventStore.appendToStream(TEST_ORDERS, orderId, List.of(event));
+        });
+
+        var queueName = testProcessor.getDurableQueueName();
+
+        Awaitility.waitAtMost(Duration.ofSeconds(3))
+                  .untilAsserted(() -> {
+                      assertThat(durableQueues.getTotalDeadLetterMessagesQueuedFor(queueName)).isEqualTo(1);
+                  });
+        assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(0);
+
+        var eventConfirmed = new EventProcessorIT.OrderConfirmedEvent(orderId);
+        unitOfWorkFactory.usingUnitOfWork(uow -> {
+            eventStore.appendToStream(TEST_ORDERS, orderId, List.of(eventConfirmed));
+        });
+
+        Awaitility.waitAtMost(Duration.ofSeconds(3))
+                  .untilAsserted(() -> {
+                      assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(1);
+                  });
+
+        var queuedMessages = durableQueues.getQueuedMessages(queueName, DurableQueues.QueueingSortOrder.ASC, 0, 10);
+        assertThat(queuedMessages).hasSize(1);
+        assertThat(queuedMessages.get(0).getMessage()).isInstanceOf(OrderedMessage.class);
+        assertThat(queuedMessages.get(0).getPayload()).isInstanceOf(AggregateType.class);
+        assertThat(queuedMessages.get(0).getPayload()).isEqualTo(TEST_ORDERS);
+        assertThat(((OrderedMessage) queuedMessages.get(0).getMessage()).getKey()).isEqualTo(orderId.toString());
+        assertThat(((OrderedMessage) queuedMessages.get(0).getMessage()).getOrder()).isEqualTo(1);
     }
 
     @Test
     public void testResetAllSubscriptions() {
         IntStream.range(0, 5).forEach(i -> {
-            var orderId      = OrderId.random();
+            var orderId      = EventProcessorIT.OrderId.random();
             var orderDetails = "Test order details";
-            var placeCmd     = new PlaceOrderCommand(orderId, orderDetails);
+            var placeCmd     = new EventProcessorIT.PlaceOrderCommand(orderId, orderDetails);
             commandBus.send(placeCmd);
         });
         var subscriberId = AbstractEventProcessor.resolveSubscriberId(TEST_ORDERS, testProcessor.getProcessorName());
@@ -285,13 +315,12 @@ public class EventProcessorIT {
                                        );
         });
 
-        var queueName = testProcessor.getInboxForTesting().name().asQueueName();
+        var queueName = testProcessor.getDurableQueueName();
         assertThat(durableQueues.getTotalDeadLetterMessagesQueuedFor(queueName)).isEqualTo(0);
         assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(0);
         // Send the failing command using the processor's inbox (asynchronous, fire-and-forget)
-        var failingCmd = new FailingCommandSentViaInbox(OrderId.random(), "Intentional failure for testing");
-        testProcessor.getInboxForTesting().addMessageReceived(failingCmd);
-
+        var failingCmd = new EventProcessorIT.FailingCommandSentViaInbox(EventProcessorIT.OrderId.random(), "Intentional failure for testing");
+        testProcessor.getDurableQueuesForTesting().queueMessage(queueName, Message.of(failingCmd));
         assertThat(durableQueues.getTotalMessagesQueuedFor(queueName)).isEqualTo(1);
 
         // Set a callback to verify that we do reset resumePoints
@@ -336,92 +365,6 @@ public class EventProcessorIT {
         });
     }
 
-    // --------------------------
-    // Supporting classes for the test
-    // --------------------------
-
-    /**
-     * OrderId
-     */
-    public static class OrderId extends CharSequenceType<OrderId> {
-        protected OrderId(CharSequence value) {
-            super(value);
-        }
-
-        public static OrderId random() {
-            return new OrderId(RandomIdGenerator.generate());
-        }
-
-        public static OrderId of(CharSequence id) {
-            return new OrderId(id);
-        }
-    }
-
-    // --- Commands ---
-
-    public static class PlaceOrderCommand {
-        public final OrderId orderId;
-        public final String  orderDetails;
-
-        public PlaceOrderCommand(OrderId orderId, String orderDetails) {
-            this.orderId = orderId;
-            this.orderDetails = orderDetails;
-        }
-    }
-
-    public static class ConfirmOrderCommand {
-        public final OrderId orderId;
-
-        public ConfirmOrderCommand(OrderId orderId) {
-            this.orderId = orderId;
-        }
-    }
-
-    public static class FailingCommandSentViaInbox {
-        public final OrderId orderId;
-        public final String  reason;
-
-        public FailingCommandSentViaInbox(OrderId orderId, String reason) {
-            this.orderId = orderId;
-            this.reason = reason;
-        }
-    }
-
-    public static class FailingCommandSentUsingAsyncAndDontWaitViaCommandBus {
-        public final OrderId orderId;
-        public final String  reason;
-
-        public FailingCommandSentUsingAsyncAndDontWaitViaCommandBus(OrderId orderId, String reason) {
-            this.orderId = orderId;
-            this.reason = reason;
-        }
-    }
-
-    // --- Events ---
-
-    @Revision(1)
-    public static class OrderPlacedEvent {
-        public final OrderId orderId;
-        public final String  orderDetails;
-
-        public OrderPlacedEvent(OrderId orderId, String orderDetails) {
-            this.orderId = orderId;
-            this.orderDetails = orderDetails;
-        }
-    }
-
-    public static class OrderConfirmedEvent {
-        public final OrderId orderId;
-
-        public OrderConfirmedEvent(OrderId orderId) {
-            this.orderId = orderId;
-        }
-    }
-
-    // --------------------------
-    // Test EventProcessor
-    // --------------------------
-
     /**
      * TestOrderEventProcessor is a simple EventProcessor that:
      * <ul>
@@ -432,31 +375,28 @@ public class EventProcessorIT {
      *     <li>Handles FailingCommand by throwing an exception</li>
      * </ul>
      */
-    public static class TestOrderEventProcessor extends EventProcessor {
+    public static class TestOrderViewEventProcessor extends ViewEventProcessor {
         public static final AggregateType TEST_ORDERS = AggregateType.of("TestOrders");
-
         private final PostgresqlEventStore<?> eventStore;
-
         private final ConcurrentMap<AggregateType, GlobalEventOrder> resetPoints = new ConcurrentHashMap<>();
-
         private Consumer<ConcurrentMap<AggregateType, GlobalEventOrder>> resetCallback;
+        private final AtomicInteger orderPlacedEventCounter = new AtomicInteger(0);
 
-        public TestOrderEventProcessor(EventProcessorDependencies eventProcessorDependencies,
-                                       PostgresqlEventStore<?> eventStore) {
-            this(eventProcessorDependencies, eventStore,
-                 resetPoints -> {
-                     throw new IllegalStateException("No reset callback configured");
-                 });
-        }
-
-        public TestOrderEventProcessor(EventProcessorDependencies eventProcessorDependencies,
-                                       PostgresqlEventStore<?> eventStore,
-                                       Consumer<ConcurrentMap<AggregateType, GlobalEventOrder>> resetCallback) {
+        public TestOrderViewEventProcessor(ViewEventProcessorDependencies eventProcessorDependencies,
+                                           PostgresqlEventStore<?> eventStore) {
             super(eventProcessorDependencies);
             this.eventStore = eventStore;
-            this.resetCallback = resetCallback;
             eventStore.addAggregateEventStreamConfiguration(TEST_ORDERS,
-                                                            AggregateIdSerializer.serializerFor(OrderId.class));
+                                                            AggregateIdSerializer.serializerFor(EventProcessorIT.OrderId.class));
+        }
+
+        @Override
+        public String getProcessorName() {
+            return "TestOrderViewEventProcessor";
+        }
+
+        public DurableQueues getDurableQueuesForTesting() {
+            return super.getDurableQueues();
         }
 
         public void setResetCallback(Consumer<ConcurrentMap<AggregateType, GlobalEventOrder>> resetCallback) {
@@ -464,22 +404,12 @@ public class EventProcessorIT {
         }
 
         @Override
-        public String getProcessorName() {
-            return "TestOrderEventProcessor";
-        }
-
-        @Override
         protected List<AggregateType> reactsToEventsRelatedToAggregateTypes() {
             return List.of(TEST_ORDERS);
         }
 
-
-        public Inbox getInboxForTesting() {
-            return super.getInbox();
-        }
-
         @Override
-        protected RedeliveryPolicy getInboxRedeliveryPolicy() {
+        protected RedeliveryPolicy getDurableQueueRedeliveryPolicy() {
             return RedeliveryPolicy.fixedBackoff(Duration.ofMillis(200), 3);
         }
 
@@ -495,36 +425,34 @@ public class EventProcessorIT {
         // ----- Command Handlers -----
 
         @CmdHandler
-        public void handle(PlaceOrderCommand cmd) {
+        public void handle(EventProcessorIT.PlaceOrderCommand cmd) {
             if (!eventStore.hasEventStream(TEST_ORDERS, cmd.orderId)) {
                 // Start a new event stream for this order
-                var event = new OrderPlacedEvent(cmd.orderId, cmd.orderDetails);
+                var event = new EventProcessorIT.OrderPlacedEvent(cmd.orderId, cmd.orderDetails);
                 eventStore.startStream(TEST_ORDERS, cmd.orderId, List.of(event));
             }
         }
 
         @CmdHandler
-        public void handle(ConfirmOrderCommand cmd) {
+        public void handle(EventProcessorIT.ConfirmOrderCommand cmd) {
             var eventStream = eventStore.fetchStream(TEST_ORDERS, cmd.orderId);
-            if (eventStream.isPresent() && !Lists.last(eventStream.get().eventList()).get().event().getEventTypeAsJavaClass().get().equals(OrderConfirmedEvent.class)) {
+            if (eventStream.isPresent() && !Lists.last(eventStream.get().eventList()).get().event().getEventTypeAsJavaClass().get().equals(EventProcessorIT.OrderConfirmedEvent.class)) {
                 // Append the confirmation event to the existing stream
-                var event = new OrderConfirmedEvent(cmd.orderId);
+                var event = new EventProcessorIT.OrderConfirmedEvent(cmd.orderId);
                 eventStore.appendToStream(TEST_ORDERS, cmd.orderId, event);
             }
         }
 
-
         @CmdHandler
-        public void handle(FailingCommandSentUsingAsyncAndDontWaitViaCommandBus cmd) {
+        public void handle(EventProcessorIT.FailingCommandSentUsingAsyncAndDontWaitViaCommandBus cmd) {
             System.out.println("*** Handling FailingCommand: " + cmd.reason);
             throw new RuntimeException(cmd.reason);
         }
 
-
         // ----- Message Handler -----
 
         @MessageHandler
-        public void handle(FailingCommandSentViaInbox cmd) {
+        public void handle(EventProcessorIT.FailingCommandSentViaInbox cmd) {
             System.out.println("*** Handling FailingCommand: " + cmd.reason);
             throw new RuntimeException(cmd.reason);
         }
@@ -533,58 +461,18 @@ public class EventProcessorIT {
          * When an OrderPlacedEvent is processed, send a ConfirmOrderCommand synchronously.
          */
         @MessageHandler
-        public void onOrderPlaced(OrderPlacedEvent event) {
-            getCommandBus().send(new ConfirmOrderCommand(event.orderId));
+        public void onOrderPlaced(EventProcessorIT.OrderPlacedEvent event) {
+            if (event.orderDetails.startsWith("Load")) {
+                orderPlacedEventCounter.incrementAndGet();
+            } else if (event.orderDetails.startsWith("Fail")) {
+                throw new RuntimeException(event.orderDetails);
+            } else {
+                getCommandBus().send(new EventProcessorIT.ConfirmOrderCommand(event.orderId));
+            }
         }
-    }
 
-
-    // -------------------------------------------------------------------------------------------------------------------
-
-    public static ObjectMapper createObjectMapper() {
-        var objectMapper = JsonMapper.builder()
-                                     .disable(MapperFeature.AUTO_DETECT_GETTERS)
-                                     .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
-                                     .disable(MapperFeature.AUTO_DETECT_SETTERS)
-                                     .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
-                                     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-                                     .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                                     .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                                     .enable(MapperFeature.AUTO_DETECT_CREATORS)
-                                     .enable(MapperFeature.AUTO_DETECT_FIELDS)
-                                     .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
-                                     .addModule(new Jdk8Module())
-                                     .addModule(new JavaTimeModule())
-                                     .addModule(new EssentialTypesJacksonModule())
-                                     .addModule(new EssentialsImmutableJacksonModule())
-                                     .build();
-
-        objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
-                                               .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
-                                               .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
-                                               .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
-                                               .withCreatorVisibility(JsonAutoDetect.Visibility.ANY));
-        return objectMapper;
-    }
-
-    public static class TestPersistableEventMapper implements PersistableEventMapper {
-        private final CorrelationId correlationId   = CorrelationId.random();
-        private final EventId       causedByEventId = EventId.random();
-
-        @Override
-        public PersistableEvent map(Object aggregateId, AggregateEventStreamConfiguration aggregateEventStreamConfiguration, Object event, EventOrder eventOrder) {
-            return PersistableEvent.from(EventId.random(),
-                                         aggregateEventStreamConfiguration.aggregateType,
-                                         aggregateId,
-                                         EventTypeOrName.with(event.getClass()),
-                                         event,
-                                         eventOrder,
-                                         null, // Leave reading the EventRevision to the PersistableEvent's from method
-                                         META_DATA,
-                                         OffsetDateTime.now(),
-                                         causedByEventId,
-                                         correlationId,
-                                         null);
+        public AtomicInteger getOrderPlacedEventCounter() {
+            return orderPlacedEventCounter;
         }
     }
 }

--- a/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/BatchedPersistedEventSubscriber_IT.java
+++ b/components/postgresql-event-store/src/test/java/dk/cloudcreate/essentials/components/eventsourced/eventstore/postgresql/subscription/BatchedPersistedEventSubscriber_IT.java
@@ -1,0 +1,587 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.subscription;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import dk.cloudcreate.essentials.components.distributed.fencedlock.postgresql.PostgresqlFencedLockManager;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.eventstream.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.AggregateIdSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.serializer.json.JacksonJSONEventSerializer;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.test_data.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.*;
+import dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.types.*;
+import dk.cloudcreate.essentials.components.foundation.postgresql.SqlExecutionTimeLogger;
+import dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWork;
+import dk.cloudcreate.essentials.components.foundation.types.*;
+import dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule;
+import dk.cloudcreate.essentials.jackson.types.EssentialTypesJacksonModule;
+import dk.cloudcreate.essentials.shared.collections.Lists;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.postgres.PostgresPlugin;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.*;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.*;
+
+import static dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.persistence.table_per_aggregate_type.SeparateTablePerAggregateEventStreamConfiguration.standardSingleTenantConfiguration;
+import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class BatchedPersistedEventSubscriber_IT {
+    public static final EventMetaData META_DATA = EventMetaData.of("Key1", "Value1", "Key2", "Value2");
+    public static final AggregateType PRODUCTS = AggregateType.of("Products");
+    public static final AggregateType ORDERS = AggregateType.of("Orders");
+
+    private Jdbi jdbi;
+    private AggregateType aggregateType;
+    private EventStoreUnitOfWorkFactory<EventStoreUnitOfWork> unitOfWorkFactory;
+    private TestPersistableEventMapper eventMapper;
+    private PostgresqlEventStore<SeparateTablePerAggregateEventStreamConfiguration> eventStore;
+
+    @Container
+    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+            .withDatabaseName("event-store")
+            .withUsername("test-user")
+            .withPassword("secret-password");
+    private EventStoreSubscriptionManager eventStoreSubscriptionManager;
+
+    @BeforeEach
+    void setup() {
+        jdbi = Jdbi.create(postgreSQLContainer.getJdbcUrl(),
+                postgreSQLContainer.getUsername(),
+                postgreSQLContainer.getPassword());
+        jdbi.installPlugin(new PostgresPlugin());
+        jdbi.setSqlLogger(new SqlExecutionTimeLogger());
+
+        aggregateType = ORDERS;
+        unitOfWorkFactory = new EventStoreManagedUnitOfWorkFactory(jdbi);
+        eventMapper = new TestPersistableEventMapper();
+        var jsonSerializer = new JacksonJSONEventSerializer(createObjectMapper());
+        var persistenceStrategy = new SeparateTablePerAggregateTypePersistenceStrategy(jdbi,
+                unitOfWorkFactory,
+                eventMapper,
+                SeparateTablePerAggregateTypeEventStreamConfigurationFactory.standardSingleTenantConfiguration(jsonSerializer,
+                        IdentifierColumnType.UUID,
+                        JSONColumnType.JSONB));
+
+        eventStore = new PostgresqlEventStore<>(unitOfWorkFactory,
+                persistenceStrategy);
+        eventStore.addAggregateEventStreamConfiguration(aggregateType,
+                OrderId.class);
+        eventStore.addAggregateEventStreamConfiguration(standardSingleTenantConfiguration(PRODUCTS,
+                jsonSerializer,
+                AggregateIdSerializer.serializerFor(ProductId.class),
+                IdentifierColumnType.TEXT,
+                JSONColumnType.JSON));
+
+    }
+
+    @AfterEach
+    void cleanup() {
+        unitOfWorkFactory.getCurrentUnitOfWork().ifPresent(UnitOfWork::rollback);
+        assertThat(unitOfWorkFactory.getCurrentUnitOfWork()).isEmpty();
+        if (eventStoreSubscriptionManager != null) {
+            eventStoreSubscriptionManager.stop();
+        }
+    }
+
+
+    private void disruptDatabaseConnection() {
+        System.out.println("***** Disrupting DB connection *****");
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.pauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    private void restoreDatabaseConnection() {
+        System.out.println("***** Restoring DB connection *****");
+        var dockerClient = postgreSQLContainer.getDockerClient();
+        dockerClient.unpauseContainerCmd(postgreSQLContainer.getContainerId()).exec();
+    }
+
+    @Test
+    void test_batched_subscription() throws InterruptedException {
+        testBatchedSubscription(false);
+    }
+
+    @Test
+    void test_batched_subscription_with_db_connectivity_issues() throws InterruptedException {
+        testBatchedSubscription(true);
+    }
+
+    private void testBatchedSubscription(boolean simulateDbConnectivityIssues) throws InterruptedException {
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
+        eventStoreSubscriptionManager = EventStoreSubscriptionManager.createFor(eventStore,
+                50,
+                Duration.ofMillis(100),
+                new PostgresqlFencedLockManager(jdbi,
+                        unitOfWorkFactory,
+                        Optional.of("Node1"),
+                        Duration.ofSeconds(3),
+                        Duration.ofSeconds(1),
+                        false),
+                Duration.ofSeconds(1),
+                durableSubscriptionRepository);
+
+        eventStoreSubscriptionManager.start();
+
+        var testEvents = createTestEvents();
+
+        // For product events, we'll use the standard event handler
+        var productEventsReceived = new ArrayList<PersistedEvent>();
+        var productsSubscription = eventStoreSubscriptionManager.subscribeToAggregateEventsAsynchronously(
+                SubscriberId.of("ProductsSub1"),
+                PRODUCTS,
+                GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER,
+                Optional.empty(),
+                new PersistedEventHandler() {
+                    @Override
+                    public void onResetFrom(EventStoreSubscription eventStoreSubscription, GlobalEventOrder globalEventOrder) {
+                        throw new IllegalStateException("Method shouldn't be called");
+                    }
+
+                    @Override
+                    public void handle(PersistedEvent event) {
+                        var isDuplicateEvent = productEventsReceived.contains(event);
+                        if (isDuplicateEvent) {
+                            System.out.println("Received DUPLICATE Product event: " + event);
+                            // When db connectivity is interrupted we may briefly receive messages out of order or multiple times due to overlaps in lock ownership
+                            if (!simulateDbConnectivityIssues) {
+                                throw new IllegalStateException("Received unexpected DUPLICATE Product event: " + event);
+                            }
+                        } else {
+                            System.out.println("Received Product event: " + event);
+                            productEventsReceived.add(event);
+                        }
+                    }
+                });
+        System.out.println("productsSubscription: " + productsSubscription);
+
+        // For order events, we'll use the batched event handler
+        var orderBatchesReceived = new ConcurrentLinkedDeque<List<PersistedEvent>>();
+        var orderEventsReceived = new ConcurrentLinkedDeque<PersistedEvent>();
+        var batchProcessingLatch = new CountDownLatch(1);
+        var totalBatchesProcessed = new AtomicInteger(0);
+        var maxBatchSize = 10;
+        var maxLatency = Duration.ofMillis(50);
+
+        var ordersSubscription = eventStoreSubscriptionManager.batchSubscribeToAggregateEventsAsynchronously(
+                SubscriberId.of("OrdersSub1"),
+                ORDERS,
+                GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER,
+                Optional.empty(),
+                maxBatchSize,
+                maxLatency,
+                new BatchedPersistedEventHandler() {
+                    @Override
+                    public int handleBatch(List<PersistedEvent> events) {
+                        System.out.println("Received Order batch: " + events.size() + " events, from: " +
+                                Lists.first(events).get().globalEventOrder() + " to: " +
+                                Lists.last(events).get().globalEventOrder());
+
+                        // Check for duplicates within the batch
+                        var duplicatesInBatch = events.stream()
+                                .collect(Collectors.groupingBy(PersistedEvent::globalEventOrder))
+                                .entrySet().stream()
+                                .filter(entry -> entry.getValue().size() > 1)
+                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                        if (!duplicatesInBatch.isEmpty() && !simulateDbConnectivityIssues) {
+                            throw new IllegalStateException("Received batch with duplicate events: " + duplicatesInBatch);
+                        }
+
+                        // Check if we've already processed any of these events
+                        var alreadyProcessedEvents = events.stream()
+                                .filter(orderEventsReceived::contains)
+                                .toList();
+
+                        if (!alreadyProcessedEvents.isEmpty() && !simulateDbConnectivityIssues) {
+                            throw new IllegalStateException("Received batch with already processed events: " + alreadyProcessedEvents);
+                        }
+
+                        // Add all events to our tracking collections
+                        orderBatchesReceived.add(new ArrayList<>(events));
+                        orderEventsReceived.addAll(events);
+                        totalBatchesProcessed.incrementAndGet();
+
+
+                        // If we've received enough total events, signal completion
+                        var totalNumberOfOrderEvents = testEvents.get(ORDERS)
+                                .values()
+                                .stream()
+                                .map(List::size)
+                                .reduce(Integer::sum)
+                                .orElse(0);
+
+                        if (orderEventsReceived.size() >= totalNumberOfOrderEvents) {
+                            batchProcessingLatch.countDown();
+                        }
+
+                        // Return how many events to request in the next batch
+                        return maxBatchSize;
+                    }
+
+                    @Override
+                    public void onResetFrom(EventStoreSubscription subscription, GlobalEventOrder subscribeFromAndIncludingGlobalOrder) {
+                        throw new IllegalStateException("Method shouldn't be called");
+                    }
+                });
+
+        System.out.println("ordersSubscription: " + ordersSubscription);
+
+        // Persist all test events
+        testEvents.forEach((aggregateType, aggregatesAndEvents) -> {
+            aggregatesAndEvents.forEach((aggregateId, events) -> {
+                var unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
+                System.out.println(msg("Persisting {} {} events related to aggregate id {}",
+                        events.size(),
+                        aggregateType,
+                        aggregateId));
+                var aggregateEventStream = eventStore.appendToStream(aggregateType,
+                        aggregateId,
+                        events);
+                assertThat(aggregateEventStream.aggregateId()).isEqualTo(aggregateId);
+                assertThat(aggregateEventStream.isPartialEventStream()).isTrue();
+                assertThat(aggregateEventStream.eventList().size()).isEqualTo(events.size());
+                unitOfWork.commit();
+            });
+        });
+
+        if (simulateDbConnectivityIssues) {
+            disruptDatabaseConnection();
+            Thread.sleep(5000);
+            restoreDatabaseConnection();
+        }
+
+        // Wait for all batches to be processed
+        batchProcessingLatch.await();
+
+        // Verify we received all product events
+        var totalNumberOfProductEvents = testEvents.get(PRODUCTS)
+                .values()
+                .stream()
+                .map(List::size)
+                .reduce(Integer::sum)
+                .get();
+        System.out.println("Total number of Product Events: " + totalNumberOfProductEvents);
+        var totalNumberOfOrderEvents = testEvents.get(ORDERS)
+                .values()
+                .stream()
+                .map(List::size)
+                .reduce(Integer::sum)
+                .get();
+        System.out.println("Total number of Order Events: " + totalNumberOfOrderEvents);
+        System.out.println("Total number of Batches Processed: " + totalBatchesProcessed.get());
+        System.out.println("Average batch size: " + (float) totalNumberOfOrderEvents / totalBatchesProcessed.get());
+
+        // Verify we received all Product and Order events
+        Awaitility.waitAtMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(productEventsReceived.size()).isEqualTo(totalNumberOfProductEvents));
+
+        Awaitility.waitAtMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents));
+
+        // Sleep a little to verify that no additional events were delivered
+        Thread.sleep(5000);
+
+        // Verify we only have Product related events in the product stream
+        assertThat(productEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(PRODUCTS)).findAny()).isEmpty();
+        var receivedProductEventGlobalOrders = productEventsReceived.stream()
+                .map(persistedEvent -> persistedEvent.globalEventOrder().longValue());
+        if (simulateDbConnectivityIssues) {
+            // When db connectivity is interrupted we may briefly receive messages out of order due to overlaps in lock ownership
+            receivedProductEventGlobalOrders = receivedProductEventGlobalOrders.sorted();
+        }
+        assertThat(receivedProductEventGlobalOrders
+                .toList())
+                .isEqualTo(LongStream.rangeClosed(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER.longValue(),
+                                totalNumberOfProductEvents)
+                        .boxed()
+                        .collect(Collectors.toList()));
+
+        // Check that all order events were received and are of the correct type
+        assertThat(orderEventsReceived.stream().filter(persistedEvent -> !persistedEvent.aggregateType().equals(ORDERS)).findAny()).isEmpty();
+        var receivedOrderEventGlobalOrders = orderEventsReceived.stream()
+                .map(persistedEvent -> persistedEvent.globalEventOrder().longValue());
+        if (simulateDbConnectivityIssues) {
+            // When db connectivity is interrupted we may briefly receive messages out of order due to overlaps in lock ownership
+            receivedOrderEventGlobalOrders = receivedOrderEventGlobalOrders.sorted();
+        }
+        assertThat(receivedOrderEventGlobalOrders
+                .toList())
+                .isEqualTo(LongStream.rangeClosed(GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER.longValue(),
+                                totalNumberOfOrderEvents)
+                        .boxed()
+                        .collect(Collectors.toList()));
+
+        // Verify batch sizes - most batches should be of max size or close to it
+        // (except the last one and possibly during connectivity issues)
+        if (!simulateDbConnectivityIssues) {
+            // Calculate what percentage of batches were at max capacity
+            long fullBatches = orderBatchesReceived.stream()
+                    .filter(batch -> batch.size() == maxBatchSize)
+                    .count();
+            System.out.println("Percentage of full batches: " +
+                    (float) fullBatches / orderBatchesReceived.size() * 100 + "%");
+
+            // At least some batches should be at max capacity
+            assertThat(fullBatches).isGreaterThan(0);
+        }
+
+        // Clean up
+        productsSubscription.stop();
+        ordersSubscription.stop();
+
+        // Check the ResumePoints are updated and saved
+        var lastEventOrder = new ArrayList<>(orderEventsReceived).get(totalNumberOfOrderEvents - 1);
+        var lastProductEvent = productEventsReceived.get(totalNumberOfProductEvents - 1);
+
+        assertThat(ordersSubscription.currentResumePoint().get().getResumeFromAndIncluding()).isEqualTo(lastEventOrder.globalEventOrder().increment()); // When the subscriber is stopped we store the next global event order
+        var ordersSubscriptionResumePoint = durableSubscriptionRepository.getResumePoint(ordersSubscription.subscriberId(), ordersSubscription.aggregateType());
+        assertThat(ordersSubscriptionResumePoint).isPresent();
+        Awaitility.waitAtMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(ordersSubscriptionResumePoint.get().getResumeFromAndIncluding()).isEqualTo(lastEventOrder.globalEventOrder().increment()));  // When the subscriber is stopped we store the next global event order));
+
+        assertThat(productsSubscription.currentResumePoint().get().getResumeFromAndIncluding()).isEqualTo(lastProductEvent.globalEventOrder().increment()); // // When the subscriber is stopped we store the next global event order
+        var productsSubscriptionResumePoint = durableSubscriptionRepository.getResumePoint(productsSubscription.subscriberId(), productsSubscription.aggregateType());
+        assertThat(productsSubscriptionResumePoint).isPresent();
+        assertThat(productsSubscriptionResumePoint.get().getResumeFromAndIncluding()).isEqualTo(lastProductEvent.globalEventOrder().increment());// When the subscriber is stopped we store the next global event order
+    }
+
+    @Test
+    void test_batched_subscription_with_max_latency() throws InterruptedException {
+        var durableSubscriptionRepository = new PostgresqlDurableSubscriptionRepository(jdbi, eventStore);
+        eventStoreSubscriptionManager = EventStoreSubscriptionManager.createFor(eventStore,
+                50,
+                Duration.ofMillis(100),
+                new PostgresqlFencedLockManager(jdbi,
+                        unitOfWorkFactory,
+                        Optional.of("Node1"),
+                        Duration.ofSeconds(3),
+                        Duration.ofSeconds(1),
+                        false),
+                Duration.ofSeconds(1),
+                durableSubscriptionRepository);
+
+        // Start the subscription manager
+        eventStoreSubscriptionManager.start();
+
+        // Create just a few events to test max latency trigger
+        var testEvents = createSmallTestEvents();
+
+        // For order events, we'll use the batched event handler with small batch size but short max latency
+        var orderBatchesReceived = new ConcurrentLinkedDeque<List<PersistedEvent>>();
+        var orderEventsReceived = new ConcurrentLinkedDeque<PersistedEvent>();
+        // Use smaller batch size - force batching to ensure >1 batch
+        var maxBatchSize = 50; // Smaller batch size to ensure multiple batches
+        var maxLatency = Duration.ofMillis(100); // Slightly longer latency to ensure events are processed
+
+        var ordersSubscription = eventStoreSubscriptionManager.batchSubscribeToAggregateEventsAsynchronously(
+                SubscriberId.of("OrdersLatencySub"),
+                ORDERS,
+                GlobalEventOrder.FIRST_GLOBAL_EVENT_ORDER,
+                Optional.empty(),
+                maxBatchSize,
+                maxLatency,
+                new BatchedPersistedEventHandler() {
+                    @Override
+                    public int handleBatch(List<PersistedEvent> events) {
+                        System.out.println("Received Order batch: " + events.size() + " events, from: " +
+                                Lists.first(events).get().globalEventOrder() + " to: " +
+                                Lists.last(events).get().globalEventOrder());
+
+                        // Add all events to our tracking collections
+                        orderBatchesReceived.add(new ArrayList<>(events));
+                        orderEventsReceived.addAll(events);
+
+                        // Return how many events to request in the next batch
+                        return maxBatchSize;
+                    }
+                });
+
+        System.out.println("ordersSubscription: " + ordersSubscription);
+
+        // Persist all test events
+        testEvents.forEach((aggregateType, aggregatesAndEvents) -> {
+            aggregatesAndEvents.forEach((aggregateId, events) -> {
+                var unitOfWork = unitOfWorkFactory.getOrCreateNewUnitOfWork();
+                System.out.println(msg("Persisting {} {} events related to aggregate id {}",
+                        events.size(),
+                        aggregateType,
+                        aggregateId));
+                var aggregateEventStream = eventStore.appendToStream(aggregateType,
+                        aggregateId,
+                        events);
+                assertThat(aggregateEventStream.aggregateId()).isEqualTo(aggregateId);
+                assertThat(aggregateEventStream.isPartialEventStream()).isTrue();
+                assertThat(aggregateEventStream.eventList().size()).isEqualTo(events.size());
+                unitOfWork.commit();
+            });
+        });
+
+       Awaitility.waitAtMost(Duration.ofSeconds(3)).untilAsserted( () ->
+               assertThat(orderEventsReceived.size()).isGreaterThan(1)
+       );
+
+        // Calculate statistics
+        var totalNumberOfOrderEvents = testEvents.get(ORDERS)
+                .values()
+                .stream()
+                .map(List::size)
+                .reduce(Integer::sum)
+                .get();
+        System.out.println("Total number of Order Events: " + totalNumberOfOrderEvents);
+        System.out.println("Total number of Batches Processed: " + orderBatchesReceived.size());
+        System.out.println("Average batch size: " + (float) totalNumberOfOrderEvents / orderBatchesReceived.size());
+
+        // Verify we received all Order events
+        Awaitility.waitAtMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(orderEventsReceived.size()).isEqualTo(totalNumberOfOrderEvents));
+
+        // Since we have few events and a large max batch size,
+        // max latency should trigger and we should have more than one batch
+        // but fewer batches than total events
+        assertThat(orderBatchesReceived.size()).isGreaterThanOrEqualTo(1);
+        assertThat(orderBatchesReceived.stream().mapToInt(Collection::size).sum()).isEqualTo(totalNumberOfOrderEvents);
+
+        // Clean up
+        ordersSubscription.stop();
+    }
+
+    private Map<AggregateType, Map<?, List<?>>> createTestEvents() {
+        var eventsPerAggregateType = new HashMap<AggregateType, Map<?, List<?>>>();
+
+        // Products
+        var aggregateType = PRODUCTS;
+        var aggregatesAndEvents = new HashMap<Object, List<?>>();
+        for (int i = 0; i < 10; i++) {
+            var productId = ProductId.random();
+            if (i % 2 == 0) {
+                aggregatesAndEvents.put(productId, List.of(new ProductEvent.ProductAdded(productId),
+                        new ProductEvent.ProductDiscontinued(productId)));
+            } else {
+                aggregatesAndEvents.put(productId, List.of(new ProductEvent.ProductAdded(productId)));
+            }
+        }
+        eventsPerAggregateType.put(aggregateType, aggregatesAndEvents);
+
+        // Orders
+        aggregateType = ORDERS;
+        aggregatesAndEvents = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            var orderId = OrderId.random();
+            if (i % 2 == 0) {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i),
+                        new OrderEvent.ProductAddedToOrder(orderId, ProductId.random(), i)));
+            } else if (i % 3 == 0) {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i),
+                        new OrderEvent.ProductAddedToOrder(orderId, ProductId.random(), i),
+                        new OrderEvent.ProductOrderQuantityAdjusted(orderId, ProductId.random(), i - 1)));
+            } else if (i % 5 == 0) {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i),
+                        new OrderEvent.ProductAddedToOrder(orderId, ProductId.random(), i),
+                        new OrderEvent.ProductOrderQuantityAdjusted(orderId, ProductId.random(), i - 1),
+                        new OrderEvent.ProductRemovedFromOrder(orderId, ProductId.random()),
+                        new OrderEvent.OrderAccepted(orderId)));
+            } else {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i)));
+            }
+        }
+        eventsPerAggregateType.put(aggregateType, aggregatesAndEvents);
+        return eventsPerAggregateType;
+    }
+
+    private Map<AggregateType, Map<Object, List<Object>>> createSmallTestEvents() {
+        var eventsPerAggregateType = new HashMap<AggregateType, Map<Object, List<Object>>>();
+
+        // Orders
+        var aggregateType = ORDERS;
+        var aggregatesAndEvents = new HashMap<Object, List<Object>>();
+        // Create more events to ensure multiple batches
+        for (int i = 0; i < 20; i++) {
+            var orderId = OrderId.random();
+            if (i % 2 == 0) {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i),
+                        new OrderEvent.ProductAddedToOrder(orderId, ProductId.random(), i)));
+            } else {
+                aggregatesAndEvents.put(orderId, List.of(new OrderEvent.OrderAdded(orderId, CustomerId.random(), i)));
+            }
+        }
+        eventsPerAggregateType.put(aggregateType, aggregatesAndEvents);
+        return eventsPerAggregateType;
+    }
+
+    private ObjectMapper createObjectMapper() {
+        var objectMapper = JsonMapper.builder()
+                .disable(MapperFeature.AUTO_DETECT_GETTERS)
+                .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+                .disable(MapperFeature.AUTO_DETECT_SETTERS)
+                .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .enable(MapperFeature.AUTO_DETECT_CREATORS)
+                .enable(MapperFeature.AUTO_DETECT_FIELDS)
+                .enable(MapperFeature.PROPAGATE_TRANSIENT_MARKER)
+                .addModule(new Jdk8Module())
+                .addModule(new JavaTimeModule())
+                .addModule(new EssentialTypesJacksonModule())
+                .addModule(new EssentialsImmutableJacksonModule())
+                .build();
+
+        objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withSetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.ANY));
+        return objectMapper;
+    }
+
+    private static class TestPersistableEventMapper implements PersistableEventMapper {
+        private final CorrelationId correlationId = CorrelationId.random();
+        private final EventId causedByEventId = EventId.random();
+
+        @Override
+        public PersistableEvent map(Object aggregateId, AggregateEventStreamConfiguration aggregateEventStreamConfiguration, Object event, EventOrder eventOrder) {
+            return PersistableEvent.from(EventId.random(),
+                    aggregateEventStreamConfiguration.aggregateType,
+                    aggregateId,
+                    EventTypeOrName.with(event.getClass()),
+                    event,
+                    eventOrder,
+                    EventRevision.of(1),
+                    META_DATA,
+                    OffsetDateTime.now(),
+                    causedByEventId,
+                    correlationId,
+                    null);
+        }
+    }
+}

--- a/components/postgresql-event-store/src/test/resources/logback-test.xml
+++ b/components/postgresql-event-store/src/test/resources/logback-test.xml
@@ -24,8 +24,8 @@
         </encoder>
     </appender>
 
-    <logger name="dk.cloudcreate.essentials" level="TRACE"/>
-    <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler" level="DEBUG"/>
+    <logger name="dk.cloudcreate.essentials" level="INFO"/>
+    <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.gap.PostgresqlEventStreamGapHandler" level="INFO"/>
     <logger name="dk.cloudcreate.essentials.components.foundation.transaction.jdbi.GenericHandleAwareUnitOfWorkFactory" level="INFO"/>
     <logger name="dk.cloudcreate.essentials.components.eventsourced.eventstore.postgresql.transaction.EventStoreManagedUnitOfWork" level="INFO"/>
     <logger name="dk.cloudcreate.essentials.components.foundation.transaction.UnitOfWorkFactory" level="INFO"/>

--- a/components/postgresql-queue/README.md
+++ b/components/postgresql-queue/README.md
@@ -39,7 +39,7 @@ To use `PostgreSQL Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>postgresql-queue</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesBuilder.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesBuilder.java
@@ -57,6 +57,13 @@ public final class PostgresqlDurableQueuesBuilder {
     private Duration                                                      messageHandlingTimeout       = Duration.ofSeconds(30);
 
     /**
+     * Controls whether the PostgresqlDurableQueues should use the CentralizedMessageFetcher
+     * for optimized message fetching. Default is true.
+     */
+    private boolean  useCentralizedMessageFetcher             = true;
+    private Duration centralizedMessageFetcherPollingInterval = Duration.ofMillis(20);
+
+    /**
      * @param unitOfWorkFactory the {@link UnitOfWorkFactory} needed to access the database
      * @return this builder instance
      */
@@ -146,6 +153,32 @@ public final class PostgresqlDurableQueuesBuilder {
         return this;
     }
 
+    /**
+     * Set whether to use the {@link CentralizedMessageFetcher} for optimized message fetching across multiple queues.
+     * When enabled (default), the {@link PostgresqlDurableQueues} will use {@link CentralizedMessageFetcherDurableQueueConsumer}
+     * instances to handle messages. When disabled, it will use the traditional {@link DefaultDurableQueueConsumer} instances.
+     *
+     * @param useCentralizedMessageFetcher true to use centralized fetching (default), false to use the legacy consumer approach
+     * @return this builder instance
+     */
+    public PostgresqlDurableQueuesBuilder setUseCentralizedMessageFetcher(boolean useCentralizedMessageFetcher) {
+        this.useCentralizedMessageFetcher = useCentralizedMessageFetcher;
+        return this;
+    }
+
+    /**
+     * Set the polling interval for the {@link CentralizedMessageFetcher}.
+     * This value determines how frequently the fetcher checks for new messages when none are immediately available.
+     * Default value is 20 milliseconds.
+     *
+     * @param centralizedMessageFetcherPollingInterval the polling interval duration
+     * @return this builder instance
+     */
+    public PostgresqlDurableQueuesBuilder setCentralizedMessageFetcherPollingInterval(Duration centralizedMessageFetcherPollingInterval) {
+        this.centralizedMessageFetcherPollingInterval = centralizedMessageFetcherPollingInterval;
+        return this;
+    }
+
     public PostgresqlDurableQueues build() {
         return new PostgresqlDurableQueues(unitOfWorkFactory,
                                            jsonSerializer != null ? jsonSerializer : new JacksonJSONSerializer(createDefaultObjectMapper()),
@@ -153,6 +186,8 @@ public final class PostgresqlDurableQueuesBuilder {
                                            multiTableChangeListener,
                                            queuePollingOptimizerFactory,
                                            transactionalMode,
-                                           messageHandlingTimeout);
+                                           messageHandlingTimeout,
+                                           useCentralizedMessageFetcher,
+                                           centralizedMessageFetcherPollingInterval);
     }
 }

--- a/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/QueuedMessageRowMapper.java
+++ b/components/postgresql-queue/src/main/java/dk/cloudcreate/essentials/components/queue/postgresql/QueuedMessageRowMapper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.cloudcreate.essentials.components.queue.postgresql;
+
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.shared.functional.QuadFunction;
+import org.apache.commons.lang3.function.TriFunction;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.*;
+import java.time.OffsetDateTime;
+
+import static dk.cloudcreate.essentials.shared.MessageFormatter.msg;
+
+/**
+ * JDBI Row mapper for {@link QueuedMessage} objects.
+ * Extracted to be reusable between single message and batch operations.
+ */
+public class QueuedMessageRowMapper implements RowMapper<QueuedMessage> {
+    private final TriFunction<QueueName, QueueEntryId, String, MessageMetaData> metadataDeserializer;
+    private final QuadFunction<QueueName, QueueEntryId, String, String, Object> payloadDeserializer;
+
+    /**
+     * Create a new mapper with the provided deserializers
+     *
+     * @param payloadDeserializer  function to deserialize message payloads
+     * @param metadataDeserializer function to deserialize message metadata
+     */
+    public QueuedMessageRowMapper(QuadFunction<QueueName, QueueEntryId, String, String, Object> payloadDeserializer,
+                                  TriFunction<QueueName, QueueEntryId, String, MessageMetaData> metadataDeserializer) {
+        this.payloadDeserializer = payloadDeserializer;
+        this.metadataDeserializer = metadataDeserializer;
+    }
+
+    @Override
+    public QueuedMessage map(ResultSet rs, StatementContext ctx) throws SQLException {
+        var queueName      = QueueName.of(rs.getString("queue_name"));
+        var queueEntryId   = QueueEntryId.of(rs.getString("id"));
+        var messagePayload = payloadDeserializer.apply(queueName, queueEntryId, rs.getString("message_payload"), rs.getString("message_payload_type"));
+
+        MessageMetaData messageMetaData     = null;
+        var             metaDataColumnValue = rs.getString("meta_data");
+        if (metaDataColumnValue != null) {
+            messageMetaData = metadataDeserializer.apply(queueName, queueEntryId, metaDataColumnValue);
+        } else {
+            messageMetaData = new MessageMetaData();
+        }
+
+        var     deliveryMode = QueuedMessage.DeliveryMode.valueOf(rs.getString("delivery_mode"));
+        Message message      = null;
+        switch (deliveryMode) {
+            case NORMAL:
+                message = new Message(messagePayload, messageMetaData);
+                break;
+            case IN_ORDER:
+                message = new OrderedMessage(messagePayload,
+                                             rs.getString("key"),
+                                             rs.getLong("key_order"),
+                                             messageMetaData);
+                break;
+            default:
+                throw new IllegalStateException(msg("Unsupported deliveryMode '{}'", deliveryMode));
+        }
+
+        return new DefaultQueuedMessage(queueEntryId,
+                                        queueName,
+                                        message,
+                                        rs.getObject("added_ts", OffsetDateTime.class),
+                                        rs.getObject("next_delivery_ts", OffsetDateTime.class),
+                                        rs.getObject("delivery_ts", OffsetDateTime.class),
+                                        rs.getString("last_delivery_error"),
+                                        rs.getInt("total_attempts"),
+                                        rs.getInt("redelivery_attempts"),
+                                        rs.getBoolean("is_dead_letter_message"),
+                                        rs.getBoolean("is_being_delivered"));
+    }
+}

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedFetcherDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedFetcherDurableQueueIT.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dk.cloudcreate.essentials.components.queue.postgresql;
+
+import com.zaxxer.hikari.HikariDataSource;
+import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.*;
+import dk.cloudcreate.essentials.components.foundation.messaging.queue.operations.ConsumeFromQueue;
+import dk.cloudcreate.essentials.components.foundation.test.messaging.queue.test_data.*;
+import dk.cloudcreate.essentials.components.foundation.transaction.jdbi.JdbiUnitOfWorkFactory;
+import dk.cloudcreate.essentials.components.foundation.types.CorrelationId;
+import dk.cloudcreate.essentials.shared.time.*;
+import org.assertj.core.api.SoftAssertions;
+import org.awaitility.Awaitility;
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.*;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the new centralized message fetcher design with multiple queues and different thread configurations.
+ */
+@Testcontainers
+public class CentralizedFetcherDurableQueueIT {
+    @Container
+    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+            .withDatabaseName("queue-db")
+            .withUsername("test-user")
+            .withPassword("secret-password");
+
+    private static final int NUMBER_OF_MESSAGES     = 1000;
+    private static final int MAX_PARALLEL_CONSUMERS = 20;
+
+    private JdbiUnitOfWorkFactory   unitOfWorkFactory;
+    private PostgresqlDurableQueues durableQueues;
+
+    @BeforeEach
+    void setup() {
+        var ds = new HikariDataSource();
+        ds.setJdbcUrl(postgreSQLContainer.getJdbcUrl());
+        ds.setUsername(postgreSQLContainer.getUsername());
+        ds.setPassword(postgreSQLContainer.getPassword());
+        ds.setAutoCommit(false);
+        ds.setMaximumPoolSize(MAX_PARALLEL_CONSUMERS + 1);
+
+        unitOfWorkFactory = new JdbiUnitOfWorkFactory(Jdbi.create(ds));
+
+        unitOfWorkFactory.usingUnitOfWork(uow -> uow.handle().execute("DROP TABLE IF EXISTS " + PostgresqlDurableQueues.DEFAULT_DURABLE_QUEUES_TABLE_NAME));
+
+        durableQueues = PostgresqlDurableQueues.builder()
+                                               .setUnitOfWorkFactory(unitOfWorkFactory)
+                                               .setUseCentralizedMessageFetcher(true)
+                                               .setCentralizedMessageFetcherPollingInterval(Duration.ofMillis(20))
+                                               .build();
+        durableQueues.start();
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (durableQueues != null) {
+            durableQueues.stop();
+        }
+    }
+
+    /**
+     * Test that the centralized fetcher can handle multiple queues with different thread configurations.
+     */
+    @Test
+    void test_multiple_queues_with_different_thread_configurations() {
+        // Given
+        var random = new Random();
+
+        // Set up 3 queues with different thread configs
+        var queue1 = QueueName.of("HighPriorityQueue");
+        var queue2 = QueueName.of("MediumPriorityQueue");
+        var queue3 = QueueName.of("LowPriorityQueue");
+
+        // Clear any existing messages
+        durableQueues.purgeQueue(queue1);
+        durableQueues.purgeQueue(queue2);
+        durableQueues.purgeQueue(queue3);
+
+        // Create messages for each queue
+        var queue1Messages = new ArrayList<Message>();
+        var queue2Messages = new ArrayList<Message>();
+        var queue3Messages = new ArrayList<Message>();
+
+        for (var i = 0; i < NUMBER_OF_MESSAGES; i++) {
+            // Create random test messages
+            var message = Message.of(new OrderEvent.OrderAdded(OrderId.random(),
+                                                               CustomerId.random(),
+                                                               random.nextInt()),
+                                     MessageMetaData.of("correlation_id", CorrelationId.random(),
+                                                        "trace_id", UUID.randomUUID().toString()));
+
+            // Add message to appropriate queue's list
+            if (i % 3 == 0) {
+                queue1Messages.add(message);
+            } else if (i % 3 == 1) {
+                queue2Messages.add(message);
+            } else {
+                queue3Messages.add(message);
+            }
+        }
+        assertThat(queue1Messages.size()).isGreaterThan(0);
+        assertThat(queue2Messages.size()).isGreaterThan(0);
+        assertThat(queue3Messages.size()).isGreaterThan(0);
+
+        // When - queue all messages with timing
+        System.out.println("Queuing messages to all queues");
+        var queueTimings = new ArrayList<Timing>();
+
+        queueTimings.add(timeIt("Queuing " + queue1Messages.size() + " messages to queue1",
+                                () -> unitOfWorkFactory.usingUnitOfWork(uow ->
+                                                                                durableQueues.queueMessages(queue1, queue1Messages))));
+
+        queueTimings.add(timeIt("Queuing " + queue2Messages.size() + " messages to queue2",
+                                () -> unitOfWorkFactory.usingUnitOfWork(uow ->
+                                                                                durableQueues.queueMessages(queue2, queue2Messages))));
+
+        queueTimings.add(timeIt("Queuing " + queue3Messages.size() + " messages to queue3",
+                                () -> unitOfWorkFactory.usingUnitOfWork(uow ->
+                                                                                durableQueues.queueMessages(queue3, queue3Messages))));
+
+        // Verify all messages were queued
+        assertThat(durableQueues.getTotalMessagesQueuedFor(queue1)).isEqualTo(queue1Messages.size());
+        assertThat(durableQueues.getTotalMessagesQueuedFor(queue2)).isEqualTo(queue2Messages.size());
+        assertThat(durableQueues.getTotalMessagesQueuedFor(queue3)).isEqualTo(queue3Messages.size());
+
+        // Create the message handlers
+        var queue1Handler = new RecordingQueuedMessageHandler();
+        var queue2Handler = new RecordingQueuedMessageHandler();
+        var queue3Handler = new RecordingQueuedMessageHandler();
+
+        // Set up different thread configurations
+        var queue1Consumer = durableQueues.consumeFromQueue(ConsumeFromQueue.builder()
+                                                                            .setQueueName(queue1)
+                                                                            .setConsumerName("HighPriority")
+                                                                            .setRedeliveryPolicy(RedeliveryPolicy.fixedBackoff(Duration.ofMillis(1), 5))
+                                                                            .setQueueMessageHandler(queue1Handler)
+                                                                            .setParallelConsumers(10)    // High priority gets many threads
+                                                                            .build());
+
+        var queue2Consumer = durableQueues.consumeFromQueue(ConsumeFromQueue.builder()
+                                                                            .setQueueName(queue2)
+                                                                            .setConsumerName("MediumPriority")
+                                                                            .setRedeliveryPolicy(RedeliveryPolicy.fixedBackoff(Duration.ofMillis(1), 5))
+                                                                            .setQueueMessageHandler(queue2Handler)
+                                                                            .setParallelConsumers(5)     // Medium priority
+                                                                            .build());
+
+        var queue3Consumer = durableQueues.consumeFromQueue(ConsumeFromQueue.builder()
+                                                                            .setQueueName(queue3)
+                                                                            .setConsumerName("LowPriority")
+                                                                            .setRedeliveryPolicy(RedeliveryPolicy.fixedBackoff(Duration.ofMillis(1), 5))
+                                                                            .setQueueMessageHandler(queue3Handler)
+                                                                            .setParallelConsumers(2)     // Low priority with few threads
+                                                                            .build());
+
+        // Then - verify all messages are processed, high priority queue should finish first
+        var consumptionStopWatch = StopWatch.start("Consuming all messages");
+
+        // Wait for all messages to be processed
+        Awaitility.waitAtMost(Duration.ofSeconds(60))
+                  .untilAsserted(() -> {
+                      assertThat(queue1Handler.messages.size()).isEqualTo(queue1Messages.size());
+                      assertThat(queue2Handler.messages.size()).isEqualTo(queue2Messages.size());
+                      assertThat(queue3Handler.messages.size()).isEqualTo(queue3Messages.size());
+                  });
+
+        var consumptionTiming = consumptionStopWatch.stop();
+        System.out.println(consumptionTiming);
+
+        // Verify that all messages were received correctly
+        var queue1Received = new ArrayList<>(queue1Handler.messages);
+        var queue2Received = new ArrayList<>(queue2Handler.messages);
+        var queue3Received = new ArrayList<>(queue3Handler.messages);
+
+        var softAssertions = new SoftAssertions();
+
+        // Should have received all the messages
+        softAssertions.assertThat(queue1Received).containsExactlyInAnyOrderElementsOf(queue1Messages);
+        softAssertions.assertThat(queue2Received).containsExactlyInAnyOrderElementsOf(queue2Messages);
+        softAssertions.assertThat(queue3Received).containsExactlyInAnyOrderElementsOf(queue3Messages);
+
+        // No queue should have received messages meant for other queues
+        queue1Messages.forEach(msg -> {
+            softAssertions.assertThat(queue2Received).doesNotContain(msg);
+            softAssertions.assertThat(queue3Received).doesNotContain(msg);
+        });
+
+        queue2Messages.forEach(msg -> {
+            softAssertions.assertThat(queue1Received).doesNotContain(msg);
+            softAssertions.assertThat(queue3Received).doesNotContain(msg);
+        });
+
+        queue3Messages.forEach(msg -> {
+            softAssertions.assertThat(queue1Received).doesNotContain(msg);
+            softAssertions.assertThat(queue2Received).doesNotContain(msg);
+        });
+
+        softAssertions.assertAll();
+
+        // Cleanup
+        queue1Consumer.cancel();
+        queue2Consumer.cancel();
+        queue3Consumer.cancel();
+    }
+
+    /**
+     * Test that the centralized fetcher correctly handles ordered messages
+     */
+    @Test
+    void verify_ordered_messages_are_processed_in_order() {
+        // Given
+        var queueName = QueueName.of("OrderedQueue");
+        durableQueues.purgeQueue(queueName);
+
+        // Create ordered messages with multiple keys
+        var numberOfKeys   = 10;
+        var messagesPerKey = 20;
+
+        // Generate keys
+        var keys = new ArrayList<String>();
+        for (int i = 0; i < numberOfKeys; i++) {
+            keys.add("key-" + i);
+        }
+
+        // Track expected order per key
+        var expectedOrderPerKey = new ConcurrentHashMap<String, List<OrderedMessage>>();
+        keys.forEach(key -> expectedOrderPerKey.put(key, new ArrayList<>()));
+
+        // Generate all ordered messages
+        var allOrderedMessages = new ArrayList<OrderedMessage>();
+        for (var key : keys) {
+            for (var order = 0; order < messagesPerKey; order++) {
+                var orderedMessage = OrderedMessage.of(
+                        "Message " + key + ":" + order,
+                        key,
+                        order
+                                                      );
+                allOrderedMessages.add(orderedMessage);
+                expectedOrderPerKey.get(key).add(orderedMessage);
+            }
+        }
+
+        // Shuffle the messages to ensure out-of-order queuing
+        Collections.shuffle(allOrderedMessages);
+
+        // Queue the messages
+        unitOfWorkFactory.usingUnitOfWork(uow -> durableQueues.queueMessages(queueName, allOrderedMessages));
+
+        // When - create a handler that tracks order of received messages per key
+        var orderedMessageTracker = new ConcurrentHashMap<String, List<OrderedMessage>>();
+
+        var recordingOrderedHandler = new QueuedMessageHandler() {
+            @Override
+            public void handle(QueuedMessage message) {
+                var orderedMessage = (OrderedMessage) message.getMessage();
+                orderedMessageTracker.computeIfAbsent(orderedMessage.getKey(), k -> new CopyOnWriteArrayList<>())
+                                     .add(orderedMessage);
+
+                // Add a small delay to simulate processing time
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+
+        // Create consumer with multiple threads
+        var consumer = durableQueues.consumeFromQueue(ConsumeFromQueue.builder()
+                                                                      .setQueueName(queueName)
+                                                                      .setConsumerName("OrderedConsumer")
+                                                                      .setRedeliveryPolicy(RedeliveryPolicy.fixedBackoff(Duration.ofMillis(10), 3))
+                                                                      .setQueueMessageHandler(recordingOrderedHandler)
+                                                                      .setParallelConsumers(15) // Use many parallel threads to stress test ordering
+                                                                      .build());
+
+        // Then - wait for all messages to be processed and verify ordering
+        Awaitility.waitAtMost(Duration.ofSeconds(30))
+                  .untilAsserted(() -> {
+                      var totalReceived = orderedMessageTracker.values().stream()
+                                                               .mapToInt(List::size)
+                                                               .sum();
+                      assertThat(totalReceived).isEqualTo(numberOfKeys * messagesPerKey);
+                  });
+
+        // Verify order is preserved per key
+        var softAssertions = new SoftAssertions();
+        for (var key : keys) {
+            var actualMessagesForKey   = orderedMessageTracker.get(key);
+            var expectedMessagesForKey = expectedOrderPerKey.get(key);
+
+            // Should have received all messages for this key
+            softAssertions.assertThat(actualMessagesForKey.size()).isEqualTo(messagesPerKey);
+
+            // Messages should be in order by order field
+            for (int i = 0; i < messagesPerKey; i++) {
+                softAssertions.assertThat(actualMessagesForKey.get(i).getOrder())
+                              .isEqualTo(i);
+            }
+
+            // Should match expected order
+            softAssertions.assertThat(actualMessagesForKey).containsExactlyElementsOf(expectedMessagesForKey);
+        }
+
+        softAssertions.assertAll();
+
+        // Cleanup
+        consumer.cancel();
+    }
+
+    private Timing timeIt(String description, Runnable action) {
+        var stopWatch = StopWatch.start(description);
+        action.run();
+        var timing = stopWatch.stop();
+        System.out.println(timing);
+        return timing;
+    }
+
+    private static class RecordingQueuedMessageHandler implements QueuedMessageHandler {
+        ConcurrentLinkedQueue<Message> messages = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public void handle(QueuedMessage message) {
+            messages.add(message.getMessage());
+        }
+    }
+}

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for distributed competing consumers using the centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedPostgresqlDistributedCompetingConsumersDurableQueuesIT extends PostgresqlDistributedCompetingConsumersDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true;
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests using the centralized message fetcher approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedPostgresqlDurableQueuesIT extends PostgresqlDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlDurableQueuesLoadIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlDurableQueuesLoadIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Load testing with centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedPostgresqlDurableQueuesLoadIT extends PostgresqlDurableQueuesLoadIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for local competing consumers using the centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedPostgresqlLocalCompetingConsumersDurableQueueIT extends PostgresqlLocalCompetingConsumersDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlLocalOrderedMessagesDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlLocalOrderedMessagesDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for local ordered messages using the centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedPostgresqlLocalOrderedMessagesDurableQueueIT extends PostgresqlLocalOrderedMessagesDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedPostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for local ordered messages redelivery using the centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedPostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT extends PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedSingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedSingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for single operation transaction distributed competing consumers using the centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedSingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT extends SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedSingleOperationTransactionPostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedSingleOperationTransactionPostgresqlDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for single operation transaction mode using the centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedSingleOperationTransactionPostgresqlDurableQueuesIT extends SingleOperationTransactionPostgresqlDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedSingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/CentralizedSingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for single operation transaction local competing consumers using the centralized message fetcher
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class CentralizedSingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT extends SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return true; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBusIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/DurableLocalCommandBusIT.java
@@ -22,17 +22,29 @@ import org.jdbi.v3.core.Jdbi;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
 
+/**
+ * Base class for durable local command bus tests
+ */
 @Testcontainers
-public class DurableLocalCommandBusIT extends AbstractDurableLocalCommandBusIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+public abstract class DurableLocalCommandBusIT extends AbstractDurableLocalCommandBusIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
 
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
+
     @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
-        return PostgresqlDurableQueues.builder().setUnitOfWorkFactory(unitOfWorkFactory).build();
+        return PostgresqlDurableQueues.builder()
+                                     .setUnitOfWorkFactory(unitOfWorkFactory)
+                                     .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
+                                     .build();
     }
 
     @Override

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesIT.java
@@ -26,13 +26,22 @@ import org.testcontainers.junit.jupiter.*;
 
 import static dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues.createDefaultObjectMapper;
 
+/**
+ * Base test class for PostgresqlDurableQueues integration tests
+ */
 @Testcontainers
-class PostgresqlDurableQueuesIT extends DurableQueuesIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class PostgresqlDurableQueuesIT extends DurableQueuesIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
+
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
 
     @Override
     protected JSONSerializer createJSONSerializer() {
@@ -45,6 +54,7 @@ class PostgresqlDurableQueuesIT extends DurableQueuesIT<PostgresqlDurableQueues,
         return PostgresqlDurableQueues.builder()
                                       .setUnitOfWorkFactory(unitOfWorkFactory)
                                       .setJsonSerializer(jsonSerializer)
+                                      .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
                                       .build();
     }
 

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesLoadIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlDurableQueuesLoadIT.java
@@ -34,13 +34,22 @@ import java.time.Duration;
 
 import static dk.cloudcreate.essentials.jackson.immutable.EssentialsImmutableJacksonModule.createObjectMapper;
 
+/**
+ * Base class for load testing PostgreSQL durable queues
+ */
 @Testcontainers
-class PostgresqlDurableQueuesLoadIT extends DurableQueuesLoadIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class PostgresqlDurableQueuesLoadIT extends DurableQueuesLoadIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
+    
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
 
     @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
@@ -57,6 +66,7 @@ class PostgresqlDurableQueuesLoadIT extends DurableQueuesLoadIT<PostgresqlDurabl
                                                                                                   ),
                                                                                                   LocalEventBus.builder().build(),
                                                                                                   true))
+                                      .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
                                       .build();
     }
 

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -24,17 +24,29 @@ import org.jdbi.v3.core.Jdbi;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
 
+/**
+ * Base class for local competing consumers tests
+ */
 @Testcontainers
-class PostgresqlLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class PostgresqlLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
 
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
+
     @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
-        return PostgresqlDurableQueues.builder().setUnitOfWorkFactory(unitOfWorkFactory).build();
+        return PostgresqlDurableQueues.builder()
+                                     .setUnitOfWorkFactory(unitOfWorkFactory)
+                                     .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
+                                     .build();
     }
 
     @Override

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesDurableQueueIT.java
@@ -24,17 +24,29 @@ import org.jdbi.v3.core.Jdbi;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
 
+/**
+ * Base class for local ordered messages tests
+ */
 @Testcontainers
-class PostgresqlLocalOrderedMessagesDurableQueueIT extends LocalOrderedMessagesDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class PostgresqlLocalOrderedMessagesDurableQueueIT extends LocalOrderedMessagesDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
 
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
+
     @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
-        return PostgresqlDurableQueues.builder().setUnitOfWorkFactory(unitOfWorkFactory).build();
+        return PostgresqlDurableQueues.builder()
+                                     .setUnitOfWorkFactory(unitOfWorkFactory)
+                                     .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
+                                     .build();
     }
 
     @Override

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -24,17 +24,29 @@ import org.jdbi.v3.core.Jdbi;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.*;
 
+/**
+ * Base class for local ordered messages redelivery tests
+ */
 @Testcontainers
-class PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT extends LocalOrderedMessagesRedeliveryDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT extends LocalOrderedMessagesRedeliveryDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
 
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
+
     @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
-        return PostgresqlDurableQueues.builder().setUnitOfWorkFactory(unitOfWorkFactory).build();
+        return PostgresqlDurableQueues.builder()
+                                     .setUnitOfWorkFactory(unitOfWorkFactory)
+                                     .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
+                                     .build();
     }
 
     @Override

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -26,13 +26,22 @@ import org.testcontainers.junit.jupiter.*;
 
 import java.time.Duration;
 
+/**
+ * Base class for single operation transaction distributed competing consumers tests
+ */
 @Testcontainers
-class SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT extends DistributedCompetingConsumersDurableQueuesIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT extends DistributedCompetingConsumersDurableQueuesIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
+
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
 
     @Override
     protected void disruptDatabaseConnection() {
@@ -52,6 +61,7 @@ class SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQu
                                       .setUnitOfWorkFactory(unitOfWorkFactory)
                                       .setMessageHandlingTimeout(Duration.ofSeconds(5))
                                       .setTransactionalMode(TransactionalMode.SingleOperationTransaction)
+                                      .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
                                       .build();
     }
 

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlDurableQueuesIT.java
@@ -33,13 +33,22 @@ import java.util.UUID;
 import static dk.cloudcreate.essentials.components.queue.postgresql.PostgresqlDurableQueues.createDefaultObjectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Base class for single operation transaction tests
+ */
 @Testcontainers
-class SingleOperationTransactionPostgresqlDurableQueuesIT extends DurableQueuesIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class SingleOperationTransactionPostgresqlDurableQueuesIT extends DurableQueuesIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
+
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
 
     @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory,
@@ -49,6 +58,7 @@ class SingleOperationTransactionPostgresqlDurableQueuesIT extends DurableQueuesI
                                       .setTransactionalMode(TransactionalMode.SingleOperationTransaction)
                                       .setMessageHandlingTimeout(Duration.ofSeconds(5))
                                       .setJsonSerializer(jsonSerializer)
+                                      .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
                                       .build();
     }
 

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -26,13 +26,22 @@ import org.testcontainers.junit.jupiter.*;
 
 import java.time.Duration;
 
+/**
+ * Base class for single operation transaction local competing consumers tests
+ */
 @Testcontainers
-class SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
+abstract class SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT extends LocalCompetingConsumersDurableQueueIT<PostgresqlDurableQueues, GenericHandleAwareUnitOfWorkFactory.GenericHandleAwareUnitOfWork, JdbiUnitOfWorkFactory> {
     @Container
-    private final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
+    protected final PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:latest")
             .withDatabaseName("queue-db")
             .withUsername("test-user")
             .withPassword("secret-password");
+
+    /**
+     * Determine whether to use the centralized message fetcher
+     * @return true for centralized message fetcher, false for traditional consumer
+     */
+    protected abstract boolean useCentralizedMessageFetcher();
 
     @Override
     protected PostgresqlDurableQueues createDurableQueues(JdbiUnitOfWorkFactory unitOfWorkFactory) {
@@ -40,6 +49,7 @@ class SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT 
                                       .setUnitOfWorkFactory(unitOfWorkFactory)
                                       .setMessageHandlingTimeout(Duration.ofSeconds(5))
                                       .setTransactionalMode(TransactionalMode.SingleOperationTransaction)
+                                      .setUseCentralizedMessageFetcher(useCentralizedMessageFetcher())
                                       .build();
     }
 

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for distributed competing consumers using the traditional consumer approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalPostgresqlDistributedCompetingConsumersDurableQueuesIT extends PostgresqlDistributedCompetingConsumersDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests using the traditional message fetcher approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalPostgresqlDurableQueuesIT extends PostgresqlDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlDurableQueuesLoadIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlDurableQueuesLoadIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Load testing with traditional queue consumers
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalPostgresqlDurableQueuesLoadIT extends PostgresqlDurableQueuesLoadIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for local competing consumers using the traditional consumer approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalPostgresqlLocalCompetingConsumersDurableQueueIT extends PostgresqlLocalCompetingConsumersDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlLocalOrderedMessagesDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlLocalOrderedMessagesDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for local ordered messages using the traditional consumer approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalPostgresqlLocalOrderedMessagesDurableQueueIT extends PostgresqlLocalOrderedMessagesDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalPostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for local ordered messages redelivery using the traditional consumer approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalPostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT extends PostgresqlLocalOrderedMessagesRedeliveryDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalSingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalSingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for single operation transaction distributed competing consumers using the traditional consumer approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalSingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT extends SingleOperationTransactionPostgresqlDistributedCompetingConsumersDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalSingleOperationTransactionPostgresqlDurableQueuesIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalSingleOperationTransactionPostgresqlDurableQueuesIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for single operation transaction mode using the traditional consumer approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalSingleOperationTransactionPostgresqlDurableQueuesIT extends SingleOperationTransactionPostgresqlDurableQueuesIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalSingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
+++ b/components/postgresql-queue/src/test/java/dk/cloudcreate/essentials/components/queue/postgresql/TraditionalSingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT.java
@@ -14,25 +14,14 @@
  * limitations under the License.
  */
 
-package dk.cloudcreate.essentials.components.foundation.messaging.queue;
-
-import dk.cloudcreate.essentials.components.foundation.Lifecycle;
-import dk.cloudcreate.essentials.components.foundation.messaging.RedeliveryPolicy;
+package dk.cloudcreate.essentials.components.queue.postgresql;
 
 /**
- * {@link DurableQueues} consumer
- *
- * @see DefaultDurableQueueConsumer
- * @see DurableQueueConsumerNotifications
- * @see QueuePollingOptimizer
+ * Integration tests for single operation transaction local competing consumers using the traditional consumer approach
  */
-public interface DurableQueueConsumer extends Lifecycle {
-    QueueName queueName();
-
-    String consumerName();
-
-
-    void cancel();
-
-    RedeliveryPolicy getRedeliveryPolicy();
+class TraditionalSingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT extends SingleOperationTransactionPostgresqlLocalCompetingConsumersDurableQueueIT {
+    @Override
+    protected boolean useCentralizedMessageFetcher() {
+        return false; 
+    }
 }

--- a/components/spring-boot-starter-mongodb/README.md
+++ b/components/spring-boot-starter-mongodb/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-mongodb` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-mongodb</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -108,7 +108,9 @@ then you need to check the component document to learn about the Security implic
 - `PostgresqlDurableQueues` using the `JSONSerializer` as JSON serializer
   - Supports additional properties:
   - ```
-    essentials.durable-queues.shared-queue-table-name=durable_queues
+    essentials.durable-queues.shared-queue-table-name=durable_queues 
+    essentials.durable-queues.use-centralized-message-fetcher=true (default)
+    essentials.durable-queues.centralized-message-fetcher-polling-interval=20ms (default)
     essentials.durable-queues.transactional-mode=fullytransactional or singleoperationtransaction (default)
     essentials.durable-queues.polling-delay-interval-increment-factor=0.5
     essentials.durable-queues.max-polling-interval=2s

--- a/components/spring-boot-starter-postgresql-event-store/README.md
+++ b/components/spring-boot-starter-postgresql-event-store/README.md
@@ -20,7 +20,7 @@ To use `spring-boot-starter-postgresql-event-store` to add the following depende
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql-event-store</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -18,7 +18,7 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-boot-starter-postgresql</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/spring-boot-starter-postgresql/README.md
+++ b/components/spring-boot-starter-postgresql/README.md
@@ -66,6 +66,8 @@ To use `spring-boot-starter-postgresql` to add the following dependency:
   - Supports additional properties:
   - ```
     essentials.durable-queues.shared-queue-table-name=durable_queues
+    essentials.durable-queues.use-centralized-message-fetcher=true (default)
+    essentials.durable-queues.centralized-message-fetcher-polling-interval=20ms (default)
     essentials.durable-queues.transactional-mode=fullytransactional or singleoperationtransaction (default)
     essentials.durable-queues.polling-delay-interval-increment-factor=0.5
     essentials.durable-queues.max-polling-interval=2s

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsConfiguration.java
@@ -257,6 +257,8 @@ public class EssentialsComponentsConfiguration {
                                                    .setJsonSerializer(jsonSerializer)
                                                    .setSharedQueueTableName(properties.getDurableQueues().getSharedQueueTableName())
                                                    .setMultiTableChangeListener(optionalMultiTableChangeListener.orElse(null))
+                                                   .setUseCentralizedMessageFetcher(properties.getDurableQueues().isUseCentralizedMessageFetcher())
+                                                   .setCentralizedMessageFetcherPollingInterval(properties.getDurableQueues().getCentralizedMessageFetcherPollingInterval())
                                                    .setQueuePollingOptimizerFactory(consumeFromQueue -> new QueuePollingOptimizer.SimpleQueuePollingOptimizer(consumeFromQueue,
                                                                                                                                                               (long) (consumeFromQueue.getPollingInterval().toMillis() *
                                                                                                                                                                       properties.getDurableQueues()

--- a/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
+++ b/components/spring-boot-starter-postgresql/src/main/java/dk/cloudcreate/essentials/components/boot/autoconfigure/postgresql/EssentialsComponentsProperties.java
@@ -278,9 +278,11 @@ public class EssentialsComponentsProperties {
 
         private Double pollingDelayIntervalIncrementFactor = 0.5d;
 
-        private Duration          maxPollingInterval     = Duration.ofMillis(2000);
-        private TransactionalMode transactionalMode      = TransactionalMode.SingleOperationTransaction;
-        private Duration          messageHandlingTimeout = Duration.ofSeconds(30);
+        private Duration          maxPollingInterval                       = Duration.ofMillis(2000);
+        private TransactionalMode transactionalMode                        = TransactionalMode.SingleOperationTransaction;
+        private Duration          messageHandlingTimeout                   = Duration.ofSeconds(30);
+        private boolean           useCentralizedMessageFetcher             = true;
+        private Duration          centralizedMessageFetcherPollingInterval = Duration.ofMillis(20);
 
         private boolean verboseTracing = false;
 
@@ -408,7 +410,8 @@ public class EssentialsComponentsProperties {
          * When the {@link PostgresqlDurableQueues} polling returns 0 messages, what should the increase in the {@link ConsumeFromQueue#getPollingInterval()}
          * be? (logic: new_polling_interval = current_polling_interval + base_polling_interval * polling_delay_interval_increment_factor)<br>
          * Default is 0.5d<br>
-         * This is used to avoid polling a the {@link DurableQueues} for a queue that isn't experiencing a lot of messages
+         * This is used to avoid polling a the {@link DurableQueues} for a queue that isn't experiencing a lot of messages<br>
+         * Only relevant when #setUseCentralizedMessageFetcher(boolean) is set to false
          *
          * @return the increase in the {@link ConsumeFromQueue#getPollingInterval()} when the {@link DurableQueues} polling returns 0 messages
          */
@@ -420,7 +423,8 @@ public class EssentialsComponentsProperties {
          * When the {@link PostgresqlDurableQueues} polling returns 0 messages, what should the increase in the {@link ConsumeFromQueue#getPollingInterval()}
          * be? (logic: new_polling_interval = current_polling_interval + base_polling_interval * polling_delay_interval_increment_factor)<br>
          * Default is 0.5d<br>
-         * This is used to avoid polling a the {@link DurableQueues} for a queue that isn't experiencing a lot of messages
+         * This is used to avoid polling a the {@link DurableQueues} for a queue that isn't experiencing a lot of messages<br>
+         * Only relevant when #setUseCentralizedMessageFetcher(boolean) is set to false
          *
          * @param pollingDelayIntervalIncrementFactor the increase in the {@link ConsumeFromQueue#getPollingInterval()} when the {@link DurableQueues} polling returns 0 messages
          */
@@ -430,7 +434,8 @@ public class EssentialsComponentsProperties {
 
         /**
          * What is the maximum polling interval (when adjusted using {@link #setPollingDelayIntervalIncrementFactor(Double)})<br>
-         * Default is 2 seconds
+         * Default is 2 seconds<br>
+         * Only relevant when #setUseCentralizedMessageFetcher(boolean) is set to false
          *
          * @return What is the maximum polling interval (when adjusted using {@link #setPollingDelayIntervalIncrementFactor(Double)})
          */
@@ -440,12 +445,57 @@ public class EssentialsComponentsProperties {
 
         /**
          * What is the maximum polling interval (when adjusted using {@link #setPollingDelayIntervalIncrementFactor(Double)})<br>
-         * Default is 2 seconds
+         * Default is 2 seconds<br>
+         * Only relevant when #setUseCentralizedMessageFetcher(boolean) is set to false
          *
          * @param maxPollingInterval the maximum polling interval (when adjusted using {@link #setPollingDelayIntervalIncrementFactor(Double)})
          */
         public void setMaxPollingInterval(Duration maxPollingInterval) {
             this.maxPollingInterval = maxPollingInterval;
+        }
+
+        /**
+         * Get whether to use the {@link CentralizedMessageFetcher} for optimized message fetching across multiple queues.
+         * When enabled (default), the {@link PostgresqlDurableQueues} will use {@link CentralizedMessageFetcherDurableQueueConsumer}
+         * instances to handle messages. When disabled, it will use the traditional {@link DefaultDurableQueueConsumer} instances.
+         *
+         * @return true if using centralized fetching (default), false if using the legacy consumer approach
+         */
+        public boolean isUseCentralizedMessageFetcher() {
+            return useCentralizedMessageFetcher;
+        }
+
+        /**
+         * Set whether to use the {@link CentralizedMessageFetcher} for optimized message fetching across multiple queues.
+         * When enabled (default), the {@link PostgresqlDurableQueues} will use {@link CentralizedMessageFetcherDurableQueueConsumer}
+         * instances to handle messages. When disabled, it will use the traditional {@link DefaultDurableQueueConsumer} instances.
+         *
+         * @param useCentralizedMessageFetcher true to use centralized fetching (default), false to use the legacy consumer approach
+         */
+        public void setUseCentralizedMessageFetcher(boolean useCentralizedMessageFetcher) {
+            this.useCentralizedMessageFetcher = useCentralizedMessageFetcher;
+        }
+
+        /**
+         * Get the polling interval for the {@link CentralizedMessageFetcher}.
+         * This value determines how frequently the fetcher checks for new messages when none are immediately available.
+         * Default value is 20 milliseconds.
+         *
+         * @return the polling interval duration
+         */
+        public Duration getCentralizedMessageFetcherPollingInterval() {
+            return centralizedMessageFetcherPollingInterval;
+        }
+
+        /**
+         * Set the polling interval for the {@link CentralizedMessageFetcher}.
+         * This value determines how frequently the fetcher checks for new messages when none are immediately available.
+         * Default value is 20 milliseconds.
+         *
+         * @param centralizedMessageFetcherPollingInterval the polling interval duration
+         */
+        public void setCentralizedMessageFetcherPollingInterval(Duration centralizedMessageFetcherPollingInterval) {
+            this.centralizedMessageFetcherPollingInterval = centralizedMessageFetcherPollingInterval;
         }
     }
 

--- a/components/spring-postgresql-event-store/README.md
+++ b/components/spring-postgresql-event-store/README.md
@@ -45,7 +45,7 @@ To use `Spring Postgresql Event Store` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>spring-postgresql-event-store</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-distributed-fenced-lock/README.md
+++ b/components/springdata-mongo-distributed-fenced-lock/README.md
@@ -30,7 +30,7 @@ To use `Spring Data MongoDB Distributed Fenced Lock` just add the following Mave
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-distributed-fenced-lock</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/components/springdata-mongo-queue/README.md
+++ b/components/springdata-mongo-queue/README.md
@@ -33,7 +33,7 @@ To use `MongoDB Durable Queue` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials.components</groupId>
     <artifactId>springdata-mongo-queue</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 You need to decide on which `TransactionalMode` to run the `MongoDurableQueues` in.

--- a/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
+++ b/components/springdata-mongo-queue/src/main/java/dk/cloudcreate/essentials/components/queue/springdata/mongodb/MongoDurableQueues.java
@@ -1314,6 +1314,17 @@ public final class MongoDurableQueues implements DurableQueues {
         return getTotalMessagesQueuedFor(queueName) > 0;
     }
 
+
+    @Override
+    public final boolean hasOrderedMessageQueuedForKey(QueueName queueName, String key) {
+        requireNonNull(queueName, "No queueName provided");
+        requireNonNull(key, "No key provided");
+        return mongoTemplate.count(query(where("queueName").is(queueName)
+                                         .and("key").is(key)
+                                         .and("deliveryMode").is(QueuedMessage.DeliveryMode.IN_ORDER.name())),
+                                   this.sharedQueueCollectionName) > 0;
+    }
+
     @Override
     public final long getTotalMessagesQueuedFor(GetTotalMessagesQueuedFor operation) {
         requireNonNull(operation, "You must specify a GetTotalMessagesQueuedFor instance");

--- a/immutable-jackson/README.md
+++ b/immutable-jackson/README.md
@@ -49,7 +49,7 @@ To use `Immutable-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable-jackson</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/immutable/README.md
+++ b/immutable/README.md
@@ -21,7 +21,7 @@ To use `Immutable` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>immutable</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <netty-bom.version>4.2.0.Final</netty-bom.version>
         <junit-bom.version>5.12.2</junit-bom.version>
         <testcontainers-bom.version>1.21.0</testcontainers-bom.version>
-        <jdbi3-bom.version>3.49.2</jdbi3-bom.version>
+        <jdbi3-bom.version>3.49.3</jdbi3-bom.version>
         <jackson-bom.version>2.19.0</jackson-bom.version>
         <mockito-bom.version>5.17.0</mockito-bom.version>
         <logback.version>1.5.18</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,39 +61,37 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
-        <kotlin.version>2.0.21</kotlin.version>
+        <kotlin.version>2.1.20</kotlin.version>
         <revision>DEV-SNAPSHOT</revision>
         <skipDependencyCheck>false</skipDependencyCheck>
 
-        <spring-boot.version>3.2.12</spring-boot.version>
-        <spring-framework-bom.version>6.1.18</spring-framework-bom.version>
-        <reactor-bom.version>2023.0.16</reactor-bom.version>
-        <spring-data-mongodb.version>4.2.12</spring-data-mongodb.version>
-        <spring-data-jpa.version>3.2.12</spring-data-jpa.version>
+        <spring-boot.version>3.3.11</spring-boot.version>
+        <spring-framework-bom.version>6.1.19</spring-framework-bom.version>
+        <reactor-bom.version>2023.0.17</reactor-bom.version>
+        <spring-data-mongodb.version>4.3.11</spring-data-mongodb.version>
+        <spring-data-jpa.version>3.3.11</spring-data-jpa.version>
         <objenesis.version>3.4</objenesis.version>
         <postgresql.version>42.7.5</postgresql.version>
         <slf4j.version>2.0.17</slf4j.version>
         <awaitility.version>4.3.0</awaitility.version>
         <assertj.version>3.27.3</assertj.version>
-        <mongodb-driver-sync.version>4.11.5</mongodb-driver-sync.version>
+        <mongodb-driver-sync.version>5.0.1</mongodb-driver-sync.version>
         <log4j-to-slf4j.version>2.24.3</log4j-to-slf4j.version>
         <json-smart.version>2.5.2</json-smart.version>
         <json-path.version>2.9.0</json-path.version>
-        <snakeyaml.version>2.3</snakeyaml.version>
-        <micrometer.version>1.12.13</micrometer.version>
-        <micrometer-tracing.version>1.2.12</micrometer-tracing.version>
-        <netty-bom.version>4.1.119.Final</netty-bom.version>
-        <junit-bom.version>5.12.1</junit-bom.version>
-        <testcontainers-bom.version>1.20.6</testcontainers-bom.version>
-        <jdbi3-bom.version>3.49.0</jdbi3-bom.version>
-        <jackson-bom.version>2.18.3</jackson-bom.version>
-        <mockito-bom.version>5.16.1</mockito-bom.version>
+        <snakeyaml.version>2.4</snakeyaml.version>
+        <micrometer.version>1.13.13</micrometer.version>
+        <micrometer-tracing.version>1.3.11</micrometer-tracing.version>
+        <netty-bom.version>4.2.0.Final</netty-bom.version>
+        <junit-bom.version>5.12.2</junit-bom.version>
+        <testcontainers-bom.version>1.21.0</testcontainers-bom.version>
+        <jdbi3-bom.version>3.49.2</jdbi3-bom.version>
+        <jackson-bom.version>2.19.0</jackson-bom.version>
+        <mockito-bom.version>5.17.0</mockito-bom.version>
         <logback.version>1.5.18</logback.version>
         <avro.version>1.12.0</avro.version>
         <commons-compress.version>1.27.1</commons-compress.version>
         <xmlunit-core.version>2.10.0</xmlunit-core.version>
-        <!-- Due to CVE in version 10.1.33 included by Spring Boot 3.2.12 -->
-        <tomcat.version>10.1.39</tomcat.version>
 
         <dokka.version>2.0.0</dokka.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
@@ -212,22 +210,6 @@
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
                 <scope>provided</scope>
-            </dependency>
-            <!-- Due to CVE in Tomcat 10.1.33 included by Spring Boot 3.2.12 -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-el</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/reactive/README.md
+++ b/reactive/README.md
@@ -17,7 +17,7 @@ To use `Reactive` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>reactive</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -17,7 +17,7 @@ To use `Shared` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>shared</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/types-avro/README.md
+++ b/types-avro/README.md
@@ -17,7 +17,7 @@ To use `Types-Avro` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-avro</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/types-jackson/README.md
+++ b/types-jackson/README.md
@@ -23,7 +23,7 @@ To use `Types-Jackson` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jackson</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/types-jdbi/README.md
+++ b/types-jdbi/README.md
@@ -22,7 +22,7 @@ To use `Types-JDBI` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-jdbi</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/types-spring-web/README.md
+++ b/types-spring-web/README.md
@@ -23,7 +23,7 @@ To use `Types-Spring-Web` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-spring-web</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/types-springdata-jpa/README.md
+++ b/types-springdata-jpa/README.md
@@ -25,7 +25,7 @@ To use `Types-SpringData-JPA` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-jpa</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/types-springdata-mongo/README.md
+++ b/types-springdata-mongo/README.md
@@ -22,7 +22,7 @@ To use `Types-SpringData-Mongo` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types-springdata-mongo</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 

--- a/types/README.md
+++ b/types/README.md
@@ -23,7 +23,7 @@ To use `Types` just add the following Maven dependency:
 <dependency>
     <groupId>dk.cloudcreate.essentials</groupId>
     <artifactId>types</artifactId>
-    <version>0.40.23</version>
+    <version>0.40.24</version>
 </dependency>
 ```
 


### PR DESCRIPTION
**Large release with many new features, some of experimental character.**
Please see descriptions below

- Added support for `use-centralized-message-fetcher` along with configurable `centralized-message-fetcher-polling-interval` to Postgresql starters
  - Note: `use-centralized-message-fetcher` is **enabled** per default for Postgresql Spring-Boot starters!
  - Documented newly added properties for centralized message fetcher in relevant READMEs.
- Refactored across multiple PostgreSQL-related integration tests and foundational interfaces:
  - Introduced `CentralizedMessageFetcher` which fetches messages from queues using a single polling thread and distributes them to `DurableQueueConsumer` worker threads, thereby reducing database load by having a single polling thread per `DurableQueues` instance
  - Introduced `useCentralizedMessageFetcher` property for `PostgresqlDurableQueues` to support centralized message fetching - **enabled per default**!
  - Added `RedeliveryPolicy` accessor to `DurableQueueConsumer` and implemented in `DefaultDurableQueueConsumer`.
  - Added `toString` method to `CentralizedMessageFetcherDurableQueueConsumer` class for improved debug logging.
  - Extracted reusable Javadoc comments and improved method/field documentation for queue-related abstractions.
  - Modified `equals` and `hashCode` implementations in `MessageMetaData` for correctness.
  - Standardized thread visibility of `PostgreSQLContainer` fields and refactored integration tests to be abstract base classes where applicable.
  - Increased test timeout from 80 to 120 seconds in `LocalOrderedMessagesRedeliveryDurableQueueIT` test.
  - Ensured ordered message processing correctness tests and centralized fetcher integration tests across multiple configurations. Added new test class `CentralizedFetcherDurableQueueIT`.
  - Added `hasOrderedMessageQueuedForKey` method to `DurableQueues` and its implementations; introduced corresponding tests

- Refactored `EventProcessor` hierarchy and enhance subscription capabilities.
  - Refactored `EventProcessor` to extend `AbstractEventProcessor` for shared behavior. **Please report any backwards incompatibility!**
  - Added the experimental `ViewEventProcessor` where `PersistedEvent`'s are processed directly and only in case of an error handling the event will this event (and later events associated with the same aggregate id) by queued onto the underlying durable queue associated with this processor.
  - Added `ViewEventProcessorDependencies` bean creation in `EventStoreConfiguration`.
  - Introduced `subscribeToAggregateEventsAsynchronously` in `EventStoreSubscriptionManager`.
  - Enhanced reset subscription logic and handling in `EventProcessor`.
  - Simplified and added test for `resetAllSubscriptions` in `EventProcessorIT`.

- Add batched asynchronous event subscription to `EventStoreSubscriptionManager`
  - Introduced `batchSubscribeToAggregateEventsAsynchronously` in `EventStoreSubscriptionManager` for higher throughput batch processing.
    - Introduced `BatchedPersistedEventHandler`
    - Added `NonExclusiveBatchedAsynchronousSubscription` class for managing batched event subscriptions.
    - Created `BatchedPersistedEventSubscriber` class to support batch subscription with retries and error handling improvements.

- Add support for `SQLTransientException in `IOExceptionUtil`
  - Added a corresponding test for validation
- Return `Flux.empty()` instead of `Flux.error()` when closing listener handle fails in `ListenNotify`

Updated dependencies:
- Kotlin: 2.0.21 → 2.1.20
- Spring Boot: 3.2.12 → 3.3.11
- Spring Framework BOM: 6.1.18 → 6.1.19
- Reactor BOM: 2023.0.16 → 2023.0.17
- Spring Data MongoDB: 4.2.12 → 4.3.11
- Spring Data JPA: 3.2.12 → 3.3.11
- MongoDB Driver Sync: 4.11.5 → 5.0.1
- SnakeYAML: 2.3 → 2.4
- Micrometer: 1.12.13 → 1.13.13
- Micrometer Tracing: 1.2.12 → 1.3.11
- Netty BOM: 4.1.119.Final → 4.2.0.Final
- JUnit BOM: 5.12.1 → 5.12.2
- Testcontainers BOM: 1.20.6 → 1.21.0
- JDBI3 BOM: 3.49.0 → 3.49.3
- Jackson BOM: 2.18.3 → 2.19.0
- Mockito BOM: 5.16.1 → 5.17.0
- Removed unnecessary Tomcat dependencies.